### PR TITLE
feat: update environment variable prefixes from ASTRO_ to GALACTILOG_

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@
 #   1. Variable substitution in docker-compose.yml (${VAR_NAME} syntax)
 #      — used for host paths, postgres credentials, and building connection strings
 #   2. Passed directly into the app container as environment variables
-#      — all ASTRO_* variables are read by the application at runtime
+#      — all GALACTILOG_* variables are read by the application at runtime
 #
 # Variables with defaults in docker-compose.yml (${VAR:-default}) will use the
 # default if not set here. Variables without defaults must be set explicitly.
@@ -20,44 +20,45 @@
 # PostgreSQL Credentials
 # -----------------------------------------------------------------------------
 # These configure the postgres container AND are interpolated into the
-# ASTRO_DATABASE_URL connection string in docker-compose.yml.
+# GALACTILOG_DATABASE_URL connection string in docker-compose.yml.
 # Change these if you want a custom database username, password, or name.
 # Must match across .env and docker-compose.yml — the compose file references
-# these via ${POSTGRES_USER}, ${POSTGRES_PASSWORD}, ${POSTGRES_DB}.
+# these via ${GALACTILOG_POSTGRES_USER}, ${GALACTILOG_POSTGRES_PASSWORD},
+# ${GALACTILOG_POSTGRES_DB}.
 
-POSTGRES_USER=astro
-POSTGRES_PASSWORD=astro
-POSTGRES_DB=astro_catalog
+GALACTILOG_POSTGRES_USER=galactilog
+GALACTILOG_POSTGRES_PASSWORD=galactilog
+GALACTILOG_POSTGRES_DB=galactilog_catalog
 
 # -----------------------------------------------------------------------------
 # Application Settings
 # -----------------------------------------------------------------------------
-# These ASTRO_* variables are passed directly to the application container.
+# These GALACTILOG_* variables are passed directly to the application container.
 # The database URL and Redis URL are also set in docker-compose.yml via
 # variable substitution, so the values here serve as documentation/override.
 
 # PostgreSQL connection string using the async driver.
-# In docker-compose.yml this is built from POSTGRES_USER/PASSWORD/DB above,
-# so you typically don't need to set this unless using an external database.
-ASTRO_DATABASE_URL=postgresql+asyncpg://astro:astro@postgres:5432/astro_catalog
+# In docker-compose.yml this is built from GALACTILOG_POSTGRES_USER/PASSWORD/DB
+# above, so you typically don't need to set this unless using an external database.
+GALACTILOG_DATABASE_URL=postgresql+asyncpg://galactilog:galactilog@postgres:5432/galactilog_catalog
 
 # Redis connection string for the Celery task queue and caching.
 # The default points to the redis container defined in docker-compose.yml.
-ASTRO_REDIS_URL=redis://redis:6379/0
+GALACTILOG_REDIS_URL=redis://redis:6379/0
 
 # Container-internal path where FITS files are mounted.
 # This must match the volume mount target in docker-compose.yml.
 # You should not need to change this unless you modify the compose volumes.
-ASTRO_FITS_DATA_PATH=/app/data/fits
+GALACTILOG_FITS_DATA_PATH=/app/data/fits
 
 # Container-internal path for generated JPEG thumbnails.
 # Same as above — must match the volume mount target in docker-compose.yml.
-ASTRO_THUMBNAILS_PATH=/app/data/thumbnails
+GALACTILOG_THUMBNAILS_PATH=/app/data/thumbnails
 
 # Maximum width in pixels for generated thumbnails.
 # Larger values produce sharper thumbnails but use more disk space.
 # Default: 800
-ASTRO_THUMBNAIL_MAX_WIDTH=800
+GALACTILOG_THUMBNAIL_MAX_WIDTH=800
 
 # -----------------------------------------------------------------------------
 # Host Paths (Volume Mounts)
@@ -72,18 +73,18 @@ ASTRO_THUMBNAIL_MAX_WIDTH=800
 # Example Linux:   /home/user/astrophotography/fits
 # Example Windows:  //c/Users/user/AstroData/fits (Docker Desktop path format)
 # Example NAS:      /mnt/nas/astrophotography
-FITS_DATA_HOST_PATH=/path/to/your/fits/files
+GALACTILOG_FITS_HOST_PATH=/path/to/your/fits/files
 
 # Directory for generated JPEG thumbnails (read-write).
 # GalactiLog creates thumbnails during ingest — this directory will grow over time.
 # Example: /home/user/galactilog/thumbnails
-THUMBNAILS_HOST_PATH=/path/to/store/thumbnails
+GALACTILOG_THUMBNAILS_HOST_PATH=/path/to/store/thumbnails
 
 # Directory for PostgreSQL data persistence (read-write).
 # Without this, database data lives in a Docker named volume.
 # Set this to persist data in a known location for easy backups.
 # Example: /home/user/galactilog/postgres
-POSTGRES_DATA_HOST_PATH=/path/to/store/database
+GALACTILOG_POSTGRES_DATA_HOST_PATH=/path/to/store/database
 
 # -----------------------------------------------------------------------------
 # Authentication
@@ -95,17 +96,17 @@ POSTGRES_DATA_HOST_PATH=/path/to/store/database
 # an admin account is auto-created with this password.
 # Once any user exists in the database, this variable is ignored.
 # REQUIRED for first-time setup. Must be 8+ characters.
-ASTRO_ADMIN_PASSWORD=
+GALACTILOG_ADMIN_PASSWORD=
 
 # Admin username for the auto-created account.
 # Default: admin
-# ASTRO_ADMIN_USERNAME=admin
+# GALACTILOG_ADMIN_USERNAME=admin
 
 # Optional viewer (read-only) account. Created on first start alongside admin.
 # Viewer can browse targets, images, and stats but cannot change settings or
 # trigger scans. Useful for sharing access without admin privileges.
-# ASTRO_VIEWER_USERNAME=viewer
-# ASTRO_VIEWER_PASSWORD=
+# GALACTILOG_VIEWER_USERNAME=viewer
+# GALACTILOG_VIEWER_PASSWORD=
 
 # -----------------------------------------------------------------------------
 # Optional Overrides
@@ -116,20 +117,20 @@ ASTRO_ADMIN_PASSWORD=
 # When true (default), auth cookies are set with the Secure flag, which means
 # browsers will only send them over HTTPS connections.
 # Set to false if accessing GalactiLog over plain HTTP (e.g., http://localhost).
-# ASTRO_HTTPS=true
+# GALACTILOG_HTTPS=true
 
 # Secret key for signing JWT access tokens (HS256).
 # If not set, a random secret is generated at startup. This means all active
 # sessions are invalidated whenever the container restarts.
 # Set this to a long random string for persistent sessions across restarts.
 # Generate one with: openssl rand -hex 32
-# ASTRO_JWT_SECRET=
+# GALACTILOG_JWT_SECRET=
 
 # Access token lifetime in seconds. Default: 1800 (30 minutes).
 # Shorter values are more secure but cause more frequent silent refreshes.
-# ASTRO_ACCESS_TOKEN_EXPIRY=1800
+# GALACTILOG_ACCESS_TOKEN_EXPIRY=1800
 
 # Refresh token lifetime in seconds. Default: 604800 (7 days).
 # After this period, users must log in again. Refresh tokens rotate on each
 # use, so active users stay logged in as long as they visit within this window.
-# ASTRO_REFRESH_TOKEN_EXPIRY=604800
+# GALACTILOG_REFRESH_TOKEN_EXPIRY=604800

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -4,7 +4,7 @@ from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
-    database_url: str = "postgresql+asyncpg://astro:astro@localhost:5432/astro_catalog"
+    database_url: str = "postgresql+asyncpg://galactilog:galactilog@localhost:5432/galactilog_catalog"
     redis_url: str = "redis://localhost:6379/0"
     fits_data_path: str = "/app/data/fits"
     thumbnails_path: str = "/app/data/thumbnails"
@@ -18,13 +18,13 @@ class Settings(BaseSettings):
     viewer_username: str = ""
     viewer_password: str = ""
 
-    model_config = {"env_prefix": "ASTRO_"}
+    model_config = {"env_prefix": "GALACTILOG_"}
 
 
 settings = Settings()
 
 # Auto-generate JWT secret if not set -- stable for the lifetime of the process,
-# but tokens won't survive a restart. Fine for getting started; set ASTRO_JWT_SECRET
+# but tokens won't survive a restart. Fine for getting started; set GALACTILOG_JWT_SECRET
 # in .env for persistence across restarts.
 if not settings.jwt_secret:
     settings.jwt_secret = secrets.token_hex(32)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -18,8 +18,8 @@ logger = logging.getLogger(__name__)
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Warn if JWT secret was auto-generated (won't survive restarts)
-    if not os.environ.get("ASTRO_JWT_SECRET"):
-        logger.warning("ASTRO_JWT_SECRET is not set — using auto-generated secret. Sessions will not survive restarts. Set ASTRO_JWT_SECRET in .env for persistence.")
+    if not os.environ.get("GALACTILOG_JWT_SECRET"):
+        logger.warning("GALACTILOG_JWT_SECRET is not set — using auto-generated secret. Sessions will not survive restarts. Set GALACTILOG_JWT_SECRET in .env for persistence.")
 
     # Ensure database tables exist on startup
     from app.database import engine
@@ -75,7 +75,7 @@ def create_app() -> FastAPI:
         return JSONResponse(status_code=429, content={"detail": "Rate limit exceeded"})
 
     # CORS for dev mode
-    cors_origins = os.environ.get("ASTRO_CORS_ORIGINS")
+    cors_origins = os.environ.get("GALACTILOG_CORS_ORIGINS")
     if cors_origins:
         application.add_middleware(
             CORSMiddleware,

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -2,12 +2,12 @@ import os
 import sys
 from unittest.mock import MagicMock
 
-os.environ.setdefault("ASTRO_DATABASE_URL", "postgresql+asyncpg://test:test@localhost:5432/test_catalog")
-os.environ.setdefault("ASTRO_REDIS_URL", "redis://localhost:6379/1")
-os.environ.setdefault("ASTRO_FITS_DATA_PATH", "/tmp/test_fits")
-os.environ.setdefault("ASTRO_THUMBNAILS_PATH", "/tmp/test_thumbnails")
-os.environ.setdefault("ASTRO_JWT_SECRET", "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
-os.environ.setdefault("ASTRO_HTTPS", "false")
+os.environ.setdefault("GALACTILOG_DATABASE_URL", "postgresql+asyncpg://test:test@localhost:5432/test_catalog")
+os.environ.setdefault("GALACTILOG_REDIS_URL", "redis://localhost:6379/1")
+os.environ.setdefault("GALACTILOG_FITS_DATA_PATH", "/tmp/test_fits")
+os.environ.setdefault("GALACTILOG_THUMBNAILS_PATH", "/tmp/test_thumbnails")
+os.environ.setdefault("GALACTILOG_JWT_SECRET", "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
+os.environ.setdefault("GALACTILOG_HTTPS", "false")
 
 # Stub out native modules that may not be available in the test environment
 for _mod in ("fitsio",):

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -9,6 +9,6 @@ def test_settings_defaults():
 
 
 def test_settings_from_env(monkeypatch):
-    monkeypatch.setenv("ASTRO_THUMBNAIL_MAX_WIDTH", "400")
+    monkeypatch.setenv("GALACTILOG_THUMBNAIL_MAX_WIDTH", "400")
     s = Settings()
     assert s.thumbnail_max_width == 400

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -8,12 +8,12 @@
 # This file uses ${VAR:-default} syntax to reference variables from your .env
 # file. Docker Compose automatically loads the .env file from the same directory.
 #
-#   ${POSTGRES_USER:-astro}  — uses POSTGRES_USER from .env, or "astro" if not set
-#   ${FITS_DATA_HOST_PATH:-./sample_fits}  — uses the .env value, or ./sample_fits
+#   ${GALACTILOG_POSTGRES_USER:-galactilog}  — uses GALACTILOG_POSTGRES_USER from .env, or "galactilog" if not set
+#   ${GALACTILOG_FITS_HOST_PATH:-./sample_fits}  — uses the .env value, or ./sample_fits
 #
 # The `env_file: .env` directive on the app service passes ALL variables from
 # .env into the container as environment variables. The `environment:` block
-# below overrides specific variables (like ASTRO_DATABASE_URL) to use the
+# below overrides specific variables (like GALACTILOG_DATABASE_URL) to use the
 # docker-internal hostnames (e.g., "postgres" instead of "localhost").
 #
 # In short:
@@ -34,20 +34,20 @@ services:
     environment:
       # These come from .env. They configure the postgres container's init script
       # which creates the database and user on first start.
-      POSTGRES_USER: ${POSTGRES_USER:-astro}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-astro}
-      POSTGRES_DB: ${POSTGRES_DB:-astro_catalog}
+      POSTGRES_USER: ${GALACTILOG_POSTGRES_USER:-galactilog}
+      POSTGRES_PASSWORD: ${GALACTILOG_POSTGRES_PASSWORD:-galactilog}
+      POSTGRES_DB: ${GALACTILOG_POSTGRES_DB:-galactilog_catalog}
     volumes:
-      # Database storage. When POSTGRES_DATA_HOST_PATH is set in .env, a bind
-      # mount is used (recommended for production — easy to back up and locate).
+      # Database storage. When GALACTILOG_POSTGRES_DATA_HOST_PATH is set in .env,
+      # a bind mount is used (recommended for production — easy to back up and locate).
       # When not set, falls back to the "postgres_data" named volume.
-      - ${POSTGRES_DATA_HOST_PATH:-postgres_data}:/var/lib/postgresql/data
+      - ${GALACTILOG_POSTGRES_DATA_HOST_PATH:-postgres_data}:/var/lib/postgresql/data
     ports:
       # Exposed for local development tools (pgAdmin, psql, etc.).
       # Remove or comment out in production if external access is not needed.
       - "5432:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U astro"]
+      test: ["CMD-SHELL", "pg_isready -U ${GALACTILOG_POSTGRES_USER:-galactilog}"]
       interval: 5s
       timeout: 3s
       retries: 5
@@ -82,8 +82,8 @@ services:
       - "8080:80"
 
     # Load all variables from .env into the container environment.
-    # This is how ASTRO_ADMIN_PASSWORD, ASTRO_HTTPS, ASTRO_JWT_SECRET, and
-    # other app settings reach the application without listing each one here.
+    # This is how GALACTILOG_ADMIN_PASSWORD, GALACTILOG_HTTPS, GALACTILOG_JWT_SECRET,
+    # and other app settings reach the application without listing each one here.
     env_file: .env
 
     # Override specific variables with container-aware values.
@@ -92,26 +92,26 @@ services:
     environment:
       # Database URL built from .env credentials, using the docker-internal
       # hostname "postgres" (the service name above) instead of localhost.
-      ASTRO_DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-astro}:${POSTGRES_PASSWORD:-astro}@postgres:5432/${POSTGRES_DB:-astro_catalog}
+      GALACTILOG_DATABASE_URL: postgresql+asyncpg://${GALACTILOG_POSTGRES_USER:-galactilog}:${GALACTILOG_POSTGRES_PASSWORD:-galactilog}@postgres:5432/${GALACTILOG_POSTGRES_DB:-galactilog_catalog}
 
       # Redis URL using the docker-internal hostname "redis".
-      ASTRO_REDIS_URL: redis://redis:6379/0
+      GALACTILOG_REDIS_URL: redis://redis:6379/0
 
       # Container-internal paths for FITS data and thumbnails.
       # These must match the right side of the volume mounts below.
-      ASTRO_FITS_DATA_PATH: /app/data/fits
-      ASTRO_THUMBNAILS_PATH: /app/data/thumbnails
+      GALACTILOG_FITS_DATA_PATH: /app/data/fits
+      GALACTILOG_THUMBNAILS_PATH: /app/data/thumbnails
 
     volumes:
-      # Thumbnail storage. When THUMBNAILS_HOST_PATH is set in .env, a bind
-      # mount is used. Otherwise falls back to the "thumbnails_data" named volume.
-      - ${THUMBNAILS_HOST_PATH:-thumbnails_data}:/app/data/thumbnails
+      # Thumbnail storage. When GALACTILOG_THUMBNAILS_HOST_PATH is set in .env,
+      # a bind mount is used. Otherwise falls back to the "thumbnails_data" named volume.
+      - ${GALACTILOG_THUMBNAILS_HOST_PATH:-thumbnails_data}:/app/data/thumbnails
 
       # FITS data directory (read-only). The :ro flag prevents the container
       # from modifying your original FITS files.
-      # When FITS_DATA_HOST_PATH is set in .env, that host directory is mounted.
+      # When GALACTILOG_FITS_HOST_PATH is set in .env, that host directory is mounted.
       # Otherwise falls back to ./sample_fits for testing.
-      - ${FITS_DATA_HOST_PATH:-./sample_fits}:/app/data/fits:ro
+      - ${GALACTILOG_FITS_HOST_PATH:-./sample_fits}:/app/data/fits:ro
 
     depends_on:
       postgres:
@@ -120,8 +120,8 @@ services:
         condition: service_healthy
 
 # Named volumes used as fallbacks when host paths are not set in .env.
-# When POSTGRES_DATA_HOST_PATH / THUMBNAILS_HOST_PATH are defined, Docker uses
-# bind mounts instead and these named volumes are not created.
+# When GALACTILOG_POSTGRES_DATA_HOST_PATH / GALACTILOG_THUMBNAILS_HOST_PATH are
+# defined, Docker uses bind mounts instead and these named volumes are not created.
 # For production, always set host paths in .env for predictable data locations.
 volumes:
   postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,15 +2,15 @@ services:
   postgres:
     image: postgres:16-alpine
     environment:
-      POSTGRES_USER: ${POSTGRES_USER:-astro}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-astro}
-      POSTGRES_DB: ${POSTGRES_DB:-astro_catalog}
+      POSTGRES_USER: ${GALACTILOG_POSTGRES_USER:-galactilog}
+      POSTGRES_PASSWORD: ${GALACTILOG_POSTGRES_PASSWORD:-galactilog}
+      POSTGRES_DB: ${GALACTILOG_POSTGRES_DB:-galactilog_catalog}
     volumes:
-      - ${POSTGRES_DATA_HOST_PATH:-postgres_data}:/var/lib/postgresql/data
+      - ${GALACTILOG_POSTGRES_DATA_HOST_PATH:-postgres_data}:/var/lib/postgresql/data
     ports:
       - "5432:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U astro"]
+      test: ["CMD-SHELL", "pg_isready -U ${GALACTILOG_POSTGRES_USER:-galactilog}"]
       interval: 5s
       timeout: 3s
       retries: 5
@@ -32,14 +32,14 @@ services:
       - "8080:80"
     env_file: .env
     environment:
-      ASTRO_DATABASE_URL: postgresql+asyncpg://astro:astro@postgres:5432/astro_catalog
-      ASTRO_REDIS_URL: redis://redis:6379/0
-      ASTRO_FITS_DATA_PATH: /app/data/fits
-      ASTRO_THUMBNAILS_PATH: /app/data/thumbnails
+      GALACTILOG_DATABASE_URL: postgresql+asyncpg://${GALACTILOG_POSTGRES_USER:-galactilog}:${GALACTILOG_POSTGRES_PASSWORD:-galactilog}@postgres:5432/${GALACTILOG_POSTGRES_DB:-galactilog_catalog}
+      GALACTILOG_REDIS_URL: redis://redis:6379/0
+      GALACTILOG_FITS_DATA_PATH: /app/data/fits
+      GALACTILOG_THUMBNAILS_PATH: /app/data/thumbnails
     volumes:
       - ./backend:/app
-      - ${THUMBNAILS_HOST_PATH:-thumbnails_data}:/app/data/thumbnails
-      - ${FITS_DATA_HOST_PATH:-./sample_fits}:/app/data/fits:ro
+      - ${GALACTILOG_THUMBNAILS_HOST_PATH:-thumbnails_data}:/app/data/thumbnails
+      - ${GALACTILOG_FITS_HOST_PATH:-./sample_fits}:/app/data/fits:ro
     depends_on:
       postgres:
         condition: service_healthy
@@ -48,6 +48,6 @@ services:
 
 volumes:
   # Named volumes used as fallbacks when host paths are not set in .env
-  # When POSTGRES_DATA_HOST_PATH / THUMBNAILS_HOST_PATH are set, bind mounts are used instead
+  # When GALACTILOG_POSTGRES_DATA_HOST_PATH / GALACTILOG_THUMBNAILS_HOST_PATH are set, bind mounts are used instead
   postgres_data:
   thumbnails_data:

--- a/guides/CONFIGURATION.md
+++ b/guides/CONFIGURATION.md
@@ -18,23 +18,23 @@ GalactiLog uses two configuration files in the project root:
                     container-internal values (e.g., database hostname = "postgres")
 ```
 
-Docker Compose loads `.env` automatically from the same directory. The `env_file: .env` directive on the app service passes every variable from `.env` into the container. The `environment:` block in docker-compose.yml overrides specific variables (like `ASTRO_DATABASE_URL`) with container-aware values -- for example, using `postgres` (the Docker service name) as the database hostname instead of `localhost`.
+Docker Compose loads `.env` automatically from the same directory. The `env_file: .env` directive on the app service passes every variable from `.env` into the container. The `environment:` block in docker-compose.yml overrides specific variables (like `GALACTILOG_DATABASE_URL`) with container-aware values -- for example, using `postgres` (the Docker service name) as the database hostname instead of `localhost`.
 
 Variables in docker-compose.yml use `${VAR:-default}` syntax. If the variable is set in `.env`, that value is used. If not, the default after `:-` applies. This means you can run GalactiLog with minimal configuration -- only the host paths and admin password are strictly required.
 
 ## Environment Variables
 
-All application environment variables use the `ASTRO_` prefix. These are set in the `.env` file in the project root.
+All environment variables use the `GALACTILOG_` prefix to avoid collisions with other tools. These are set in the `.env` file in the project root.
 
 ### Application Settings
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ASTRO_DATABASE_URL` | `postgresql+asyncpg://astro:astro@postgres:5432/astro_catalog` | PostgreSQL connection string (async driver). Normally built from POSTGRES_USER/PASSWORD/DB in docker-compose.yml. Only set this directly if connecting to an external database. |
-| `ASTRO_REDIS_URL` | `redis://redis:6379/0` | Redis connection string for task queue and caching. Default points to the redis container. Only change if using an external Redis instance. |
-| `ASTRO_FITS_DATA_PATH` | `/app/data/fits` | Container-internal path where FITS files are mounted. Must match the volume mount target in docker-compose.yml. |
-| `ASTRO_THUMBNAILS_PATH` | `/app/data/thumbnails` | Container-internal path for generated thumbnails. Must match the volume mount target in docker-compose.yml. |
-| `ASTRO_THUMBNAIL_MAX_WIDTH` | `800` | Maximum thumbnail width in pixels. Larger values produce sharper thumbnails but use more disk space. |
+| `GALACTILOG_DATABASE_URL` | `postgresql+asyncpg://galactilog:galactilog@postgres:5432/galactilog_catalog` | PostgreSQL connection string (async driver). Normally built from GALACTILOG_POSTGRES_USER/PASSWORD/DB in docker-compose.yml. Only set this directly if connecting to an external database. |
+| `GALACTILOG_REDIS_URL` | `redis://redis:6379/0` | Redis connection string for task queue and caching. Default points to the redis container. Only change if using an external Redis instance. |
+| `GALACTILOG_FITS_DATA_PATH` | `/app/data/fits` | Container-internal path where FITS files are mounted. Must match the volume mount target in docker-compose.yml. |
+| `GALACTILOG_THUMBNAILS_PATH` | `/app/data/thumbnails` | Container-internal path for generated thumbnails. Must match the volume mount target in docker-compose.yml. |
+| `GALACTILOG_THUMBNAIL_MAX_WIDTH` | `800` | Maximum thumbnail width in pixels. Larger values produce sharper thumbnails but use more disk space. |
 
 ### Docker Compose Host Paths
 
@@ -42,19 +42,19 @@ These variables map directories on your host machine into the Docker containers.
 
 | Variable | Fallback | Description |
 |----------|----------|-------------|
-| `FITS_DATA_HOST_PATH` | `./sample_fits` | Host directory containing your FITS files. Mounted read-only into the container. Use an absolute path to your imaging data (e.g., `/mnt/nas/astrophotography`). |
-| `THUMBNAILS_HOST_PATH` | `thumbnails_data` (named volume) | Host directory for thumbnail storage. GalactiLog creates JPEG thumbnails during ingest -- this directory grows over time. Set a host path for easy access and backups. |
-| `POSTGRES_DATA_HOST_PATH` | `postgres_data` (named volume) | Host directory for PostgreSQL data persistence. Set this to persist the database in a known location for backups. Without it, data lives in a Docker named volume. |
+| `GALACTILOG_FITS_HOST_PATH` | `./sample_fits` | Host directory containing your FITS files. Mounted read-only into the container. Use an absolute path to your imaging data (e.g., `/mnt/nas/astrophotography`). |
+| `GALACTILOG_THUMBNAILS_HOST_PATH` | `thumbnails_data` (named volume) | Host directory for thumbnail storage. GalactiLog creates JPEG thumbnails during ingest -- this directory grows over time. Set a host path for easy access and backups. |
+| `GALACTILOG_POSTGRES_DATA_HOST_PATH` | `postgres_data` (named volume) | Host directory for PostgreSQL data persistence. Set this to persist the database in a known location for backups. Without it, data lives in a Docker named volume. |
 
 ### PostgreSQL Settings
 
-These configure both the postgres container (which creates the database on first start) and are interpolated into the `ASTRO_DATABASE_URL` connection string in docker-compose.yml. They must stay in sync.
+These configure both the postgres container (which creates the database on first start) and are interpolated into the `GALACTILOG_DATABASE_URL` connection string in docker-compose.yml. They must stay in sync.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `POSTGRES_USER` | `astro` | Database username. |
-| `POSTGRES_PASSWORD` | `astro` | Database password. Change this for any network-exposed deployment. |
-| `POSTGRES_DB` | `astro_catalog` | Database name. |
+| `GALACTILOG_POSTGRES_USER` | `galactilog` | Database username. |
+| `GALACTILOG_POSTGRES_PASSWORD` | `galactilog` | Database password. Change this for any network-exposed deployment. |
+| `GALACTILOG_POSTGRES_DB` | `galactilog_catalog` | Database name. |
 
 ### Authentication Settings
 
@@ -62,20 +62,20 @@ See the [Security Guide](security.md) for full details on authentication, cookie
 
 | Variable | Default | Description | When to Change |
 |----------|---------|-------------|----------------|
-| `ASTRO_ADMIN_PASSWORD` | *(none)* | Admin account password. On first start, if no users exist, an admin is auto-created with this password. Ignored once any user exists. | Required for first-time setup. Must be 8+ characters. |
-| `ASTRO_ADMIN_USERNAME` | `admin` | Username for the auto-created admin account. | Only if you want a different admin username. |
-| `ASTRO_VIEWER_USERNAME` | *(none)* | Optional read-only viewer account username, created on first start alongside admin. | When you want to share access without admin privileges (e.g., family members, club members viewing your data). |
-| `ASTRO_VIEWER_PASSWORD` | *(none)* | Password for the viewer account. | Required if ASTRO_VIEWER_USERNAME is set. Must be 8+ characters. |
-| `ASTRO_HTTPS` | `true` | Controls the Secure flag on auth cookies. When true, cookies are only sent over HTTPS. | Set to `false` if accessing GalactiLog over plain HTTP (e.g., `http://localhost`, LAN without TLS). |
-| `ASTRO_JWT_SECRET` | *(auto-generated)* | Secret key for signing JWT access tokens (HS256). When not set, a random key is generated at startup, invalidating all sessions on restart. | Set to a long random string (`openssl rand -hex 32`) for persistent sessions across container restarts. |
-| `ASTRO_ACCESS_TOKEN_EXPIRY` | `1800` (30 min) | Access token lifetime in seconds. | Shorter values are more secure but cause more frequent silent refreshes. Increase if users report being logged out mid-session. |
-| `ASTRO_REFRESH_TOKEN_EXPIRY` | `604800` (7 days) | Refresh token lifetime in seconds. Users must re-login after this period of inactivity. | Increase for less frequent logins. Decrease for tighter security. |
+| `GALACTILOG_ADMIN_PASSWORD` | *(none)* | Admin account password. On first start, if no users exist, an admin is auto-created with this password. Ignored once any user exists. | Required for first-time setup. Must be 8+ characters. |
+| `GALACTILOG_ADMIN_USERNAME` | `admin` | Username for the auto-created admin account. | Only if you want a different admin username. |
+| `GALACTILOG_VIEWER_USERNAME` | *(none)* | Optional read-only viewer account username, created on first start alongside admin. | When you want to share access without admin privileges (e.g., family members, club members viewing your data). |
+| `GALACTILOG_VIEWER_PASSWORD` | *(none)* | Password for the viewer account. | Required if `GALACTILOG_VIEWER_USERNAME` is set. Must be 8+ characters. |
+| `GALACTILOG_HTTPS` | `true` | Controls the Secure flag on auth cookies. When true, cookies are only sent over HTTPS. | Set to `false` if accessing GalactiLog over plain HTTP (e.g., `http://localhost`, LAN without TLS). |
+| `GALACTILOG_JWT_SECRET` | *(auto-generated)* | Secret key for signing JWT access tokens (HS256). When not set, a random key is generated at startup, invalidating all sessions on restart. | Set to a long random string (`openssl rand -hex 32`) for persistent sessions across container restarts. |
+| `GALACTILOG_ACCESS_TOKEN_EXPIRY` | `1800` (30 min) | Access token lifetime in seconds. | Shorter values are more secure but cause more frequent silent refreshes. Increase if users report being logged out mid-session. |
+| `GALACTILOG_REFRESH_TOKEN_EXPIRY` | `604800` (7 days) | Refresh token lifetime in seconds. Users must re-login after this period of inactivity. | Increase for less frequent logins. Decrease for tighter security. |
 
 ### CORS (Development Only)
 
 | Variable | Default | Description | When to Change |
 |----------|---------|-------------|----------------|
-| `ASTRO_CORS_ORIGINS` | *(none)* | Comma-separated list of allowed origins for CORS. Not needed in production (same-origin behind nginx). | Set to `http://localhost:3000` when running the frontend dev server separately from the backend. |
+| `GALACTILOG_CORS_ORIGINS` | *(none)* | Comma-separated list of allowed origins for CORS. Not needed in production (same-origin behind nginx). | Set to `http://localhost:3000` when running the frontend dev server separately from the backend. |
 
 ## Auto-Scan
 

--- a/guides/INSTALL.md
+++ b/guides/INSTALL.md
@@ -57,31 +57,31 @@ Edit `.env` with your paths (see [`.env.example`](../.env.example) for all optio
 
 ### 3. Configure Host Paths
 
-Update the three `*_HOST_PATH` variables in `.env`:
+Update the three `GALACTILOG_*_HOST_PATH` variables in `.env`:
 
 | Variable | Description | Notes |
 |----------|-------------|-------|
-| `FITS_DATA_HOST_PATH` | Directory containing your FITS files | Mounted read-only in the container. Can be a nested directory structure; GalactiLog scans recursively. |
-| `THUMBNAILS_HOST_PATH` | Where generated JPEG thumbnails are stored | Created automatically. Needs read/write access. |
-| `POSTGRES_DATA_HOST_PATH` | PostgreSQL data directory | Created automatically. Persists your database across container restarts. |
+| `GALACTILOG_FITS_HOST_PATH` | Directory containing your FITS files | Mounted read-only in the container. Can be a nested directory structure; GalactiLog scans recursively. |
+| `GALACTILOG_THUMBNAILS_HOST_PATH` | Where generated JPEG thumbnails are stored | Created automatically. Needs read/write access. |
+| `GALACTILOG_POSTGRES_DATA_HOST_PATH` | PostgreSQL data directory | Created automatically. Persists your database across container restarts. |
 
 **Windows (local paths):**
 ```
-FITS_DATA_HOST_PATH=D:/Astrophotography/Data
-THUMBNAILS_HOST_PATH=D:/GalactiLog/thumbnails
-POSTGRES_DATA_HOST_PATH=D:/GalactiLog/postgres
+GALACTILOG_FITS_HOST_PATH=D:/Astrophotography/Data
+GALACTILOG_THUMBNAILS_HOST_PATH=D:/GalactiLog/thumbnails
+GALACTILOG_POSTGRES_DATA_HOST_PATH=D:/GalactiLog/postgres
 ```
 
 **Linux (local paths):**
 ```
-FITS_DATA_HOST_PATH=/home/user/astro/data
-THUMBNAILS_HOST_PATH=/home/user/galactilog/thumbnails
-POSTGRES_DATA_HOST_PATH=/home/user/galactilog/postgres
+GALACTILOG_FITS_HOST_PATH=/home/user/astro/data
+GALACTILOG_THUMBNAILS_HOST_PATH=/home/user/galactilog/thumbnails
+GALACTILOG_POSTGRES_DATA_HOST_PATH=/home/user/galactilog/postgres
 ```
 
 **Linux (NFS mount):**
 
-If your FITS files are on a NAS or network share, mount the NFS export on the host first, then point `FITS_DATA_HOST_PATH` to the mount point:
+If your FITS files are on a NAS or network share, mount the NFS export on the host first, then point `GALACTILOG_FITS_HOST_PATH` to the mount point:
 
 ```bash
 # Mount the NFS share (add to /etc/fstab for persistence)
@@ -90,7 +90,7 @@ sudo mount -t nfs nas.local:/volume1/astrophotography /mnt/astro
 ```
 
 ```
-FITS_DATA_HOST_PATH=/mnt/astro
+GALACTILOG_FITS_HOST_PATH=/mnt/astro
 ```
 
 The FITS directory is mounted read-only into the container, so GalactiLog will never modify your source files. To make the NFS mount persistent across reboots, add it to `/etc/fstab` (the `ro` option mounts the NFS share read-only on the host as well):
@@ -230,7 +230,7 @@ ports:
 
 ### FITS files not found during scan
 
-- Verify `FITS_DATA_HOST_PATH` in `.env` points to the correct directory
+- Verify `GALACTILOG_FITS_HOST_PATH` in `.env` points to the correct directory
 - The path is mounted read-only; ensure the directory exists and is readable
 - GalactiLog scans for files with extensions `.fits`, `.fit`, and `.fts` (case-insensitive)
 - Check container logs: `docker compose logs app`
@@ -258,7 +258,7 @@ docker compose up -d
 
 ### Thumbnails not generating
 
-- Check that `THUMBNAILS_HOST_PATH` exists and is writable
+- Check that `GALACTILOG_THUMBNAILS_HOST_PATH` exists and is writable
 - Calibration frames (DARK, FLAT, BIAS) do not generate thumbnails by design
 - View worker logs for errors: `docker compose logs app | grep celery`
 

--- a/guides/NINA-SETUP.md
+++ b/guides/NINA-SETUP.md
@@ -147,7 +147,7 @@ The following table summarizes which N.I.N.A. components and plugins produce dat
 GalactiLog scans your FITS directory recursively. It works with any directory structure, but a typical N.I.N.A. layout looks like this:
 
 ```
-/astro_incoming/                        <-- FITS_DATA_HOST_PATH
+/astro_incoming/                        <-- GALACTILOG_FITS_HOST_PATH
   M31 - Andromeda Galaxy/
     2025-01-15/
       M31_Light_Ha_300s_001.fits

--- a/guides/security.md
+++ b/guides/security.md
@@ -49,11 +49,11 @@ Token families group all refresh tokens descended from a single login. If a revo
 | Attribute | Access Token Cookie | Refresh Token Cookie |
 |-----------|--------------------|--------------------|
 | HttpOnly | Yes | Yes |
-| Secure | Yes (configurable via `ASTRO_HTTPS`) | Yes (configurable via `ASTRO_HTTPS`) |
+| Secure | Yes (configurable via `GALACTILOG_HTTPS`) | Yes (configurable via `GALACTILOG_HTTPS`) |
 | SameSite | Strict | Strict |
 | Path | `/` | `/api/auth/refresh` |
 
-Set `ASTRO_HTTPS=false` for local development without HTTPS.
+Set `GALACTILOG_HTTPS=false` for local development without HTTPS.
 
 ## Security Headers
 
@@ -132,18 +132,18 @@ Backend enforces role permissions on all endpoints. Frontend hides controls for 
 
 Not needed in production (frontend and API are same-origin behind nginx).
 
-For development: set `ASTRO_CORS_ORIGINS` environment variable with an explicit allowlist (e.g., `http://localhost:3000`). Credentials are allowed (`allow_credentials=True`).
+For development: set `GALACTILOG_CORS_ORIGINS` environment variable with an explicit allowlist (e.g., `http://localhost:3000`). Credentials are allowed (`allow_credentials=True`).
 
 ## User Management
 
 ### First-Time Setup
 
-Set `ASTRO_ADMIN_PASSWORD` in `.env`. On first start, if no users exist, an admin account is created automatically:
+Set `GALACTILOG_ADMIN_PASSWORD` in `.env`. On first start, if no users exist, an admin account is created automatically:
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `ASTRO_ADMIN_PASSWORD` | *(none)* | Admin password. Required for auto-creation. |
-| `ASTRO_ADMIN_USERNAME` | `admin` | Admin username. |
+| `GALACTILOG_ADMIN_PASSWORD` | *(none)* | Admin password. Required for auto-creation. |
+| `GALACTILOG_ADMIN_USERNAME` | `admin` | Admin username. |
 
 Once a user exists in the database, these variables are ignored.
 

--- a/setup.sh
+++ b/setup.sh
@@ -69,9 +69,9 @@ HOST_IP=$(detect_lan_ip)
 header "Configuration"
 
 # Hardcoded paths
-PG_USER="astro"
-PG_PASS="astro"
-PG_DB="astro_catalog"
+PG_USER="galactilog"
+PG_PASS="galactilog"
+PG_DB="galactilog_catalog"
 FITS_PATH="/astro_incoming"
 THUMBNAILS_PATH="/docker/astro_cataloger/thumbnails"
 PG_DATA_PATH="/docker/astro_cataloger/postgres"
@@ -137,25 +137,25 @@ cat > "$ENV_FILE" <<ENVEOF
 # ──────────────────────────────────────────────────────────────
 
 # PostgreSQL
-POSTGRES_USER=${PG_USER}
-POSTGRES_PASSWORD=${PG_PASS}
-POSTGRES_DB=${PG_DB}
+GALACTILOG_POSTGRES_USER=${PG_USER}
+GALACTILOG_POSTGRES_PASSWORD=${PG_PASS}
+GALACTILOG_POSTGRES_DB=${PG_DB}
 
 # Application
-ASTRO_DATABASE_URL=postgresql+asyncpg://${PG_USER}:${PG_PASS}@postgres:5432/${PG_DB}
-ASTRO_REDIS_URL=redis://redis:6379/0
-ASTRO_FITS_DATA_PATH=/app/data/fits
-ASTRO_THUMBNAILS_PATH=/app/data/thumbnails
-ASTRO_THUMBNAIL_MAX_WIDTH=${THUMB_WIDTH}
+GALACTILOG_DATABASE_URL=postgresql+asyncpg://${PG_USER}:${PG_PASS}@postgres:5432/${PG_DB}
+GALACTILOG_REDIS_URL=redis://redis:6379/0
+GALACTILOG_FITS_DATA_PATH=/app/data/fits
+GALACTILOG_THUMBNAILS_PATH=/app/data/thumbnails
+GALACTILOG_THUMBNAIL_MAX_WIDTH=${THUMB_WIDTH}
 
 # Host paths (mapped into containers)
-FITS_DATA_HOST_PATH=${FITS_PATH}
-THUMBNAILS_HOST_PATH=${THUMBNAILS_PATH}
-POSTGRES_DATA_HOST_PATH=${PG_DATA_PATH}
+GALACTILOG_FITS_HOST_PATH=${FITS_PATH}
+GALACTILOG_THUMBNAILS_HOST_PATH=${THUMBNAILS_PATH}
+GALACTILOG_POSTGRES_DATA_HOST_PATH=${PG_DATA_PATH}
 
 # Authentication
-ASTRO_ADMIN_USERNAME=${ADMIN_USER}
-ASTRO_ADMIN_PASSWORD=${ADMIN_PASS}
+GALACTILOG_ADMIN_USERNAME=${ADMIN_USER}
+GALACTILOG_ADMIN_PASSWORD=${ADMIN_PASS}
 ENVEOF
 
 success "Created $ENV_FILE"


### PR DESCRIPTION
**Summary**
This pull request renames all environment variable prefixes from `ASTRO_` to `GALACTILOG_`, establishing a consistent naming convention for project configuration.

**Changes**
*   Renamed all `ASTRO_` prefixed environment variables to `GALACTILOG_` across the codebase.
*   Updated configuration parsing logic in `backend/app/config.py` to recognize the new prefix.
*   Modified `docker-compose.yml` and `docker-compose.example.yml` to use `GALACTILOG_` variables.
*   Updated `.env.example` with the new prefix.
*   Adjusted `setup.sh` script to reflect the new naming.
*   Revised all relevant documentation in the `guides/` directory.
*   Updated backend tests in `backend/tests/` to align with the new configuration.

**Impact**
*   **Configuration**: All environment variables now use the `GALACTILOG_` prefix.
*   **Deployment**: `docker-compose` configurations require updates to function correctly.
*   **Development Environment**: Local `.env` files and setup scripts must be updated.
*   **Testing**: Backend configuration tests are modified.
*   **Documentation**: User and developer guides reflect the new naming convention.

---
*This PR description was automatically generated.*
