### PR TITLE
Update minimum password length to 8 characters

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,7 +94,7 @@ POSTGRES_DATA_HOST_PATH=/path/to/store/database
 # Admin account password. On first start, if no users exist in the database,
 # an admin account is auto-created with this password.
 # Once any user exists in the database, this variable is ignored.
-# REQUIRED for first-time setup. Must be 12+ characters.
+# REQUIRED for first-time setup. Must be 8+ characters.
 ASTRO_ADMIN_PASSWORD=
 
 # Admin username for the auto-created account.

--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -12,9 +12,9 @@ from app.services.auth import hash_password
 
 
 async def create_user(username: str, role: str) -> None:
-    password = getpass.getpass("Password (min 12 chars): ")
-    if len(password) < 12:
-        print("Error: Password must be at least 12 characters.")
+    password = getpass.getpass("Password (min 8 chars): ")
+    if len(password) < 8:
+        print("Error: Password must be at least 8 characters.")
         sys.exit(1)
     if len(password) > 128:
         print("Error: Password must be at most 128 characters.")

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -22,12 +22,12 @@ class MeResponse(BaseModel):
 
 class PasswordChangeRequest(BaseModel):
     current_password: str
-    new_password: str = Field(min_length=12, max_length=128)
+    new_password: str = Field(min_length=8, max_length=128)
 
 
 class UserCreateRequest(BaseModel):
     username: str = Field(min_length=1, max_length=150)
-    password: str = Field(min_length=12, max_length=128)
+    password: str = Field(min_length=8, max_length=128)
     role: str = Field(pattern=r"^(admin|viewer)$")
 
 

--- a/frontend/src/components/settings/UsersTab.tsx
+++ b/frontend/src/components/settings/UsersTab.tsx
@@ -103,13 +103,13 @@ export const UsersTab: Component = () => {
               />
             </div>
             <div>
-              <label class="block text-xs text-theme-text-secondary mb-1">Password (min 12 chars)</label>
+              <label class="block text-xs text-theme-text-secondary mb-1">Password (min 8 chars)</label>
               <input
                 type="password"
                 value={newPassword()}
                 onInput={(e) => setNewPassword(e.currentTarget.value)}
                 class="w-full bg-theme-base border border-theme-border rounded px-2 py-1.5 text-sm text-theme-text-primary"
-                minLength={12}
+                minLength={8}
                 required
               />
             </div>

--- a/guides/CONFIGURATION.md
+++ b/guides/CONFIGURATION.md
@@ -62,10 +62,10 @@ See the [Security Guide](security.md) for full details on authentication, cookie
 
 | Variable | Default | Description | When to Change |
 |----------|---------|-------------|----------------|
-| `ASTRO_ADMIN_PASSWORD` | *(none)* | Admin account password. On first start, if no users exist, an admin is auto-created with this password. Ignored once any user exists. | Required for first-time setup. Must be 12+ characters. |
+| `ASTRO_ADMIN_PASSWORD` | *(none)* | Admin account password. On first start, if no users exist, an admin is auto-created with this password. Ignored once any user exists. | Required for first-time setup. Must be 8+ characters. |
 | `ASTRO_ADMIN_USERNAME` | `admin` | Username for the auto-created admin account. | Only if you want a different admin username. |
 | `ASTRO_VIEWER_USERNAME` | *(none)* | Optional read-only viewer account username, created on first start alongside admin. | When you want to share access without admin privileges (e.g., family members, club members viewing your data). |
-| `ASTRO_VIEWER_PASSWORD` | *(none)* | Password for the viewer account. | Required if ASTRO_VIEWER_USERNAME is set. Must be 12+ characters. |
+| `ASTRO_VIEWER_PASSWORD` | *(none)* | Password for the viewer account. | Required if ASTRO_VIEWER_USERNAME is set. Must be 8+ characters. |
 | `ASTRO_HTTPS` | `true` | Controls the Secure flag on auth cookies. When true, cookies are only sent over HTTPS. | Set to `false` if accessing GalactiLog over plain HTTP (e.g., `http://localhost`, LAN without TLS). |
 | `ASTRO_JWT_SECRET` | *(auto-generated)* | Secret key for signing JWT access tokens (HS256). When not set, a random key is generated at startup, invalidating all sessions on restart. | Set to a long random string (`openssl rand -hex 32`) for persistent sessions across container restarts. |
 | `ASTRO_ACCESS_TOKEN_EXPIRY` | `1800` (30 min) | Access token lifetime in seconds. | Shorter values are more secure but cause more frequent silent refreshes. Increase if users report being logged out mid-session. |

--- a/guides/security.md
+++ b/guides/security.md
@@ -15,7 +15,7 @@ Cookie-based JWT authentication, same-origin behind nginx reverse proxy.
 
 | Rule | Detail |
 |------|--------|
-| Length | 12-128 characters |
+| Length | 8-128 characters |
 | Characters | Any Unicode, no restrictions |
 | Hashing | Argon2id via `pwdlib` (`PasswordHash.recommended()` defaults) |
 | Defaults | None; CLI forces interactive password input |

--- a/setup.sh
+++ b/setup.sh
@@ -86,10 +86,10 @@ echo "  An admin account will be created on first start."
 read -rp "  Admin username [admin]: " ADMIN_USER
 ADMIN_USER="${ADMIN_USER:-admin}"
 while true; do
-    read -rsp "  Admin password (min 12 chars): " ADMIN_PASS
+    read -rsp "  Admin password (min 8 chars): " ADMIN_PASS
     echo ""
-    if [ ${#ADMIN_PASS} -lt 12 ]; then
-        warn "Password must be at least 12 characters."
+    if [ ${#ADMIN_PASS} -lt 8 ]; then
+        warn "Password must be at least 8 characters."
         continue
     fi
     read -rsp "  Confirm password: " ADMIN_PASS_CONFIRM


### PR DESCRIPTION
**Summary**
This pull request standardizes the minimum password length requirement to 8 characters across the application. It updates backend validation, frontend displays, and relevant documentation to reflect this change.

**Changes**
*   Updated the minimum password length requirement to 8 characters.
*   Modified backend authentication schemas to enforce the new minimum password length.
*   Adjusted frontend user settings components to display and validate against the 8-character minimum.
*   Updated `.env.example`, `guides/CONFIGURATION.md`, and `guides/security.md` to reflect the new password policy.
*   Modified `backend/app/cli.py` and `setup.sh` to align with the updated password length requirements during setup and CLI operations.

**Impact**
*   Backend authentication schema validation.
*   Frontend user interface for password changes and user creation.
*   Application setup and command-line interface tools.
*   Developer and security documentation.
*   Environment variable examples.

---
*This PR description was automatically generated.*
