### PR TITLE
Implement Granular Statistics Timeline

### DIFF
--- a/backend/app/api/stats.py
+++ b/backend/app/api/stats.py
@@ -15,10 +15,12 @@ from app.models import Image, Target
 from app.services.normalization import load_alias_maps, normalize_filter, normalize_equipment
 from app.schemas.stats import (
     StatsResponse, OverviewStats, EquipmentStats, EquipmentItem,
-    TimelineEntry, TopTarget, DataQualityStats, HfrBucket,
+    TimelineEntry, TimelineDetailEntry, TopTarget, DataQualityStats, HfrBucket,
     StorageStats, IngestEntry,
     EquipmentComboMetrics, EquipmentFilterMetrics,
+    SiteCoords,
 )
+from app.services.astro_night import dark_hours_for_night, dark_hours_for_month, dark_hours_for_week
 
 router = APIRouter(prefix="/stats", tags=["stats"])
 
@@ -56,6 +58,35 @@ async def _refresh_storage_cache() -> None:
         _storage_cache["fits"] = fits
         _storage_cache["thumbnails"] = thumbs
         _storage_last_update = time.time()
+
+
+async def _extract_site_coords(session: AsyncSession) -> SiteCoords | None:
+    """Extract the most common lat/lon from FITS raw_headers.
+
+    Checks SITELAT/SITELONG (N.I.N.A.), OBSLAT/OBSLONG, and LAT-OBS/LONG-OBS.
+    Returns the most frequently occurring coordinate pair, or None.
+    """
+    lat_keys = ["SITELAT", "OBSLAT", "LAT-OBS"]
+    lon_keys = ["SITELONG", "OBSLONG", "LONG-OBS"]
+
+    for lat_key, lon_key in zip(lat_keys, lon_keys):
+        q = select(
+            Image.raw_headers[lat_key].astext.label("lat"),
+            Image.raw_headers[lon_key].astext.label("lon"),
+            func.count().label("cnt"),
+        ).where(
+            Image.raw_headers[lat_key].isnot(None),
+            Image.raw_headers[lon_key].isnot(None),
+        ).group_by("lat", "lon").order_by(func.count().desc()).limit(1)
+
+        result = await session.execute(q)
+        row = result.first()
+        if row and row.lat and row.lon:
+            try:
+                return SiteCoords(latitude=float(row.lat), longitude=float(row.lon))
+            except (ValueError, TypeError):
+                continue
+    return None
 
 
 @router.get("", response_model=StatsResponse)
@@ -261,7 +292,7 @@ async def get_stats(session: AsyncSession = Depends(get_session), user: User = D
         normalized_usage[canonical] = normalized_usage.get(canonical, 0.0) + seconds
     filter_usage = normalized_usage
 
-    # Timeline (monthly integration)
+    # Timeline — monthly (backward compat)
     month_label = func.to_char(Image.capture_date, 'YYYY-MM').label('month')
     timeline_q = select(
         month_label,
@@ -271,6 +302,69 @@ async def get_stats(session: AsyncSession = Depends(get_session), user: User = D
     ).group_by(month_label).order_by(month_label)
     timeline_result = await session.execute(timeline_q)
     timeline = [TimelineEntry(month=r[0], integration_seconds=float(r[1])) for r in timeline_result.all()]
+
+    # Site coordinates (for efficiency calc)
+    site_coords = await _extract_site_coords(session)
+
+    # Timeline — monthly with efficiency
+    timeline_monthly: list[TimelineDetailEntry] = []
+    for entry in timeline:
+        eff = None
+        if site_coords:
+            year, month = map(int, entry.month.split("-"))
+            dark_h = dark_hours_for_month(year, month, site_coords.latitude, site_coords.longitude)
+            if dark_h > 0:
+                eff = round((entry.integration_seconds / 3600) / dark_h * 100, 1)
+        timeline_monthly.append(TimelineDetailEntry(
+            period=entry.month,
+            integration_seconds=entry.integration_seconds,
+            efficiency_pct=eff,
+        ))
+
+    # Timeline — weekly
+    week_label = func.to_char(Image.capture_date, 'IYYY-"W"IW').label('week')
+    weekly_q = select(
+        week_label,
+        func.coalesce(func.sum(Image.exposure_time), 0),
+    ).where(
+        Image.capture_date.isnot(None), Image.image_type == "LIGHT"
+    ).group_by(week_label).order_by(week_label)
+    weekly_result = await session.execute(weekly_q)
+    timeline_weekly: list[TimelineDetailEntry] = []
+    for r in weekly_result.all():
+        eff = None
+        if site_coords:
+            parts = r[0].split("-W")
+            year, week = int(parts[0]), int(parts[1])
+            dark_h = dark_hours_for_week(year, week, site_coords.latitude, site_coords.longitude)
+            if dark_h > 0:
+                eff = round((float(r[1]) / 3600) / dark_h * 100, 1)
+        timeline_weekly.append(TimelineDetailEntry(
+            period=r[0], integration_seconds=float(r[1]), efficiency_pct=eff,
+        ))
+
+    # Timeline — daily
+    day_label = func.to_char(Image.capture_date, 'YYYY-MM-DD').label('day')
+    daily_q = select(
+        day_label,
+        func.coalesce(func.sum(Image.exposure_time), 0),
+    ).where(
+        Image.capture_date.isnot(None), Image.image_type == "LIGHT"
+    ).group_by(day_label).order_by(day_label)
+    daily_result = await session.execute(daily_q)
+    timeline_daily: list[TimelineDetailEntry] = []
+    for r in daily_result.all():
+        eff = None
+        if site_coords:
+            from datetime import date as date_type
+            parts = r[0].split("-")
+            d = date_type(int(parts[0]), int(parts[1]), int(parts[2]))
+            dark_h = dark_hours_for_night(d, site_coords.latitude, site_coords.longitude)
+            if dark_h > 0:
+                eff = round((float(r[1]) / 3600) / dark_h * 100, 1)
+        timeline_daily.append(TimelineDetailEntry(
+            period=r[0], integration_seconds=float(r[1]), efficiency_pct=eff,
+        ))
 
     # Top targets
     top_q = select(
@@ -348,6 +442,10 @@ async def get_stats(session: AsyncSession = Depends(get_session), user: User = D
         equipment_performance=equipment_performance,
         filter_usage=filter_usage,
         timeline=timeline,
+        timeline_monthly=timeline_monthly,
+        timeline_weekly=timeline_weekly,
+        timeline_daily=timeline_daily,
+        site_coords=site_coords,
         top_targets=top_targets,
         data_quality=data_quality,
         storage=storage,

--- a/backend/app/schemas/stats.py
+++ b/backend/app/schemas/stats.py
@@ -24,6 +24,17 @@ class TimelineEntry(BaseModel):
     integration_seconds: float
 
 
+class TimelineDetailEntry(BaseModel):
+    period: str
+    integration_seconds: float
+    efficiency_pct: float | None = None
+
+
+class SiteCoords(BaseModel):
+    latitude: float
+    longitude: float
+
+
 class TopTarget(BaseModel):
     name: str
     integration_seconds: float
@@ -82,6 +93,10 @@ class StatsResponse(BaseModel):
     equipment_performance: list[EquipmentComboMetrics]
     filter_usage: dict[str, float]
     timeline: list[TimelineEntry]
+    timeline_monthly: list[TimelineDetailEntry]
+    timeline_weekly: list[TimelineDetailEntry]
+    timeline_daily: list[TimelineDetailEntry]
+    site_coords: SiteCoords | None
     top_targets: list[TopTarget]
     data_quality: DataQualityStats
     storage: StorageStats

--- a/backend/app/services/astro_night.py
+++ b/backend/app/services/astro_night.py
@@ -1,0 +1,62 @@
+"""Calculate astronomical dark hours using astropy solar position.
+
+Astronomical night = sun below -18 degrees altitude.
+Samples sun altitude every 10 minutes across the night window (local noon to next noon)
+and sums intervals where sun is below -18 degrees.
+"""
+from datetime import date, timedelta
+from functools import lru_cache
+import calendar
+
+import numpy as np
+from astropy.coordinates import EarthLocation, AltAz, get_sun
+from astropy.time import Time
+import astropy.units as u
+
+# Sample every 10 minutes across 24h = 144 points
+_SAMPLES_PER_DAY = 144
+_SAMPLE_INTERVAL_HOURS = 24.0 / _SAMPLES_PER_DAY
+_ASTRO_TWILIGHT_DEG = -18.0
+
+
+def dark_hours_for_night(d: date, lat: float, lon: float) -> float:
+    """Return hours of astronomical darkness for the night starting on date `d`.
+
+    Computes sun altitude at 10-minute intervals from local noon on `d`
+    to local noon on `d+1`, counting intervals where altitude < -18 degrees.
+    """
+    location = EarthLocation(lat=lat * u.deg, lon=lon * u.deg, height=0 * u.m)
+
+    # Start at noon UTC on the given date (close enough — error < 1 sample interval)
+    start = Time(f"{d.isoformat()}T12:00:00", scale="utc")
+    offsets = np.arange(_SAMPLES_PER_DAY) * _SAMPLE_INTERVAL_HOURS / 24.0  # in days
+    times = start + offsets * u.day
+
+    altaz = AltAz(obstime=times, location=location)
+    sun_alt = get_sun(times).transform_to(altaz).alt.deg
+
+    dark_count = np.sum(sun_alt < _ASTRO_TWILIGHT_DEG)
+    return float(dark_count * _SAMPLE_INTERVAL_HOURS)
+
+
+@lru_cache(maxsize=512)
+def dark_hours_for_month(year: int, month: int, lat: float, lon: float) -> float:
+    """Return total astronomical dark hours for all nights in a given month."""
+    days_in_month = calendar.monthrange(year, month)[1]
+    total = 0.0
+    for day in range(1, days_in_month + 1):
+        total += dark_hours_for_night(date(year, month, day), lat, lon)
+    return round(total, 1)
+
+
+@lru_cache(maxsize=2048)
+def dark_hours_for_week(year: int, week: int, lat: float, lon: float) -> float:
+    """Return total astronomical dark hours for an ISO week."""
+    # Monday of the ISO week
+    jan4 = date(year, 1, 4)
+    start_of_week1 = jan4 - timedelta(days=jan4.weekday())
+    monday = start_of_week1 + timedelta(weeks=week - 1)
+    total = 0.0
+    for i in range(7):
+        total += dark_hours_for_night(monday + timedelta(days=i), lat, lon)
+    return round(total, 1)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "pwdlib[argon2]>=0.2.0",
     "PyJWT>=2.9.0",
     "slowapi>=0.1.9",
+    "astropy>=6.0.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/tests/test_astro_night.py
+++ b/backend/tests/test_astro_night.py
@@ -1,0 +1,49 @@
+"""Tests for astronomical night duration calculation."""
+import pytest
+from datetime import date
+from app.services.astro_night import dark_hours_for_night, dark_hours_for_month
+
+
+class TestDarkHoursForNight:
+    """Test single-night astronomical darkness calculation."""
+
+    def test_winter_solstice_mid_latitude(self):
+        """Winter solstice at ~33N should have long dark hours (~10-12h)."""
+        hours = dark_hours_for_night(date(2025, 12, 21), 33.0, -117.0)
+        assert 10.0 < hours < 13.0
+
+    def test_summer_solstice_mid_latitude(self):
+        """Summer solstice at ~33N should have short dark hours (~5-7h)."""
+        hours = dark_hours_for_night(date(2025, 6, 21), 33.0, -117.0)
+        assert 5.0 < hours < 8.0
+
+    def test_arctic_summer_very_short(self):
+        """Arctic summer should have near-zero dark hours."""
+        hours = dark_hours_for_night(date(2025, 6, 21), 65.0, 25.0)
+        assert hours < 2.0
+
+    def test_returns_float(self):
+        hours = dark_hours_for_night(date(2025, 3, 20), 33.0, -117.0)
+        assert isinstance(hours, float)
+        assert hours >= 0.0
+
+
+class TestDarkHoursForMonth:
+    """Test monthly aggregation of dark hours."""
+
+    def test_december_more_than_june(self):
+        """At mid-northern latitude, December should have more dark hours than June."""
+        dec = dark_hours_for_month(2025, 12, 33.0, -117.0)
+        jun = dark_hours_for_month(2025, 6, 33.0, -117.0)
+        assert dec > jun
+
+    def test_returns_positive_float(self):
+        hours = dark_hours_for_month(2025, 1, 33.0, -117.0)
+        assert isinstance(hours, float)
+        assert hours > 0.0
+
+    def test_february_fewer_days(self):
+        """February total should be less than March (fewer days, similar night length)."""
+        feb = dark_hours_for_month(2025, 2, 33.0, -117.0)
+        mar = dark_hours_for_month(2025, 3, 33.0, -117.0)
+        assert feb < mar

--- a/backend/tests/test_astro_night.py
+++ b/backend/tests/test_astro_night.py
@@ -1,7 +1,7 @@
 """Tests for astronomical night duration calculation."""
 import pytest
 from datetime import date
-from app.services.astro_night import dark_hours_for_night, dark_hours_for_month
+from app.services.astro_night import dark_hours_for_night, dark_hours_for_month, dark_hours_for_week
 
 
 class TestDarkHoursForNight:
@@ -47,3 +47,18 @@ class TestDarkHoursForMonth:
         feb = dark_hours_for_month(2025, 2, 33.0, -117.0)
         mar = dark_hours_for_month(2025, 3, 33.0, -117.0)
         assert feb < mar
+
+
+class TestDarkHoursForWeek:
+    """Test weekly aggregation of dark hours."""
+
+    def test_winter_week_more_than_summer_week(self):
+        """At mid-northern latitude, a December week should have more dark hours than a June week."""
+        winter = dark_hours_for_week(2025, 51, 33.0, -117.0)  # mid-December
+        summer = dark_hours_for_week(2025, 25, 33.0, -117.0)  # mid-June
+        assert winter > summer
+
+    def test_returns_positive_float(self):
+        hours = dark_hours_for_week(2025, 1, 33.0, -117.0)
+        assert isinstance(hours, float)
+        assert hours > 0.0

--- a/backend/tests/test_stats_timeline.py
+++ b/backend/tests/test_stats_timeline.py
@@ -1,0 +1,119 @@
+"""Tests for timeline granularity in /stats endpoint."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from httpx import AsyncClient, ASGITransport
+
+from app.main import app
+from app.database import get_session
+from app.api.deps import get_current_user
+from app.models.user import User
+
+
+def _make_admin_user():
+    from app.models.user import UserRole
+    user = MagicMock(spec=User)
+    user.id = __import__("uuid").uuid4()
+    user.username = "admin"
+    user.role = UserRole.admin
+    user.is_active = True
+    return user
+
+
+def _make_mock_session_for_stats():
+    """Build a mock session that returns plausible empty results for all get_stats queries."""
+    session = AsyncMock()
+
+    def _empty_result():
+        r = MagicMock()
+        r.one.return_value = (0, 0, 0)
+        r.all.return_value = []
+        r.first.return_value = None
+        r.scalar_one.return_value = 0
+        r.scalar_one_or_none.return_value = None
+        return r
+
+    # Overview returns (total_seconds, target_count, total_frames)
+    overview_result = MagicMock()
+    overview_result.one.return_value = (0, 0, 0)
+
+    # All subsequent queries return empty
+    def _side_effect(*args, **kwargs):
+        r = MagicMock()
+        r.one.return_value = (0, 0, 0)
+        r.all.return_value = []
+        r.first.return_value = None
+        r.scalar_one.return_value = 0
+        r.scalar_one_or_none.return_value = None
+        return r
+
+    session.execute = AsyncMock(side_effect=lambda *a, **kw: _side_effect())
+    return session
+
+
+@pytest.mark.asyncio
+async def test_stats_has_timeline_fields():
+    """Verify /stats returns all three timeline granularities and site_coords."""
+    session = _make_mock_session_for_stats()
+    user = _make_admin_user()
+
+    async def override_session():
+        yield session
+
+    async def override_user():
+        return user
+
+    app.dependency_overrides[get_session] = override_session
+    app.dependency_overrides[get_current_user] = override_user
+
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/api/stats")
+
+        assert resp.status_code == 200
+        data = resp.json()
+
+        assert "timeline" in data
+        assert isinstance(data["timeline"], list)
+
+        assert "timeline_monthly" in data
+        assert "timeline_weekly" in data
+        assert "timeline_daily" in data
+        assert "site_coords" in data
+
+        assert isinstance(data["timeline_monthly"], list)
+        assert isinstance(data["timeline_weekly"], list)
+        assert isinstance(data["timeline_daily"], list)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_timeline_detail_entry_shape():
+    """Verify TimelineDetailEntry has period, integration_seconds, efficiency_pct."""
+    session = _make_mock_session_for_stats()
+    user = _make_admin_user()
+
+    async def override_session():
+        yield session
+
+    async def override_user():
+        return user
+
+    app.dependency_overrides[get_session] = override_session
+    app.dependency_overrides[get_current_user] = override_user
+
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/api/stats")
+
+        data = resp.json()
+
+        for key in ("timeline_monthly", "timeline_weekly", "timeline_daily"):
+            for entry in data[key]:
+                assert "period" in entry
+                assert "integration_seconds" in entry
+                assert "efficiency_pct" in entry
+    finally:
+        app.dependency_overrides.clear()

--- a/frontend/src/components/ImagingTimeline.tsx
+++ b/frontend/src/components/ImagingTimeline.tsx
@@ -13,7 +13,7 @@ const BAR_GAP = 2;
 const BAR_AREA_HEIGHT = 220;
 
 type Preset = "all" | "1y" | "q" | "m" | "w";
-type DailyMode = "imaged" | "all";
+type GapMode = "imaged" | "all";
 type Granularity = "monthly" | "weekly" | "daily";
 
 interface Props {
@@ -86,7 +86,56 @@ function periodToDateRange(period: string, gran: Granularity): { from: string; t
   return { from: period, to: period };
 }
 
-/** Generate all dates between first and last entry */
+/** Generate all months between first and last entry (YYYY-MM format) */
+function allMonthsBetween(data: TimelineDetailEntry[]): string[] {
+  if (data.length === 0) return [];
+  const [sy, sm] = data[0].period.split("-").map(Number);
+  const [ey, em] = data[data.length - 1].period.split("-").map(Number);
+  const months: string[] = [];
+  let y = sy, m = sm;
+  while (y < ey || (y === ey && m <= em)) {
+    months.push(`${y}-${String(m).padStart(2, "0")}`);
+    m++;
+    if (m > 12) { m = 1; y++; }
+  }
+  return months;
+}
+
+/** Generate all ISO weeks between first and last entry (YYYY-WNN format) */
+function allWeeksBetween(data: TimelineDetailEntry[]): string[] {
+  if (data.length === 0) return [];
+  const parseWeek = (s: string) => {
+    const parts = s.split("-W");
+    return { y: parseInt(parts[0]), w: parseInt(parts[1]) };
+  };
+  const start = parseWeek(data[0].period);
+  const end = parseWeek(data[data.length - 1].period);
+  // Walk via dates: find Monday of start week, iterate 7 days at a time
+  const jan4 = new Date(start.y, 0, 4);
+  const startOfWeek1 = new Date(jan4);
+  startOfWeek1.setDate(jan4.getDate() - jan4.getDay() + 1);
+  const monday = new Date(startOfWeek1);
+  monday.setDate(startOfWeek1.getDate() + (start.w - 1) * 7);
+
+  const weeks: string[] = [];
+  const endLabel = `${end.y}-W${String(end.w).padStart(2, "0")}`;
+  let cur = new Date(monday);
+  for (let safety = 0; safety < 1000; safety++) {
+    // Get ISO week/year for cur (Thursday-based)
+    const thu = new Date(cur);
+    thu.setDate(cur.getDate() + 3);
+    const isoYear = thu.getFullYear();
+    const jan1 = new Date(isoYear, 0, 1);
+    const isoWeek = Math.ceil(((thu.getTime() - jan1.getTime()) / 86400000 + jan1.getDay() + 1) / 7);
+    const label = `${isoYear}-W${String(isoWeek).padStart(2, "0")}`;
+    weeks.push(label);
+    if (label === endLabel) break;
+    cur.setDate(cur.getDate() + 7);
+  }
+  return weeks;
+}
+
+/** Generate all dates between first and last entry (YYYY-MM-DD format) */
 function allDatesBetween(data: TimelineDetailEntry[]): string[] {
   if (data.length === 0) return [];
   const start = new Date(data[0].period);
@@ -94,17 +143,26 @@ function allDatesBetween(data: TimelineDetailEntry[]): string[] {
   const dates: string[] = [];
   const cur = new Date(start);
   while (cur <= end) {
-    dates.push(cur.toISOString().slice(0, 10));
+    const y = cur.getFullYear();
+    const m = String(cur.getMonth() + 1).padStart(2, "0");
+    const d = String(cur.getDate()).padStart(2, "0");
+    dates.push(`${y}-${m}-${d}`);
     cur.setDate(cur.getDate() + 1);
   }
   return dates;
+}
+
+/** Fill gaps in data using a period generator */
+function fillGaps(data: TimelineDetailEntry[], allPeriods: string[]): TimelineDetailEntry[] {
+  const dataMap = new Map(data.map(e => [e.period, e]));
+  return allPeriods.map(p => dataMap.get(p) ?? { period: p, integration_seconds: 0, efficiency_pct: null });
 }
 
 const ImagingTimeline: Component<Props> = (props) => {
   const navigate = useNavigate();
   const [zoom, setZoom] = createSignal(1);
   const [activePreset, setActivePreset] = createSignal<Preset | null>("all");
-  const [dailyMode, setDailyMode] = createSignal<DailyMode>("imaged");
+  const [gapMode, setGapMode] = createSignal<GapMode>("imaged");
 
   // Drag-to-pan state
   const [isDragging, setIsDragging] = createSignal(false);
@@ -116,18 +174,18 @@ const ImagingTimeline: Component<Props> = (props) => {
 
   const granularity = createMemo(() => granularityForZoom(zoom()));
 
-  /** Active dataset based on zoom level */
+  /** Active dataset based on zoom level and gap mode */
   const activeData = createMemo((): TimelineDetailEntry[] => {
     const gran = granularity();
-    if (gran === "monthly") return props.monthly;
-    if (gran === "weekly") return props.weekly;
+    const showAll = gapMode() === "all";
 
-    if (dailyMode() === "all") {
-      const allDates = allDatesBetween(props.daily);
-      const dataMap = new Map(props.daily.map(e => [e.period, e]));
-      return allDates.map(d => dataMap.get(d) ?? { period: d, integration_seconds: 0, efficiency_pct: null });
+    if (gran === "monthly") {
+      return showAll ? fillGaps(props.monthly, allMonthsBetween(props.monthly)) : props.monthly;
     }
-    return props.daily;
+    if (gran === "weekly") {
+      return showAll ? fillGaps(props.weekly, allWeeksBetween(props.weekly)) : props.weekly;
+    }
+    return showAll ? fillGaps(props.daily, allDatesBetween(props.daily)) : props.daily;
   });
 
   const maxVal = createMemo(() => Math.max(...activeData().map(e => e.integration_seconds), 1));
@@ -286,25 +344,23 @@ const ImagingTimeline: Component<Props> = (props) => {
       <div class="flex items-center justify-between flex-wrap gap-2">
         <h3 class="text-white font-medium text-sm">Imaging Timeline</h3>
         <div class="flex items-center gap-3">
-          {/* Daily mode toggle */}
-          <Show when={granularity() === "daily"}>
-            <div class="flex gap-0.5">
-              <button
-                class={`px-2 py-0.5 text-xs rounded ${dailyMode() === "imaged" ? "bg-theme-accent text-white" : "bg-theme-surface-alt text-theme-text-secondary"}`}
-                onClick={() => setDailyMode("imaged")}
-              >Imaged only</button>
-              <button
-                class={`px-2 py-0.5 text-xs rounded ${dailyMode() === "all" ? "bg-theme-accent text-white" : "bg-theme-surface-alt text-theme-text-secondary"}`}
-                onClick={() => setDailyMode("all")}
-              >All nights</button>
-            </div>
-          </Show>
+          {/* Gap mode toggle */}
+          <div class="flex gap-0.5">
+            <button
+              class={`px-2 py-0.5 text-xs rounded transition-colors duration-200 ${gapMode() === "imaged" ? "bg-theme-accent text-white" : "bg-theme-surface-alt text-theme-text-secondary"}`}
+              onClick={() => setGapMode("imaged")}
+            >Imaged only</button>
+            <button
+              class={`px-2 py-0.5 text-xs rounded transition-colors duration-200 ${gapMode() === "all" ? "bg-theme-accent text-white" : "bg-theme-surface-alt text-theme-text-secondary"}`}
+              onClick={() => setGapMode("all")}
+            >{granularity() === "daily" ? "All nights" : granularity() === "weekly" ? "All weeks" : "All months"}</button>
+          </div>
           {/* Presets */}
           <div class="flex gap-0.5">
             <For each={presets}>
               {(p) => (
                 <button
-                  class={`px-2 py-0.5 text-xs rounded ${activePreset() === p.key ? "bg-theme-accent text-white" : "bg-theme-surface-alt text-theme-text-secondary hover:text-white"}`}
+                  class={`px-2 py-0.5 text-xs rounded transition-colors duration-200 ${activePreset() === p.key ? "bg-theme-accent text-white" : "bg-theme-surface-alt text-theme-text-secondary hover:text-white"}`}
                   onClick={() => applyPreset(p.key)}
                 >{p.label}</button>
               )}
@@ -329,7 +385,7 @@ const ImagingTimeline: Component<Props> = (props) => {
         onMouseUp={handleMouseUp}
         onMouseLeave={handleMouseUp}
       >
-        <div style={{ width: `${innerWidth()}px`, "min-width": "100%" }}>
+        <div style={{ width: `${innerWidth()}px`, "min-width": "100%", transition: "width 300ms ease" }}>
           {/* Bars with labels above */}
           <div class="flex items-end" style={{ height: `${BAR_AREA_HEIGHT}px`, gap: `${BAR_GAP}px` }}>
             <For each={activeData()}>
@@ -355,8 +411,8 @@ const ImagingTimeline: Component<Props> = (props) => {
                     </Show>
                     {/* Bar */}
                     <div
-                      class={`w-full rounded-t transition-colors ${isEmpty() ? "" : "bg-theme-accent hover:opacity-80 cursor-pointer"}`}
-                      style={{ height: isEmpty() ? "0px" : `${Math.max(pct(), 1)}%`, "min-height": isEmpty() ? "0" : "2px" }}
+                      class={`w-full rounded-t ${isEmpty() ? "" : "bg-theme-accent hover:opacity-80 cursor-pointer"}`}
+                      style={{ height: isEmpty() ? "0px" : `${Math.max(pct(), 1)}%`, "min-height": isEmpty() ? "0" : "2px", transition: "height 300ms ease" }}
                       title={!isEmpty() ? `${formatLabel(entry.period, granularity())}: ${formatHours(entry.integration_seconds)}` : undefined}
                       onClick={() => !isEmpty() && handleBarClick(entry)}
                     />

--- a/frontend/src/components/ImagingTimeline.tsx
+++ b/frontend/src/components/ImagingTimeline.tsx
@@ -30,6 +30,7 @@ function presetToZoom(preset: Preset): number {
     case "q": return 5;
     case "m": return 11;
     case "w": return 16;
+    default: return 1;
   }
 }
 
@@ -74,7 +75,12 @@ function periodToDateRange(period: string, gran: Granularity): { from: string; t
     monday.setDate(startOfWeek1.getDate() + (week - 1) * 7);
     const sunday = new Date(monday);
     sunday.setDate(monday.getDate() + 6);
-    const fmt = (d: Date) => d.toISOString().slice(0, 10);
+    const fmt = (d: Date) => {
+      const y = d.getFullYear();
+      const mo = String(d.getMonth() + 1).padStart(2, "0");
+      const day = String(d.getDate()).padStart(2, "0");
+      return `${y}-${mo}-${day}`;
+    };
     return { from: fmt(monday), to: fmt(sunday) };
   }
   return { from: period, to: period };
@@ -336,7 +342,7 @@ const ImagingTimeline: Component<Props> = (props) => {
                     style={{ width: `${barWidth()}px`, "flex-shrink": "0" }}
                   >
                     {/* Efficiency label */}
-                    <Show when={showEfficiency() && entry.efficiency_pct != null}>
+                    <Show when={showEfficiency() && entry.efficiency_pct != null && i() % labelInterval() === 0}>
                       <span class="text-green-400 leading-none mb-0.5" style={{ "font-size": "0.6rem" }}>
                         {entry.efficiency_pct}%
                       </span>
@@ -349,8 +355,9 @@ const ImagingTimeline: Component<Props> = (props) => {
                     </Show>
                     {/* Bar */}
                     <div
-                      class={`w-full rounded-t transition-colors ${isEmpty() ? "" : "bg-theme-accent hover:brightness-125 cursor-pointer"}`}
+                      class={`w-full rounded-t transition-colors ${isEmpty() ? "" : "bg-theme-accent hover:opacity-80 cursor-pointer"}`}
                       style={{ height: isEmpty() ? "0px" : `${Math.max(pct(), 1)}%`, "min-height": isEmpty() ? "0" : "2px" }}
+                      title={!isEmpty() ? `${formatLabel(entry.period, granularity())}: ${formatHours(entry.integration_seconds)}` : undefined}
                       onClick={() => !isEmpty() && handleBarClick(entry)}
                     />
                   </div>

--- a/frontend/src/components/ImagingTimeline.tsx
+++ b/frontend/src/components/ImagingTimeline.tsx
@@ -1,70 +1,207 @@
-import { Component, For, createMemo, createSignal, onMount, onCleanup } from "solid-js";
-import type { TimelineEntry } from "../types";
+import { Component, For, Show, createMemo, createSignal, onMount, onCleanup } from "solid-js";
+import { useNavigate } from "@solidjs/router";
+import type { TimelineDetailEntry } from "../types";
 
+// Zoom range: 1-20. Thresholds for granularity transitions.
+const ZOOM_MONTHLY_MAX = 4;
+const ZOOM_WEEKLY_MAX = 10;
 const MIN_ZOOM = 1;
-const MAX_ZOOM = 8;
-const BAR_BASE_WIDTH = 28; // px per bar at zoom 1
+const MAX_ZOOM = 20;
+
+const BAR_BASE_WIDTH = 28;
 const BAR_GAP = 2;
+const BAR_AREA_HEIGHT = 220;
 
-const ImagingTimeline: Component<{ timeline: TimelineEntry[] }> = (props) => {
-  const maxVal = () => Math.max(...props.timeline.map((t) => t.integration_seconds), 1);
+type Preset = "all" | "1y" | "q" | "m" | "w";
+type DailyMode = "imaged" | "all";
+type Granularity = "monthly" | "weekly" | "daily";
 
+interface Props {
+  monthly: TimelineDetailEntry[];
+  weekly: TimelineDetailEntry[];
+  daily: TimelineDetailEntry[];
+}
+
+/** Map a preset to a zoom level */
+function presetToZoom(preset: Preset): number {
+  switch (preset) {
+    case "all": return 1;
+    case "1y": return 2;
+    case "q": return 5;
+    case "m": return 11;
+    case "w": return 16;
+  }
+}
+
+function granularityForZoom(z: number): Granularity {
+  if (z <= ZOOM_MONTHLY_MAX) return "monthly";
+  if (z <= ZOOM_WEEKLY_MAX) return "weekly";
+  return "daily";
+}
+
+/** Format a period string for x-axis labels */
+function formatLabel(period: string, gran: Granularity): string {
+  const months = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
+  if (gran === "monthly") {
+    const [y, m] = period.split("-");
+    return `${months[parseInt(m, 10) - 1]} ${y}`;
+  }
+  if (gran === "weekly") {
+    // "2025-W03" → "W3 '25"
+    const parts = period.split("-W");
+    return `W${parseInt(parts[1])} '${parts[0].slice(2)}`;
+  }
+  // daily: "2025-12-03" → "Dec 3"
+  const [, m, d] = period.split("-");
+  return `${months[parseInt(m, 10) - 1]} ${parseInt(d, 10)}`;
+}
+
+/** Compute date_from and date_to for click navigation */
+function periodToDateRange(period: string, gran: Granularity): { from: string; to: string } {
+  if (gran === "monthly") {
+    const [y, m] = period.split("-").map(Number);
+    const lastDay = new Date(y, m, 0).getDate();
+    return { from: period + "-01", to: `${period}-${String(lastDay).padStart(2, "0")}` };
+  }
+  if (gran === "weekly") {
+    const parts = period.split("-W");
+    const year = parseInt(parts[0]);
+    const week = parseInt(parts[1]);
+    const jan4 = new Date(year, 0, 4);
+    const startOfWeek1 = new Date(jan4);
+    startOfWeek1.setDate(jan4.getDate() - jan4.getDay() + 1);
+    const monday = new Date(startOfWeek1);
+    monday.setDate(startOfWeek1.getDate() + (week - 1) * 7);
+    const sunday = new Date(monday);
+    sunday.setDate(monday.getDate() + 6);
+    const fmt = (d: Date) => d.toISOString().slice(0, 10);
+    return { from: fmt(monday), to: fmt(sunday) };
+  }
+  return { from: period, to: period };
+}
+
+/** Generate all dates between first and last entry */
+function allDatesBetween(data: TimelineDetailEntry[]): string[] {
+  if (data.length === 0) return [];
+  const start = new Date(data[0].period);
+  const end = new Date(data[data.length - 1].period);
+  const dates: string[] = [];
+  const cur = new Date(start);
+  while (cur <= end) {
+    dates.push(cur.toISOString().slice(0, 10));
+    cur.setDate(cur.getDate() + 1);
+  }
+  return dates;
+}
+
+const ImagingTimeline: Component<Props> = (props) => {
+  const navigate = useNavigate();
   const [zoom, setZoom] = createSignal(1);
+  const [activePreset, setActivePreset] = createSignal<Preset | null>("all");
+  const [dailyMode, setDailyMode] = createSignal<DailyMode>("imaged");
+
+  // Drag-to-pan state
+  const [isDragging, setIsDragging] = createSignal(false);
+  let dragStartX = 0;
+  let dragScrollStart = 0;
+  let didDrag = false;
+
   let containerRef!: HTMLDivElement;
 
+  const granularity = createMemo(() => granularityForZoom(zoom()));
+
+  /** Active dataset based on zoom level */
+  const activeData = createMemo((): TimelineDetailEntry[] => {
+    const gran = granularity();
+    if (gran === "monthly") return props.monthly;
+    if (gran === "weekly") return props.weekly;
+
+    if (dailyMode() === "all") {
+      const allDates = allDatesBetween(props.daily);
+      const dataMap = new Map(props.daily.map(e => [e.period, e]));
+      return allDates.map(d => dataMap.get(d) ?? { period: d, integration_seconds: 0, efficiency_pct: null });
+    }
+    return props.daily;
+  });
+
+  const maxVal = createMemo(() => Math.max(...activeData().map(e => e.integration_seconds), 1));
+
+  const barWidth = createMemo(() => BAR_BASE_WIDTH * (zoom() / MIN_ZOOM));
+
+  const innerWidth = createMemo(() => activeData().length * (barWidth() + BAR_GAP));
+
   const labelInterval = createMemo(() => {
-    const z = zoom();
-    if (z >= 4) return 1;
-    if (z >= 2) return 2;
-    const len = props.timeline.length;
-    if (len <= 12) return 1;
-    if (len <= 18) return 2;
-    if (len <= 30) return 3;
+    const w = barWidth();
+    if (w >= 50) return 1;
+    if (w >= 35) return 2;
+    if (w >= 25) return 3;
     return 4;
   });
 
-  const innerWidth = createMemo(() => {
-    const count = props.timeline.length;
-    return count * (BAR_BASE_WIDTH * zoom() + BAR_GAP);
-  });
+  const showEfficiency = createMemo(() => barWidth() >= 36);
 
-  const formatLabel = (month: string) => {
-    const [y, m] = month.split("-");
-    const names = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
-    return `${names[parseInt(m, 10) - 1]} ${y}`;
+  const formatHours = (secs: number): string => {
+    const h = secs / 3600;
+    return h < 10 ? `${h.toFixed(1)}h` : `${Math.round(h)}h`;
   };
 
-  // Scroll to right end (newest) on mount
-  onMount(() => {
-    if (containerRef) {
-      containerRef.scrollLeft = containerRef.scrollWidth;
-    }
-  });
+  // --- Preset navigation ---
+  const applyPreset = (preset: Preset) => {
+    setActivePreset(preset);
+    const z = presetToZoom(preset);
+    setZoom(z);
+    requestAnimationFrame(() => {
+      if (containerRef) {
+        containerRef.scrollLeft = containerRef.scrollWidth;
+      }
+    });
+  };
 
-  // Zoom via Ctrl+wheel, pan via plain wheel
+  // --- Scroll-to-zoom ---
   const handleWheel = (e: WheelEvent) => {
-    if (e.ctrlKey || e.metaKey) {
-      e.preventDefault();
-      const rect = containerRef.getBoundingClientRect();
-      const mouseX = e.clientX - rect.left;
-      const scrollBefore = containerRef.scrollLeft;
-      const posInContent = scrollBefore + mouseX;
-      const oldZoom = zoom();
+    e.preventDefault();
+    const rect = containerRef.getBoundingClientRect();
+    const mouseX = e.clientX - rect.left;
+    const scrollBefore = containerRef.scrollLeft;
+    const posInContent = scrollBefore + mouseX;
+    const oldZoom = zoom();
 
-      const delta = e.deltaY > 0 ? -0.15 : 0.15;
-      const newZoom = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, oldZoom + delta * oldZoom));
-      setZoom(newZoom);
+    const delta = e.deltaY > 0 ? -0.3 : 0.3;
+    const newZoom = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, oldZoom + delta * oldZoom));
+    setZoom(newZoom);
+    setActivePreset(null);
 
-      // Keep the point under the cursor stable
-      requestAnimationFrame(() => {
-        const scale = newZoom / oldZoom;
-        containerRef.scrollLeft = posInContent * scale - mouseX;
-      });
-    }
+    requestAnimationFrame(() => {
+      const scale = newZoom / oldZoom;
+      containerRef.scrollLeft = posInContent * scale - mouseX;
+    });
   };
 
-  // Touch pinch-to-zoom
+  // --- Drag to pan ---
+  const handleMouseDown = (e: MouseEvent) => {
+    if (e.button !== 0) return;
+    setIsDragging(true);
+    didDrag = false;
+    dragStartX = e.clientX;
+    dragScrollStart = containerRef.scrollLeft;
+    e.preventDefault();
+  };
+
+  const handleMouseMove = (e: MouseEvent) => {
+    if (!isDragging()) return;
+    const dx = e.clientX - dragStartX;
+    if (Math.abs(dx) > 3) didDrag = true;
+    containerRef.scrollLeft = dragScrollStart - dx;
+  };
+
+  const handleMouseUp = () => {
+    setIsDragging(false);
+  };
+
+  // --- Touch: pinch-to-zoom + single-finger pan ---
   let lastTouchDist = 0;
+  let lastTouchX = 0;
+
   const getTouchDist = (touches: TouchList): number => {
     if (touches.length < 2) return 0;
     const dx = touches[1].clientX - touches[0].clientX;
@@ -72,15 +209,12 @@ const ImagingTimeline: Component<{ timeline: TimelineEntry[] }> = (props) => {
     return Math.sqrt(dx * dx + dy * dy);
   };
 
-  const getTouchCenter = (touches: TouchList): number => {
-    if (touches.length < 2) return touches[0].clientX;
-    return (touches[0].clientX + touches[1].clientX) / 2;
-  };
-
   const handleTouchStart = (e: TouchEvent) => {
     if (e.touches.length === 2) {
       e.preventDefault();
       lastTouchDist = getTouchDist(e.touches);
+    } else if (e.touches.length === 1) {
+      lastTouchX = e.touches[0].clientX;
     }
   };
 
@@ -88,25 +222,18 @@ const ImagingTimeline: Component<{ timeline: TimelineEntry[] }> = (props) => {
     if (e.touches.length === 2) {
       e.preventDefault();
       const dist = getTouchDist(e.touches);
-      const center = getTouchCenter(e.touches);
-
       if (lastTouchDist > 0) {
         const scale = dist / lastTouchDist;
-        const rect = containerRef.getBoundingClientRect();
-        const centerX = center - rect.left;
-        const scrollBefore = containerRef.scrollLeft;
-        const posInContent = scrollBefore + centerX;
         const oldZoom = zoom();
         const newZoom = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, oldZoom * scale));
         setZoom(newZoom);
-
-        requestAnimationFrame(() => {
-          const zoomScale = newZoom / oldZoom;
-          containerRef.scrollLeft = posInContent * zoomScale - centerX;
-        });
+        setActivePreset(null);
       }
-
       lastTouchDist = dist;
+    } else if (e.touches.length === 1) {
+      const dx = e.touches[0].clientX - lastTouchX;
+      containerRef.scrollLeft -= dx;
+      lastTouchX = e.touches[0].clientX;
     }
   };
 
@@ -114,12 +241,24 @@ const ImagingTimeline: Component<{ timeline: TimelineEntry[] }> = (props) => {
     lastTouchDist = 0;
   };
 
+  // --- Bar click ---
+  const handleBarClick = (entry: TimelineDetailEntry) => {
+    if (didDrag) return;
+    const range = periodToDateRange(entry.period, granularity());
+    navigate(`/?date_from=${range.from}&date_to=${range.to}`);
+  };
+
+  // --- Mount/cleanup ---
   onMount(() => {
     containerRef.addEventListener("wheel", handleWheel, { passive: false });
     containerRef.addEventListener("touchstart", handleTouchStart, { passive: false });
     containerRef.addEventListener("touchmove", handleTouchMove, { passive: false });
     containerRef.addEventListener("touchend", handleTouchEnd);
+    requestAnimationFrame(() => {
+      if (containerRef) containerRef.scrollLeft = containerRef.scrollWidth;
+    });
   });
+
   onCleanup(() => {
     containerRef?.removeEventListener("wheel", handleWheel);
     containerRef?.removeEventListener("touchstart", handleTouchStart);
@@ -127,51 +266,109 @@ const ImagingTimeline: Component<{ timeline: TimelineEntry[] }> = (props) => {
     containerRef?.removeEventListener("touchend", handleTouchEnd);
   });
 
+  const presets: { key: Preset; label: string }[] = [
+    { key: "all", label: "All" },
+    { key: "1y", label: "1Y" },
+    { key: "q", label: "Q" },
+    { key: "m", label: "M" },
+    { key: "w", label: "W" },
+  ];
+
   return (
     <div class="bg-theme-surface border border-theme-border rounded-[var(--radius-md)] shadow-[var(--shadow-sm)] p-4 space-y-2">
-      <div class="flex items-center justify-between">
+      {/* Header */}
+      <div class="flex items-center justify-between flex-wrap gap-2">
         <h3 class="text-white font-medium text-sm">Imaging Timeline</h3>
-        <span class="text-caption text-theme-text-secondary select-none">
-          <span class="hidden sm:inline">Ctrl+Scroll to zoom</span>
-          <span class="sm:hidden">Pinch to zoom</span>
-        </span>
+        <div class="flex items-center gap-3">
+          {/* Daily mode toggle */}
+          <Show when={granularity() === "daily"}>
+            <div class="flex gap-0.5">
+              <button
+                class={`px-2 py-0.5 text-xs rounded ${dailyMode() === "imaged" ? "bg-theme-accent text-white" : "bg-theme-surface-alt text-theme-text-secondary"}`}
+                onClick={() => setDailyMode("imaged")}
+              >Imaged only</button>
+              <button
+                class={`px-2 py-0.5 text-xs rounded ${dailyMode() === "all" ? "bg-theme-accent text-white" : "bg-theme-surface-alt text-theme-text-secondary"}`}
+                onClick={() => setDailyMode("all")}
+              >All nights</button>
+            </div>
+          </Show>
+          {/* Presets */}
+          <div class="flex gap-0.5">
+            <For each={presets}>
+              {(p) => (
+                <button
+                  class={`px-2 py-0.5 text-xs rounded ${activePreset() === p.key ? "bg-theme-accent text-white" : "bg-theme-surface-alt text-theme-text-secondary hover:text-white"}`}
+                  onClick={() => applyPreset(p.key)}
+                >{p.label}</button>
+              )}
+            </For>
+          </div>
+          <span class="text-micro text-theme-text-secondary select-none hidden sm:inline">
+            Scroll to zoom · Drag to pan
+          </span>
+        </div>
       </div>
+
+      {/* Chart area */}
       <div
         ref={containerRef}
-        class="overflow-x-auto scrollbar-thin"
-        style={{ "scroll-behavior": "auto" }}
+        class="overflow-x-auto scrollbar-thin select-none"
+        style={{
+          "scroll-behavior": "auto",
+          cursor: isDragging() ? "grabbing" : "grab",
+        }}
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseUp}
       >
         <div style={{ width: `${innerWidth()}px`, "min-width": "100%" }}>
-          {/* Bars */}
-          <div class="flex items-end h-36" style={{ gap: `${BAR_GAP}px` }}>
-            <For each={props.timeline}>
-              {(entry) => {
+          {/* Bars with labels above */}
+          <div class="flex items-end" style={{ height: `${BAR_AREA_HEIGHT}px`, gap: `${BAR_GAP}px` }}>
+            <For each={activeData()}>
+              {(entry, i) => {
                 const pct = () => (entry.integration_seconds / maxVal()) * 100;
+                const isEmpty = () => entry.integration_seconds === 0;
                 return (
                   <div
-                    class="h-full flex items-end"
-                    style={{ width: `${BAR_BASE_WIDTH * zoom()}px`, "flex-shrink": "0" }}
-                    title={`${formatLabel(entry.month)}: ${(entry.integration_seconds / 3600).toFixed(1)}h`}
+                    class="h-full flex flex-col items-center justify-end"
+                    style={{ width: `${barWidth()}px`, "flex-shrink": "0" }}
                   >
+                    {/* Efficiency label */}
+                    <Show when={showEfficiency() && entry.efficiency_pct != null}>
+                      <span class="text-green-400 leading-none mb-0.5" style={{ "font-size": "0.6rem" }}>
+                        {entry.efficiency_pct}%
+                      </span>
+                    </Show>
+                    {/* Hour label */}
+                    <Show when={!isEmpty() && i() % labelInterval() === 0}>
+                      <span class="text-theme-accent leading-none mb-0.5" style={{ "font-size": "0.65rem" }}>
+                        {formatHours(entry.integration_seconds)}
+                      </span>
+                    </Show>
+                    {/* Bar */}
                     <div
-                      class="w-full bg-theme-accent rounded-t min-h-[2px]"
-                      style={{ height: `${pct()}%` }}
+                      class={`w-full rounded-t transition-colors ${isEmpty() ? "" : "bg-theme-accent hover:brightness-125 cursor-pointer"}`}
+                      style={{ height: isEmpty() ? "0px" : `${Math.max(pct(), 1)}%`, "min-height": isEmpty() ? "0" : "2px" }}
+                      onClick={() => !isEmpty() && handleBarClick(entry)}
                     />
                   </div>
                 );
               }}
             </For>
           </div>
-          {/* Labels */}
+
+          {/* X-axis labels */}
           <div class="flex mt-1" style={{ gap: `${BAR_GAP}px` }}>
-            <For each={props.timeline}>
+            <For each={activeData()}>
               {(entry, i) => (
                 <div
                   class="text-center"
-                  style={{ width: `${BAR_BASE_WIDTH * zoom()}px`, "flex-shrink": "0" }}
+                  style={{ width: `${barWidth()}px`, "flex-shrink": "0" }}
                 >
                   <span class="text-micro text-theme-text-secondary whitespace-nowrap">
-                    {i() % labelInterval() === 0 ? formatLabel(entry.month) : ""}
+                    {i() % labelInterval() === 0 ? formatLabel(entry.period, granularity()) : ""}
                   </span>
                 </div>
               )}

--- a/frontend/src/pages/StatisticsPage.tsx
+++ b/frontend/src/pages/StatisticsPage.tsx
@@ -41,7 +41,11 @@ const StatisticsPage: Component = () => {
               <TopTargets targets={data().top_targets} />
             </div>
 
-            <ImagingTimeline timeline={data().timeline} />
+            <ImagingTimeline
+              monthly={data().timeline_monthly}
+              weekly={data().timeline_weekly}
+              daily={data().timeline_daily}
+            />
 
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4 [&>*]:border [&>*]:border-theme-border [&>*]:rounded-[var(--radius-md)] [&>*]:shadow-[var(--shadow-sm)]">
               <StorageBreakdown

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -328,6 +328,17 @@ export interface TimelineEntry {
   integration_seconds: number;
 }
 
+export interface TimelineDetailEntry {
+  period: string;
+  integration_seconds: number;
+  efficiency_pct: number | null;
+}
+
+export interface SiteCoords {
+  latitude: number;
+  longitude: number;
+}
+
 export interface TopTarget {
   name: string;
   integration_seconds: number;
@@ -378,6 +389,10 @@ export interface StatsResponse {
   equipment_performance: EquipmentComboMetrics[];
   filter_usage: Record<string, number>;
   timeline: TimelineEntry[];
+  timeline_monthly: TimelineDetailEntry[];
+  timeline_weekly: TimelineDetailEntry[];
+  timeline_daily: TimelineDetailEntry[];
+  site_coords: SiteCoords | null;
   top_targets: TopTarget[];
   data_quality: {
     avg_hfr: number | null;


### PR DESCRIPTION
**Summary**
This pull request introduces a multi-granularity statistics timeline, including backend data generation, astronomical night calculations, and an interactive frontend component with zoom and granularity switching.

**Changes**
*   Rewrote the `ImagingTimeline` component to support zoom levels, granularity switching, and bar click navigation.
*   Added multi-granularity timeline data generation to the `/stats` API endpoint.
*   Implemented an astronomical night calculation service.
*   Extended the `StatsResponse` schema with `TimelineDetailEntry` and `SiteCoords` types.
*   Extended the gap-fill toggle to all granularities and added smooth transitions to the timeline UI.
*   Fixed a timezone bug, improved switch exhaustiveness, corrected tooltip display, and adjusted label density based on code review.
*   Added test coverage for astronomical night calculations and `stats` timeline data.
*   Added `astropy` as a new backend dependency for astronomical calculations.

**Impact**
*   The `/stats` API endpoint now returns multi-granularity timeline data.
*   New data structures for timeline details and site coordinates are available in the `StatsResponse` schema.
*   A new backend service provides astronomical night calculations.
*   The `ImagingTimeline` visualization component is re-architected to support new interactive features.
*   The statistics page integrates the updated timeline component.
*   New frontend types align with backend schema changes.
*   New unit tests cover astronomical night calculations and timeline data generation.

---
*This PR description was automatically generated.*
