### PR TITLE
fix: handle single-channel XISF images with trailing dimension

### DIFF
--- a/backend/app/services/xisf_parser.py
+++ b/backend/app/services/xisf_parser.py
@@ -201,6 +201,10 @@ def generate_xisf_thumbnail(
     data = xobj.read_image(0).astype(np.float32)
 
     # xisf library returns channels-last [H, W, C] for color, [H, W] for mono
+    # Squeeze trailing single-channel dimension [H, W, 1] -> [H, W]
+    if data.ndim == 3 and (data.shape[2] == 1 or data.shape[0] == 1):
+        data = data.squeeze()
+
     if data.ndim == 2:
         data = _normalize_to_unit(data)
         resized = _resize_array(data, max_width)


### PR DESCRIPTION
**Summary**
This PR resolves an issue preventing correct thumbnail generation for single-channel XISF images that include a trailing dimension.

**Changes**
*   Correctly handle single-channel XISF images with a trailing dimension during thumbnail generation.

**Impact**
The `backend/app/services/xisf_parser.py` file is updated. This change impacts the backend service responsible for XISF image parsing and thumbnail creation.

---
*This PR description was automatically generated.*
