### PR TITLE
Per-Rig Session Data and UI Refinements

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -307,36 +307,57 @@ jobs:
             gh release delete "$TAG" --yes --cleanup-tag
           done
 
-      - name: Clean up old Docker Hub dev images
-        if: github.ref == 'refs/heads/dev'
+      - name: Clean up old Docker Hub images
+        if: github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main'
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: |
-          KEEP=2
-          REPO="chvvkumar/galactilog"
+          python3 << 'PYEOF'
+          import json, re, time
+          from urllib.request import Request, urlopen
+          from urllib.parse import quote
 
-          # Get Docker Hub token
-          TOKEN=$(curl -s -X POST "https://hub.docker.com/v2/users/login/" \
-            -H "Content-Type: application/json" \
-            -d "{\"username\":\"${DOCKER_USERNAME}\",\"password\":\"${DOCKER_PASSWORD}\"}" \
-            | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])")
+          REPO = "chvvkumar/galactilog"
+          KEEP_RC = 2
+          KEEP_STABLE = 5
+          BRANCH = "${{ github.ref_name }}"
 
-          # List all rc tags from Docker Hub, keep newest KEEP, delete the rest
-          OLD_TAGS=$(curl -s "https://hub.docker.com/v2/repositories/${REPO}/tags/?page_size=100" \
-            -H "Authorization: Bearer ${TOKEN}" \
-            | python3 -c "
-          import sys, json, re
-          data = json.load(sys.stdin)
-          tags = [t['name'] for t in data['results']]
-          rc_tags = [t for t in tags if re.match(r'^\d+\.\d+\.\d+-rc\.\d+$', t)]
-          rc_tags.sort(key=lambda t: list(map(int, re.findall(r'\d+', t))), reverse=True)
-          for t in rc_tags[${KEEP}:]:
-              print(t)
-          ")
+          # Authenticate
+          login_req = Request("https://hub.docker.com/v2/users/login/",
+              data=json.dumps({"username": "${{ secrets.DOCKER_USERNAME }}", "password": "${{ secrets.DOCKER_PASSWORD }}"}).encode(),
+              headers={"Content-Type": "application/json"})
+          token = json.loads(urlopen(login_req).read())["token"]
+          headers = {"Authorization": f"Bearer {token}"}
 
-          for TAG in $OLD_TAGS; do
-            echo "Deleting Docker Hub tag: $TAG"
-            curl -s -X DELETE "https://hub.docker.com/v2/repositories/${REPO}/tags/${TAG}/" \
-              -H "Authorization: Bearer ${TOKEN}"
-          done
+          # Fetch all tags
+          req = Request(f"https://hub.docker.com/v2/repositories/{REPO}/tags/?page_size=100", headers=headers)
+          tags = [t["name"] for t in json.loads(urlopen(req).read())["results"]]
+
+          to_delete = []
+
+          if BRANCH == "dev":
+              # Clean up old RC tags, keep newest KEEP_RC
+              rc_tags = [t for t in tags if re.match(r"^\d+\.\d+\.\d+-rc\.\d+$", t)]
+              rc_tags.sort(key=lambda t: list(map(int, re.findall(r"\d+", t))), reverse=True)
+              to_delete = rc_tags[KEEP_RC:]
+
+          elif BRANCH == "main":
+              # Clean up old stable tags, keep newest KEEP_STABLE
+              stable_tags = [t for t in tags if re.match(r"^\d+\.\d+\.\d+$", t)]
+              stable_tags.sort(key=lambda t: list(map(int, t.split("."))), reverse=True)
+              to_delete = stable_tags[KEEP_STABLE:]
+
+          if not to_delete:
+              print("Nothing to clean up")
+          else:
+              for tag in to_delete:
+                  req = Request(f"https://hub.docker.com/v2/repositories/{REPO}/tags/{quote(tag)}/",
+                      headers=headers, method="DELETE")
+                  try:
+                      urlopen(req)
+                      print(f"Deleted: {tag}")
+                  except Exception as e:
+                      print(f"Failed to delete {tag}: {e}")
+                  time.sleep(0.5)
+          PYEOF

--- a/backend/app/api/targets.py
+++ b/backend/app/api/targets.py
@@ -20,11 +20,126 @@ from app.schemas.target import (
     TargetAggregationResponse, TargetAggregation, SessionSummary,
     AggregateStats, EquipmentResponse, SessionDetailResponse,
     TargetDetailResponse, SessionOverview, FilterDetail, FilterMedian, SessionInsight, FrameRecord,
-    TargetSearchResultFuzzy, ObjectTypeCount, NotesUpdate,
+    TargetSearchResultFuzzy, ObjectTypeCount, NotesUpdate, RigDetail,
 )
 from app.schemas.export import ExportResponse, ExportFilterRow, ExportEquipment, ExportCalibration
 
 router = APIRouter(prefix="/targets", tags=["targets"])
+
+
+def _build_rig_details(
+    images: list,
+    filter_map: dict,
+    cam_map: dict,
+    tel_map: dict,
+) -> list:
+    """Group images by normalized (telescope, camera) and return per-rig stats."""
+    rig_buckets: dict[tuple[str | None, str | None], list] = defaultdict(list)
+    for img in images:
+        tel = normalize_equipment(img.telescope, tel_map)
+        cam = normalize_equipment(img.camera, cam_map)
+        rig_buckets[(tel, cam)].append(img)
+
+    rig_details = []
+    for (tel, cam), rig_images in sorted(rig_buckets.items(), key=lambda x: (x[0][0] or "", x[0][1] or "")):
+        rig_label = f"{tel or 'Unknown'} / {cam or 'Unknown'}"
+        rig_exp = sum(i.exposure_time or 0 for i in rig_images)
+        rig_hfr = [i.median_hfr for i in rig_images if i.median_hfr is not None]
+        rig_ecc = [i.eccentricity for i in rig_images if i.eccentricity is not None]
+        rig_fwhm = [i.fwhm for i in rig_images if i.fwhm is not None]
+        rig_guiding = [i.guiding_rms_arcsec for i in rig_images if i.guiding_rms_arcsec is not None]
+        rig_stars = [i.detected_stars for i in rig_images if i.detected_stars is not None]
+
+        # Per-filter breakdown within this rig
+        rig_filter_groups: dict[str, list] = defaultdict(list)
+        for img in rig_images:
+            f = normalize_filter(img.filter_used, filter_map)
+            if f:
+                rig_filter_groups[f].append(img)
+
+        rig_filter_details = []
+        for fname, fimages in sorted(rig_filter_groups.items()):
+            f_hfr = [i.median_hfr for i in fimages if i.median_hfr is not None]
+            f_ecc = [i.eccentricity for i in fimages if i.eccentricity is not None]
+            f_exp = sum(i.exposure_time or 0 for i in fimages)
+            rig_filter_details.append(FilterDetail(
+                filter_name=fname,
+                frame_count=len(fimages),
+                integration_seconds=f_exp,
+                median_hfr=statistics.median(f_hfr) if f_hfr else None,
+                median_eccentricity=statistics.median(f_ecc) if f_ecc else None,
+                exposure_time=fimages[0].exposure_time,
+            ))
+
+        # Build frame records for this rig
+        rig_frames = []
+        for img in sorted(rig_images, key=lambda i: i.capture_date or datetime.min):
+            rig_frames.append(FrameRecord(
+                timestamp=img.capture_date.isoformat() if img.capture_date else "",
+                filter_used=normalize_filter(img.filter_used, filter_map),
+                exposure_time=img.exposure_time,
+                median_hfr=img.median_hfr,
+                eccentricity=img.eccentricity,
+                sensor_temp=img.sensor_temp,
+                gain=img.camera_gain,
+                file_name=img.file_name,
+                hfr_stdev=img.hfr_stdev,
+                fwhm=img.fwhm,
+                detected_stars=img.detected_stars,
+                guiding_rms_arcsec=img.guiding_rms_arcsec,
+                guiding_rms_ra_arcsec=img.guiding_rms_ra_arcsec,
+                guiding_rms_dec_arcsec=img.guiding_rms_dec_arcsec,
+                adu_stdev=img.adu_stdev,
+                adu_mean=img.adu_mean,
+                adu_median=img.adu_median,
+                adu_min=img.adu_min,
+                adu_max=img.adu_max,
+                focuser_position=img.focuser_position,
+                focuser_temp=img.focuser_temp,
+                rotator_position=img.rotator_position,
+                pier_side=img.pier_side,
+                airmass=img.airmass,
+                ambient_temp=img.ambient_temp,
+                dew_point=img.dew_point,
+                humidity=img.humidity,
+                pressure=img.pressure,
+                wind_speed=img.wind_speed,
+                wind_direction=img.wind_direction,
+                wind_gust=img.wind_gust,
+                cloud_cover=img.cloud_cover,
+                sky_quality=img.sky_quality,
+                rig=rig_label,
+            ))
+
+        # Gain/offset from first image in rig
+        ref = rig_images[0]
+        offset_val = next(
+            (int(img.raw_headers.get("OFFSET", 0))
+             for img in rig_images
+             if img.raw_headers and img.raw_headers.get("OFFSET") is not None),
+            None,
+        )
+
+        rig_details.append(RigDetail(
+            rig_label=rig_label,
+            telescope=tel,
+            camera=cam,
+            frame_count=len(rig_images),
+            integration_seconds=rig_exp,
+            median_hfr=statistics.median(rig_hfr) if rig_hfr else None,
+            median_eccentricity=statistics.median(rig_ecc) if rig_ecc else None,
+            median_fwhm=statistics.median(rig_fwhm) if rig_fwhm else None,
+            median_guiding_rms=statistics.median(rig_guiding) if rig_guiding else None,
+            median_detected_stars=statistics.median(rig_stars) if rig_stars else None,
+            gain=ref.camera_gain,
+            offset=offset_val,
+            exposure_times=sorted(set(i.exposure_time for i in rig_images if i.exposure_time is not None)),
+            filter_details=rig_filter_details,
+            frames=rig_frames,
+        ))
+
+    return rig_details
+
 
 # ---------------------------------------------------------------------------
 # SIMBAD object type → human-readable category mapping

--- a/backend/app/api/targets.py
+++ b/backend/app/api/targets.py
@@ -624,6 +624,13 @@ async def get_target_detail(
     session_overviews = []
     for date_key in sorted(sessions_map.keys(), reverse=True):
         sess_images = sessions_map[date_key]
+        # Count distinct rigs for this session
+        rig_set = set()
+        for img in sess_images:
+            tel = normalize_equipment(img.telescope, tel_map)
+            cam = normalize_equipment(img.camera, cam_map)
+            rig_set.add((tel, cam))
+        sess_rig_count = len(rig_set)
         sess_hfr = [i.median_hfr for i in sess_images if i.median_hfr is not None]
         sess_ecc = [i.eccentricity for i in sess_images if i.eccentricity is not None]
         sess_fwhm = [i.fwhm for i in sess_images if i.fwhm is not None]
@@ -669,6 +676,7 @@ async def get_target_detail(
             median_guiding_rms_arcsec=statistics.median(sess_guiding_rms) if sess_guiding_rms else None,
             filter_medians=sess_filter_medians,
             has_notes=date_type.fromisoformat(date_key) in note_dates if date_key != "unknown" else False,
+            rig_count=sess_rig_count,
         ))
 
     sorted_dates = sorted(sessions_map.keys())

--- a/backend/app/api/targets.py
+++ b/backend/app/api/targets.py
@@ -1413,6 +1413,42 @@ async def get_session_detail(
         last_frame=images[-1],
     )
 
+    # Per-rig insights for multi-rig sessions
+    if len(rig_details) > 1:
+        for rd in rig_details:
+            rig_hfr = [f.median_hfr for f in rd.frames if f.median_hfr is not None]
+            rig_ecc = [f.eccentricity for f in rd.frames if f.eccentricity is not None]
+            rig_median_hfr = statistics.median(rig_hfr) if rig_hfr else None
+            rig_median_ecc = statistics.median(rig_ecc) if rig_ecc else None
+            prefix = f"[{rd.rig_label}] "
+            if rig_median_hfr is not None and target_avg_hfr is not None:
+                if rig_median_hfr <= target_avg_hfr:
+                    insights.append(SessionInsight(
+                        level="good",
+                        message=f"{prefix}Good HFR (median {rig_median_hfr:.2f} vs target avg {target_avg_hfr:.2f})",
+                    ))
+                elif rig_median_hfr > target_avg_hfr * 1.3:
+                    insights.append(SessionInsight(
+                        level="warning",
+                        message=f"{prefix}Poor HFR (median {rig_median_hfr:.2f} vs target avg {target_avg_hfr:.2f})",
+                    ))
+            if rig_median_hfr is not None and len(rig_hfr) > 2:
+                threshold = rig_median_hfr * 1.5
+                outlier_count = sum(1 for v in rig_hfr if v > threshold)
+                if outlier_count > 0:
+                    insights.append(SessionInsight(
+                        level="warning",
+                        message=f"{prefix}{outlier_count} frame{'s' if outlier_count > 1 else ''} with HFR outlier{'s' if outlier_count > 1 else ''} (> {threshold:.1f})",
+                    ))
+            if rig_median_ecc is not None and len(rig_ecc) > 2:
+                threshold = rig_median_ecc * 1.5
+                outlier_count = sum(1 for v in rig_ecc if v > threshold)
+                if outlier_count > 0:
+                    insights.append(SessionInsight(
+                        level="warning",
+                        message=f"{prefix}{outlier_count} frame{'s' if outlier_count > 1 else ''} with eccentricity outlier{'s' if outlier_count > 1 else ''} (> {threshold:.2f})",
+                    ))
+
     # Fetch session note
     session_note = None
     resolved_target_id = target_obj.id if target_obj else None

--- a/backend/app/api/targets.py
+++ b/backend/app/api/targets.py
@@ -705,6 +705,19 @@ async def get_target_detail(
     )
 
 
+def _sort_clause(sort_by: str, sort_dir: str) -> str:
+    """Build SQL ORDER BY clause for target pagination."""
+    col_map = {
+        "integration": "total_integration",
+        "lastSession": "last_session_date",
+        "name": "primary_name",
+    }
+    col = col_map.get(sort_by, "total_integration")
+    direction = "ASC" if sort_dir == "asc" else "DESC"
+    nulls = "NULLS LAST" if direction == "DESC" else "NULLS FIRST"
+    return f"{col} {direction} {nulls}"
+
+
 # --- 3. Aggregation (THIRD — after fixed paths, before path params) ---
 
 @router.get("", response_model=TargetAggregationResponse)
@@ -741,6 +754,8 @@ async def list_targets_aggregated(
     humidity_max: float | None = Query(None),
     airmass_min: float | None = Query(None),
     airmass_max: float | None = Query(None),
+    sort_by: str = Query("integration", pattern="^(integration|lastSession|name)$"),
+    sort_dir: str = Query("desc", pattern="^(asc|desc)$"),
     page: int = Query(1, ge=1),
     page_size: int = Query(50, ge=1, le=250),
     user: User = Depends(get_current_user),
@@ -889,7 +904,8 @@ async def list_targets_aggregated(
                coalesce(min(t.primary_name), min(i.raw_headers->>'OBJECT'), 'Uncategorized') AS primary_name,
                sum(coalesce(i.exposure_time, 0)) AS total_integration,
                count(i.id) AS total_frames,
-               count(distinct CAST(i.capture_date AS DATE)) AS session_count
+               count(distinct CAST(i.capture_date AS DATE)) AS session_count,
+               max(CAST(i.capture_date AS DATE)) AS last_session_date
         FROM images i LEFT JOIN targets t ON i.resolved_target_id = t.id
         WHERE {where_sql}
         GROUP BY {gk}
@@ -906,7 +922,7 @@ async def list_targets_aggregated(
         WHERE {where_sql}
     ),
     page AS (
-        SELECT * FROM grouped ORDER BY total_integration DESC
+        SELECT * FROM grouped ORDER BY {_sort_clause(sort_by, sort_dir)}
         LIMIT :page_size OFFSET :page_offset
     )
     SELECT (SELECT target_count FROM agg) AS agg_target_count,

--- a/backend/app/api/targets.py
+++ b/backend/app/api/targets.py
@@ -1361,7 +1361,10 @@ async def get_session_detail(
             wind_gust=img.wind_gust,
             cloud_cover=img.cloud_cover,
             sky_quality=img.sky_quality,
+            rig=f"{normalize_equipment(img.telescope, tel_map) or 'Unknown'} / {normalize_equipment(img.camera, cam_map) or 'Unknown'}",
         ))
+
+    rig_details = _build_rig_details(images, filter_map, cam_map, tel_map)
 
     is_best_hfr = False
     if median_hfr is not None:
@@ -1437,6 +1440,7 @@ async def get_session_detail(
         median_humidity=statistics.median(humidity_values) if humidity_values else None,
         median_cloud_cover=statistics.median(cloud_cover_values) if cloud_cover_values else None,
         notes=session_note,
+        rigs=rig_details,
     )
 
 

--- a/backend/app/api/targets.py
+++ b/backend/app/api/targets.py
@@ -111,7 +111,7 @@ def _build_rig_details(
                 rig=rig_label,
             ))
 
-        # Gain/offset from first image in rig
+        # Gain/offset/thumbnail from first image in rig
         ref = rig_images[0]
         offset_val = next(
             (int(img.raw_headers.get("OFFSET", 0))
@@ -119,6 +119,12 @@ def _build_rig_details(
              if img.raw_headers and img.raw_headers.get("OFFSET") is not None),
             None,
         )
+        rig_thumb = None
+        for img in rig_images:
+            if img.thumbnail_path:
+                fn = img.thumbnail_path.split("/")[-1].split("\\")[-1]
+                rig_thumb = f"/thumbnails/{fn}"
+                break
 
         rig_details.append(RigDetail(
             rig_label=rig_label,
@@ -136,6 +142,7 @@ def _build_rig_details(
             exposure_times=sorted(set(i.exposure_time for i in rig_images if i.exposure_time is not None)),
             filter_details=rig_filter_details,
             frames=rig_frames,
+            thumbnail_url=rig_thumb,
         ))
 
     return rig_details

--- a/backend/app/schemas/target.py
+++ b/backend/app/schemas/target.py
@@ -59,6 +59,7 @@ class SessionOverview(BaseModel):
     median_guiding_rms_arcsec: float | None = None
     filter_medians: list[FilterMedian] = []
     has_notes: bool = False
+    rig_count: int = 1
 
 
 class FrameHighlight(BaseModel):
@@ -74,6 +75,24 @@ class FilterDetail(BaseModel):
     median_hfr: float | None = None
     median_eccentricity: float | None = None
     exposure_time: float | None = None
+
+
+class RigDetail(BaseModel):
+    rig_label: str
+    telescope: str | None = None
+    camera: str | None = None
+    frame_count: int
+    integration_seconds: float
+    median_hfr: float | None = None
+    median_eccentricity: float | None = None
+    median_fwhm: float | None = None
+    median_guiding_rms: float | None = None
+    median_detected_stars: float | None = None
+    gain: int | None = None
+    offset: int | None = None
+    exposure_times: list[float] = []
+    filter_details: list[FilterDetail] = []
+    frames: list["FrameRecord"] = []
 
 
 class SessionInsight(BaseModel):
@@ -115,6 +134,10 @@ class FrameRecord(BaseModel):
     wind_gust: float | None = None
     cloud_cover: float | None = None
     sky_quality: float | None = None
+    rig: str | None = None
+
+
+RigDetail.model_rebuild()
 
 
 class TargetAggregation(BaseModel):
@@ -216,6 +239,7 @@ class SessionDetailResponse(BaseModel):
     median_humidity: float | None = None
     median_cloud_cover: float | None = None
     notes: str | None = None
+    rigs: list[RigDetail] = []
 
 
 class EquipmentOption(BaseModel):

--- a/backend/app/schemas/target.py
+++ b/backend/app/schemas/target.py
@@ -93,6 +93,7 @@ class RigDetail(BaseModel):
     exposure_times: list[float] = []
     filter_details: list[FilterDetail] = []
     frames: list["FrameRecord"] = []
+    thumbnail_url: str | None = None
 
 
 class SessionInsight(BaseModel):

--- a/backend/app/services/scan_state.py
+++ b/backend/app/services/scan_state.py
@@ -33,6 +33,7 @@ class ScanStateSnapshot:
     discovered: int = 0
     removed: int = 0
     skipped_calibration: int = 0
+    new_files: int = 0
 
     def to_dict(self) -> dict:
         return {
@@ -46,6 +47,7 @@ class ScanStateSnapshot:
             "discovered": self.discovered,
             "removed": self.removed,
             "skipped_calibration": self.skipped_calibration,
+            "new_files": self.new_files,
         }
 
 
@@ -66,6 +68,7 @@ def parse_snapshot(data: dict | None) -> ScanStateSnapshot:
         discovered=int(data.get("discovered", 0)),
         removed=int(data.get("removed", 0)),
         skipped_calibration=int(data.get("skipped_calibration", 0)),
+        new_files=int(data.get("new_files", 0)),
     )
 
 
@@ -189,7 +192,8 @@ def check_complete_sync(r: sync_redis.Redis) -> None:
             "completed_at": time.time(),
         })
         r.expire(SCAN_KEY, EXPIRE_AFTER_COMPLETE)
-        msg = f"Scan complete: {snap.completed} ingested, {snap.failed} failed"
+        new_label = f" ({snap.new_files} new)" if snap.new_files else ""
+        msg = f"Scan complete: {snap.completed} ingested{new_label}, {snap.failed} failed"
         if snap.skipped_calibration > 0:
             msg += f", {snap.skipped_calibration} calibration frames skipped"
         if snap.csv_enriched > 0:
@@ -199,7 +203,7 @@ def check_complete_sync(r: sync_redis.Redis) -> None:
         append_activity_sync(r, {
             "type": "scan_complete",
             "message": msg,
-            "details": {"completed": snap.completed, "failed": snap.failed, "skipped_calibration": snap.skipped_calibration, "csv_enriched": snap.csv_enriched, "total": snap.total, "removed": snap.removed},
+            "details": {"completed": snap.completed, "failed": snap.failed, "skipped_calibration": snap.skipped_calibration, "csv_enriched": snap.csv_enriched, "total": snap.total, "removed": snap.removed, "new_files": snap.new_files},
             "timestamp": time.time(),
         })
         # Chain post-scan maintenance tasks
@@ -222,13 +226,15 @@ def start_scanning_sync(r: sync_redis.Redis) -> None:
     r.delete(SCAN_FAILED_KEY)
 
 
-def set_ingesting_sync(r: sync_redis.Redis, total: int, removed: int = 0) -> None:
+def set_ingesting_sync(r: sync_redis.Redis, total: int, removed: int = 0, new_files: int = 0) -> None:
     mapping: dict = {
         "state": "ingesting",
         "total": total,
     }
     if removed:
         mapping["removed"] = removed
+    if new_files:
+        mapping["new_files"] = new_files
     r.hset(SCAN_KEY, mapping=mapping)
 
 

--- a/backend/app/worker/tasks.py
+++ b/backend/app/worker/tasks.py
@@ -163,7 +163,7 @@ def run_scan(self, include_calibration: bool = True) -> dict:
         return {"status": "complete", "new_files_queued": 0, "already_known": cataloged, "removed": removed}
 
     # Transition to ingesting with final total — ingest tasks are already running
-    set_ingesting_sync(_redis, total=total_queued, removed=removed)
+    set_ingesting_sync(_redis, total=total_queued, removed=removed, new_files=len(new_files))
     # Some tasks may have already completed during discovery, check now
     check_complete_sync(_redis)
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -93,10 +93,12 @@ async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
   return resp.json();
 }
 
-function buildTargetQuery(filters: ActiveFilters, page?: number, pageSize?: number): string {
+function buildTargetQuery(filters: ActiveFilters, page?: number, pageSize?: number, sortBy?: string, sortDir?: string): string {
   const params = new URLSearchParams();
   if (page != null) params.set("page", String(page));
   if (pageSize != null) params.set("page_size", String(pageSize));
+  if (sortBy) params.set("sort_by", sortBy);
+  if (sortDir) params.set("sort_dir", sortDir);
   if (filters.searchQuery) params.set("search", filters.searchQuery);
   if (filters.camera) params.set("camera", filters.camera);
   if (filters.telescope) params.set("telescope", filters.telescope);
@@ -158,8 +160,8 @@ export const api = {
   deleteUser: (id: string) =>
     fetchJson<void>(`/auth/users/${id}`, { method: "DELETE" }),
 
-  getTargets: (filters: ActiveFilters, page?: number, pageSize?: number) =>
-    fetchJson<TargetAggregationResponse>(`/targets?${buildTargetQuery(filters, page, pageSize)}`),
+  getTargets: (filters: ActiveFilters, page?: number, pageSize?: number, sortBy?: string, sortDir?: string) =>
+    fetchJson<TargetAggregationResponse>(`/targets?${buildTargetQuery(filters, page, pageSize, sortBy, sortDir)}`),
 
   getSessionDetail: (targetId: string, date: string) =>
     fetchJson<SessionDetail>(`/targets/${encodeURIComponent(decodeURIComponent(targetId))}/sessions/${date}`),

--- a/frontend/src/components/DashboardFilterProvider.tsx
+++ b/frontend/src/components/DashboardFilterProvider.tsx
@@ -1,9 +1,12 @@
-import { Component, JSX, createContext, createMemo, useContext } from "solid-js";
+import { Component, JSX, createContext, createMemo, createSignal, useContext } from "solid-js";
 import { useSearchParams } from "@solidjs/router";
 import { createResource } from "solid-js";
 import { api } from "../api/client";
 import { useSettingsContext } from "./SettingsProvider";
 import type { ActiveFilters, TargetAggregationResponse } from "../types";
+
+export type SortKey = "name" | "integration" | "lastSession" | "equipment";
+export type SortDir = "asc" | "desc";
 
 interface DashboardFilterAPI {
   filters: () => ActiveFilters;
@@ -23,6 +26,9 @@ interface DashboardFilterAPI {
   totalPages: () => number;
   setPage: (page: number) => void;
   setPageSize: (size: number) => void;
+  sortKey: () => SortKey;
+  sortDir: () => SortDir;
+  toggleSort: (key: SortKey) => void;
 }
 
 const DashboardFilterContext = createContext<DashboardFilterAPI>();
@@ -99,6 +105,43 @@ const DashboardFilterProvider: Component<{ children: JSX.Element }> = (props) =>
 
   const filters = createMemo(() => deriveFilters(searchParams));
 
+  // Sort state — persisted to localStorage
+  let initialSort: { key: SortKey; dir: SortDir } = { key: "integration", dir: "desc" };
+  try {
+    const stored = localStorage.getItem("dashboard_sort");
+    if (stored) initialSort = JSON.parse(stored);
+  } catch { /* ignore corrupt localStorage */ }
+
+  const [sortKey, setSortKey] = createSignal<SortKey>(initialSort.key);
+  const [sortDir, setSortDir] = createSignal<SortDir>(initialSort.dir);
+
+  const persistSort = (key: SortKey, dir: SortDir) => {
+    localStorage.setItem("dashboard_sort", JSON.stringify({ key, dir }));
+  };
+
+  const toggleSort = (key: SortKey) => {
+    if (sortKey() === key) {
+      const newDir = sortDir() === "asc" ? "desc" : "asc";
+      setSortDir(newDir);
+      persistSort(key, newDir);
+    } else {
+      const newDir = key === "name" ? "asc" : "desc";
+      setSortKey(key);
+      setSortDir(newDir);
+      persistSort(key, newDir);
+    }
+    // Reset to page 1 when sort changes
+    setSearchParams({ page: undefined }, { replace: true });
+  };
+
+  // Map frontend sort keys to backend API values
+  const apiSortBy = createMemo(() => {
+    const key = sortKey();
+    // "equipment" has no backend sort — fall back to integration
+    if (key === "equipment") return "integration";
+    return key;
+  });
+
   const currentPage = createMemo(() => {
     const raw = searchParams.page;
     const p = parseInt(typeof raw === "string" ? raw : "1");
@@ -109,11 +152,14 @@ const DashboardFilterProvider: Component<{ children: JSX.Element }> = (props) =>
     return settingsCtx.settings()?.general.default_page_size ?? 50;
   });
 
-  // Resource key combines filters + pagination so changes to either trigger a refetch
-  const fetchKey = createMemo(() => ({ filters: filters(), page: currentPage(), pageSize: currentPageSize() }));
+  // Resource key combines filters + pagination + sort so changes to any trigger a refetch
+  const fetchKey = createMemo(() => ({
+    filters: filters(), page: currentPage(), pageSize: currentPageSize(),
+    sortBy: apiSortBy(), sortDir: sortDir(),
+  }));
 
   const [targetData, { refetch: refetchTargets }] = createResource(fetchKey, (k) =>
-    api.getTargets(k.filters, k.page, k.pageSize)
+    api.getTargets(k.filters, k.page, k.pageSize, k.sortBy, k.sortDir)
   );
 
   const set = (updates: Record<string, string | undefined>) => {
@@ -237,6 +283,9 @@ const DashboardFilterProvider: Component<{ children: JSX.Element }> = (props) =>
     },
     setPage,
     setPageSize,
+    sortKey,
+    sortDir,
+    toggleSort,
   };
 
   return (

--- a/frontend/src/components/RawHeaderAccordion.tsx
+++ b/frontend/src/components/RawHeaderAccordion.tsx
@@ -12,7 +12,7 @@ const RawHeaderAccordion: Component<{ headers: Record<string, unknown> | null }>
     <div class="border-t border-theme-border/50 pt-3">
       <button
         onClick={() => setOpen((v) => !v)}
-        class="flex justify-between items-center w-full text-xs py-2 px-0 hover:text-theme-text-primary transition-colors cursor-pointer"
+        class="flex justify-between items-center w-full text-xs py-2 px-3 rounded-[var(--radius-md)] bg-theme-base hover:bg-theme-hover hover:text-theme-text-primary transition-colors cursor-pointer"
         classList={{ "text-theme-text-primary": open(), "text-theme-text-secondary": !open() }}
       >
         <span class="font-semibold border-l-2 border-theme-accent pl-2">

--- a/frontend/src/components/RawHeaderAccordion.tsx
+++ b/frontend/src/components/RawHeaderAccordion.tsx
@@ -9,10 +9,10 @@ const RawHeaderAccordion: Component<{ headers: Record<string, unknown> | null }>
   };
 
   return (
-    <div class="border-t border-theme-border/50 pt-3">
+    <div class="bg-theme-base rounded-[var(--radius-md)]">
       <button
         onClick={() => setOpen((v) => !v)}
-        class="flex justify-between items-center w-full text-xs py-2 px-3 rounded-[var(--radius-md)] bg-theme-base hover:bg-theme-hover hover:text-theme-text-primary transition-colors cursor-pointer"
+        class="flex justify-between items-center w-full text-xs py-2 px-3 hover:bg-theme-hover rounded-[var(--radius-md)] hover:text-theme-text-primary transition-colors cursor-pointer"
         classList={{ "text-theme-text-primary": open(), "text-theme-text-secondary": !open() }}
       >
         <span class="font-semibold border-l-2 border-theme-accent pl-2">
@@ -27,9 +27,9 @@ const RawHeaderAccordion: Component<{ headers: Record<string, unknown> | null }>
         </svg>
       </button>
       <Show when={open()}>
-        <div class="mt-2 max-h-64 overflow-y-auto">
+        <div class="px-3 pb-3 max-h-64 overflow-y-auto">
           <table class="w-full text-xs">
-            <thead class="sticky top-0 bg-theme-surface">
+            <thead class="sticky top-0 bg-theme-base">
               <tr class="text-theme-text-secondary">
                 <th class="text-left py-1 px-2 font-normal">Key</th>
                 <th class="text-left py-1 px-2 font-normal">Value</th>

--- a/frontend/src/components/RigTogglePills.tsx
+++ b/frontend/src/components/RigTogglePills.tsx
@@ -1,0 +1,47 @@
+import { For } from "solid-js";
+
+/** A small palette of distinguishable rig colors. */
+const RIG_COLORS = [
+  "#60a5fa", // blue
+  "#f59e0b", // amber
+  "#34d399", // emerald
+  "#f472b6", // pink
+  "#a78bfa", // violet
+  "#fb923c", // orange
+];
+
+export function rigColor(index: number): string {
+  return RIG_COLORS[index % RIG_COLORS.length];
+}
+
+interface Props {
+  rigs: string[];
+  enabledRigs: string[];
+  onToggle: (rig: string) => void;
+}
+
+export default function RigTogglePills(props: Props) {
+  return (
+    <div class="flex flex-wrap gap-1.5">
+      <For each={props.rigs}>
+        {(rig, index) => {
+          const isActive = () => props.enabledRigs.includes(rig);
+          const color = () => rigColor(index());
+          return (
+            <button
+              class="px-2 py-0.5 rounded text-caption font-medium border transition-colors cursor-pointer"
+              style={{
+                "border-color": isActive() ? color() : "var(--color-border-default)",
+                "background-color": isActive() ? `${color()}22` : "var(--color-bg-elevated)",
+                color: isActive() ? color() : "var(--color-text-tertiary)",
+              }}
+              onClick={() => props.onToggle(rig)}
+            >
+              {rig}
+            </button>
+          );
+        }}
+      </For>
+    </div>
+  );
+}

--- a/frontend/src/components/SessionAccordionCard.tsx
+++ b/frontend/src/components/SessionAccordionCard.tsx
@@ -158,7 +158,15 @@ const SessionAccordionCard: Component<{
           <div class="flex flex-col sm:flex-row sm:items-center gap-0.5 sm:gap-0">
             <span class="font-bold text-theme-text-primary text-sm">{props.session.session_date}</span>
             <span class="text-theme-text-secondary sm:ml-3 text-xs sm:text-sm">
-              {props.session.camera ?? ""} · {props.session.telescope ?? ""}
+              {props.session.rig_count > 1 ? (
+                <span class="inline-flex items-center gap-1">
+                  <span class="px-1.5 py-0.5 rounded bg-theme-accent/20 text-theme-accent text-tiny font-semibold">
+                    {props.session.rig_count} rigs
+                  </span>
+                </span>
+              ) : (
+                <>{props.session.camera ?? ""} · {props.session.telescope ?? ""}</>
+              )}
             </span>
           </div>
         </td>

--- a/frontend/src/components/SessionAccordionCard.tsx
+++ b/frontend/src/components/SessionAccordionCard.tsx
@@ -5,6 +5,7 @@ import ReferenceThumbnail from "./ReferenceThumbnail";
 import RawHeaderAccordion from "./RawHeaderAccordion";
 import FilterBadges from "./FilterBadges";
 import SessionMetricsChart from "./SessionMetricsChart";
+import RigTogglePills, { rigColor } from "./RigTogglePills";
 import { useSettingsContext } from "./SettingsProvider";
 import { isFieldVisible } from "../utils/displaySettings";
 import { formatTime as formatTimeUtil, timezoneLabel } from "../utils/dateTime";
@@ -60,6 +61,29 @@ const SessionAccordionCard: Component<{
   const [noteSaving, setNoteSaving] = createSignal(false);
   let noteTimer: ReturnType<typeof setTimeout> | undefined;
 
+  const [enabledRigs, setEnabledRigs] = createSignal<string[]>([]);
+
+  // Initialize enabledRigs when detail loads
+  createEffect(() => {
+    const d = props.detail;
+    if (d && d.rigs.length > 0 && enabledRigs().length === 0) {
+      setEnabledRigs(d.rigs.map(r => r.rig_label));
+    }
+  });
+
+  const toggleRig = (rig: string) => {
+    setEnabledRigs((prev) => {
+      if (prev.includes(rig)) {
+        if (prev.length <= 1) return prev;
+        return prev.filter((r) => r !== rig);
+      }
+      return [...prev, rig];
+    });
+  };
+
+  const isMultiRig = () => (props.detail?.rigs.length ?? 0) > 1;
+  const rigLabels = () => props.detail?.rigs.map(r => r.rig_label) ?? [];
+
   // Sync when detail loads
   createEffect(() => {
     if (props.detail?.notes !== undefined) {
@@ -105,11 +129,11 @@ const SessionAccordionCard: Component<{
     }
   });
 
-  const sortedFrames = () => {
-    if (!props.detail) return [];
+  const sortedFrames = (inputFrames?: FrameRecord[]) => {
+    const frames = inputFrames ?? props.detail?.frames ?? [];
     const col = sortColumn();
     const asc = sortAsc();
-    return [...props.detail.frames].sort((a, b) => {
+    return [...frames].sort((a, b) => {
       const va = a[col];
       const vb = b[col];
       if (va === null || va === undefined) return 1;
@@ -133,6 +157,209 @@ const SessionAccordionCard: Component<{
     if (!props.detail?.median_hfr || !frame.median_hfr) return false;
     return frame.median_hfr > props.detail.median_hfr * 1.5;
   };
+
+  const renderFrameTable = (frames: FrameRecord[]) => (
+    <table class="w-full text-label">
+      <thead class="sticky top-0 bg-theme-base">
+        <tr class="text-theme-text-secondary border-b border-theme-border">
+          <SortHeader label={`Time (${timezoneLabel(settingsCtx.timezone())})`} column="timestamp" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} />
+          <SortHeader label="Filter" column="filter_used" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="center" />
+          <SortHeader label="Exp" column="exposure_time" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
+          <Show when={visible("quality", "hfr")}>
+            <SortHeader label="HFR" column="median_hfr" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
+          </Show>
+          <Show when={visible("quality", "eccentricity")}>
+            <SortHeader label="Ecc" column="eccentricity" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
+          </Show>
+          <Show when={visible("quality", "fwhm")}>
+            <SortHeader label="FWHM" column="fwhm" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
+          </Show>
+          <Show when={visible("quality", "detected_stars")}>
+            <SortHeader label="Stars" column="detected_stars" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
+          </Show>
+          <Show when={visible("guiding", "rms_total")}>
+            <SortHeader label="RMS" column="guiding_rms_arcsec" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
+          </Show>
+          <Show when={visible("guiding", "rms_ra")}>
+            <SortHeader label="RMS RA" column="guiding_rms_ra_arcsec" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
+          </Show>
+          <Show when={visible("guiding", "rms_dec")}>
+            <SortHeader label="RMS Dec" column="guiding_rms_dec_arcsec" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
+          </Show>
+          <Show when={visible("adu", "mean")}>
+            <SortHeader label="ADU Mean" column="adu_mean" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
+          </Show>
+          <Show when={visible("adu", "median")}>
+            <SortHeader label="ADU Med" column="adu_median" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
+          </Show>
+          <Show when={visible("adu", "stdev")}>
+            <SortHeader label="ADU σ" column="adu_stdev" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
+          </Show>
+          <Show when={visible("adu", "min")}>
+            <SortHeader label="ADU Min" column="adu_min" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
+          </Show>
+          <Show when={visible("adu", "max")}>
+            <SortHeader label="ADU Max" column="adu_max" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
+          </Show>
+          <Show when={visible("focuser", "position")}>
+            <SortHeader label="Focus" column="focuser_position" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
+          </Show>
+          <Show when={visible("focuser", "temp")}>
+            <SortHeader label="Focus Temp" column="focuser_temp" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
+          </Show>
+          <Show when={visible("weather", "ambient_temp")}>
+            <SortHeader label="Amb Temp" column="ambient_temp" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
+          </Show>
+          <Show when={visible("weather", "dew_point")}>
+            <SortHeader label="Dew Pt" column="dew_point" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
+          </Show>
+          <Show when={visible("weather", "humidity")}>
+            <SortHeader label="Humidity" column="humidity" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
+          </Show>
+          <Show when={visible("weather", "pressure")}>
+            <SortHeader label="Pressure" column="pressure" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
+          </Show>
+          <Show when={visible("weather", "wind_speed")}>
+            <SortHeader label="Wind" column="wind_speed" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
+          </Show>
+          <Show when={visible("weather", "wind_direction")}>
+            <SortHeader label="Wind Dir" column="wind_direction" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
+          </Show>
+          <Show when={visible("weather", "wind_gust")}>
+            <SortHeader label="Gust" column="wind_gust" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
+          </Show>
+          <Show when={visible("weather", "cloud_cover")}>
+            <SortHeader label="Clouds" column="cloud_cover" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
+          </Show>
+          <Show when={visible("weather", "sky_quality")}>
+            <SortHeader label="SQM" column="sky_quality" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
+          </Show>
+          <Show when={visible("mount", "airmass")}>
+            <SortHeader label="Airmass" column="airmass" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
+          </Show>
+          <Show when={visible("mount", "pier_side")}>
+            <SortHeader label="Pier" column="pier_side" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="center" />
+          </Show>
+          <Show when={visible("mount", "rotator_position")}>
+            <SortHeader label="Rotator" column="rotator_position" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
+          </Show>
+          <SortHeader label="Temp" column="sensor_temp" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
+          <SortHeader label="Gain" column="gain" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
+          <th class="text-right py-1.5 px-2 font-normal">File</th>
+        </tr>
+      </thead>
+      <tbody>
+        <For each={sortedFrames(frames)}>
+          {(frame) => (
+            <tr class={`border-b border-theme-border/30 hover:bg-theme-hover transition-colors duration-100 ${isOutlier(frame) ? "bg-theme-error/20" : ""}`}>
+              <td class="py-1 px-2 text-theme-text-primary">{formatTimeUtil(frame.timestamp, settingsCtx.timezone())}</td>
+              <td class="py-1 px-2 text-theme-text-primary text-center">{frame.filter_used ?? "—"}</td>
+              <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.exposure_time ?? "—"}s</td>
+              <Show when={visible("quality", "hfr")}>
+                <td class={`py-1 px-2 text-right tabular-nums ${isOutlier(frame) ? "text-theme-error font-bold" : "text-theme-text-primary"}`}>
+                  {frame.median_hfr?.toFixed(2) ?? "\u2014"}
+                </td>
+              </Show>
+              <Show when={visible("quality", "eccentricity")}>
+                <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.eccentricity?.toFixed(2) ?? "\u2014"}</td>
+              </Show>
+              <Show when={visible("quality", "fwhm")}>
+                <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.fwhm?.toFixed(2) ?? "\u2014"}</td>
+              </Show>
+              <Show when={visible("quality", "detected_stars")}>
+                <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.detected_stars ?? "\u2014"}</td>
+              </Show>
+              <Show when={visible("guiding", "rms_total")}>
+                <td class="py-1 px-2 text-theme-text-primary text-right">
+                  {frame.guiding_rms_arcsec !== null ? `${frame.guiding_rms_arcsec?.toFixed(2)}"` : "\u2014"}
+                </td>
+              </Show>
+              <Show when={visible("guiding", "rms_ra")}>
+                <td class="py-1 px-2 text-theme-text-primary text-right">
+                  {frame.guiding_rms_ra_arcsec !== null ? `${frame.guiding_rms_ra_arcsec?.toFixed(2)}"` : "\u2014"}
+                </td>
+              </Show>
+              <Show when={visible("guiding", "rms_dec")}>
+                <td class="py-1 px-2 text-theme-text-primary text-right">
+                  {frame.guiding_rms_dec_arcsec !== null ? `${frame.guiding_rms_dec_arcsec?.toFixed(2)}"` : "\u2014"}
+                </td>
+              </Show>
+              <Show when={visible("adu", "mean")}>
+                <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.adu_mean?.toFixed(2) ?? "\u2014"}</td>
+              </Show>
+              <Show when={visible("adu", "median")}>
+                <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.adu_median?.toFixed(2) ?? "\u2014"}</td>
+              </Show>
+              <Show when={visible("adu", "stdev")}>
+                <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.adu_stdev?.toFixed(2) ?? "\u2014"}</td>
+              </Show>
+              <Show when={visible("adu", "min")}>
+                <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.adu_min ?? "\u2014"}</td>
+              </Show>
+              <Show when={visible("adu", "max")}>
+                <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.adu_max ?? "\u2014"}</td>
+              </Show>
+              <Show when={visible("focuser", "position")}>
+                <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.focuser_position ?? "\u2014"}</td>
+              </Show>
+              <Show when={visible("focuser", "temp")}>
+                <td class="py-1 px-2 text-theme-text-primary text-right">
+                  {frame.focuser_temp !== null ? `${frame.focuser_temp?.toFixed(1)}\u00b0` : "\u2014"}
+                </td>
+              </Show>
+              <Show when={visible("weather", "ambient_temp")}>
+                <td class="py-1 px-2 text-theme-text-primary text-right">
+                  {frame.ambient_temp !== null ? `${frame.ambient_temp?.toFixed(1)}\u00b0` : "\u2014"}
+                </td>
+              </Show>
+              <Show when={visible("weather", "dew_point")}>
+                <td class="py-1 px-2 text-theme-text-primary text-right">
+                  {frame.dew_point !== null ? `${frame.dew_point?.toFixed(1)}\u00b0` : "\u2014"}
+                </td>
+              </Show>
+              <Show when={visible("weather", "humidity")}>
+                <td class="py-1 px-2 text-theme-text-primary text-right">
+                  {frame.humidity !== null ? `${frame.humidity?.toFixed(1)}%` : "\u2014"}
+                </td>
+              </Show>
+              <Show when={visible("weather", "pressure")}>
+                <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.pressure?.toFixed(2) ?? "\u2014"}</td>
+              </Show>
+              <Show when={visible("weather", "wind_speed")}>
+                <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.wind_speed?.toFixed(1) ?? "\u2014"}</td>
+              </Show>
+              <Show when={visible("weather", "wind_direction")}>
+                <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.wind_direction?.toFixed(1) ?? "\u2014"}</td>
+              </Show>
+              <Show when={visible("weather", "wind_gust")}>
+                <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.wind_gust?.toFixed(1) ?? "\u2014"}</td>
+              </Show>
+              <Show when={visible("weather", "cloud_cover")}>
+                <td class="py-1 px-2 text-theme-text-primary text-right">
+                  {frame.cloud_cover !== null ? `${frame.cloud_cover?.toFixed(1)}%` : "\u2014"}
+                </td>
+              </Show>
+              <Show when={visible("weather", "sky_quality")}>
+                <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.sky_quality?.toFixed(2) ?? "\u2014"}</td>
+              </Show>
+              <Show when={visible("mount", "airmass")}>
+                <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.airmass?.toFixed(2) ?? "\u2014"}</td>
+              </Show>
+              <Show when={visible("mount", "pier_side")}>
+                <td class="py-1 px-2 text-theme-text-primary text-center">{frame.pier_side ?? "\u2014"}</td>
+              </Show>
+              <Show when={visible("mount", "rotator_position")}>
+                <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.rotator_position?.toFixed(2) ?? "\u2014"}</td>
+              </Show>
+              <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.sensor_temp?.toFixed(0) ?? "—"}°C</td>
+              <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.gain ?? "—"}</td>
+              <td class="py-1 px-2 text-theme-text-secondary text-right truncate max-w-[150px]">{frame.file_name}</td>
+            </tr>
+          )}
+        </For>
+      </tbody>
+    </table>
+  );
 
   return (
     <>
@@ -284,6 +511,31 @@ const SessionAccordionCard: Component<{
                   </span>
                 </div>
 
+                {/* Per-rig summary (multi-rig only) */}
+                <Show when={isMultiRig()}>
+                  <div class="mt-2">
+                    <RigTogglePills rigs={rigLabels()} enabledRigs={enabledRigs()} onToggle={toggleRig} />
+                    <div class="flex flex-wrap gap-3 mt-2 text-label">
+                      <For each={props.detail!.rigs}>
+                        {(rig, index) => (
+                          <Show when={enabledRigs().includes(rig.rig_label)}>
+                            <span class="flex items-center gap-1.5">
+                              <span
+                                class="w-2 h-2 rounded-full inline-block"
+                                style={{ "background-color": rigColor(index()) }}
+                              />
+                              <span class="text-theme-text-secondary">{rig.rig_label}:</span>
+                              <span class="font-bold text-theme-text-primary">
+                                {rig.frame_count} fr · {formatIntegration(rig.integration_seconds)}
+                              </span>
+                            </span>
+                          </Show>
+                        )}
+                      </For>
+                    </div>
+                  </div>
+                </Show>
+
                 {/* Metrics table + thumbnail */}
                 <div class="grid gap-4 grid-cols-1 md:grid-cols-[1fr_200px]">
                   <div class="bg-theme-base rounded-[var(--radius-md)] overflow-x-auto">
@@ -423,7 +675,7 @@ const SessionAccordionCard: Component<{
                     onClick={() => setShowFrames(!showFrames())}
                   >
                     <span class="font-semibold border-l-2 border-theme-accent pl-2">
-                      Per-Frame Data <span class="text-theme-text-tertiary font-normal">({detail().frames.length} frames)</span>
+                      Per-Frame Data <span class="text-theme-text-tertiary font-normal">({detail().frames.length} frames{isMultiRig() ? ` · ${enabledRigs().length} rigs` : ""})</span>
                     </span>
                     <svg
                       class={`w-3.5 h-3.5 transition-transform duration-200 ${showFrames() ? "rotate-180" : ""}`}
@@ -434,208 +686,29 @@ const SessionAccordionCard: Component<{
                     </svg>
                   </button>
                   <Show when={showFrames()}>
-                    <div class="bg-theme-base rounded-[var(--radius-md)] overflow-x-auto max-h-[600px] overflow-y-auto mt-2">
-                      <table class="w-full text-label">
-                        <thead class="sticky top-0 bg-theme-base">
-                          <tr class="text-theme-text-secondary border-b border-theme-border">
-                            <SortHeader label={`Time (${timezoneLabel(settingsCtx.timezone())})`} column="timestamp" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} />
-                            <SortHeader label="Filter" column="filter_used" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="center" />
-                            <SortHeader label="Exp" column="exposure_time" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
-                            <Show when={visible("quality", "hfr")}>
-                              <SortHeader label="HFR" column="median_hfr" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
-                            </Show>
-                            <Show when={visible("quality", "eccentricity")}>
-                              <SortHeader label="Ecc" column="eccentricity" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
-                            </Show>
-                            <Show when={visible("quality", "fwhm")}>
-                              <SortHeader label="FWHM" column="fwhm" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
-                            </Show>
-                            <Show when={visible("quality", "detected_stars")}>
-                              <SortHeader label="Stars" column="detected_stars" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
-                            </Show>
-                            <Show when={visible("guiding", "rms_total")}>
-                              <SortHeader label="RMS" column="guiding_rms_arcsec" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
-                            </Show>
-                            <Show when={visible("guiding", "rms_ra")}>
-                              <SortHeader label="RMS RA" column="guiding_rms_ra_arcsec" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
-                            </Show>
-                            <Show when={visible("guiding", "rms_dec")}>
-                              <SortHeader label="RMS Dec" column="guiding_rms_dec_arcsec" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
-                            </Show>
-                            <Show when={visible("adu", "mean")}>
-                              <SortHeader label="ADU Mean" column="adu_mean" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
-                            </Show>
-                            <Show when={visible("adu", "median")}>
-                              <SortHeader label="ADU Med" column="adu_median" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
-                            </Show>
-                            <Show when={visible("adu", "stdev")}>
-                              <SortHeader label="ADU σ" column="adu_stdev" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
-                            </Show>
-                            <Show when={visible("adu", "min")}>
-                              <SortHeader label="ADU Min" column="adu_min" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
-                            </Show>
-                            <Show when={visible("adu", "max")}>
-                              <SortHeader label="ADU Max" column="adu_max" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
-                            </Show>
-                            <Show when={visible("focuser", "position")}>
-                              <SortHeader label="Focus" column="focuser_position" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
-                            </Show>
-                            <Show when={visible("focuser", "temp")}>
-                              <SortHeader label="Focus Temp" column="focuser_temp" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
-                            </Show>
-                            <Show when={visible("weather", "ambient_temp")}>
-                              <SortHeader label="Amb Temp" column="ambient_temp" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
-                            </Show>
-                            <Show when={visible("weather", "dew_point")}>
-                              <SortHeader label="Dew Pt" column="dew_point" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
-                            </Show>
-                            <Show when={visible("weather", "humidity")}>
-                              <SortHeader label="Humidity" column="humidity" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
-                            </Show>
-                            <Show when={visible("weather", "pressure")}>
-                              <SortHeader label="Pressure" column="pressure" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
-                            </Show>
-                            <Show when={visible("weather", "wind_speed")}>
-                              <SortHeader label="Wind" column="wind_speed" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
-                            </Show>
-                            <Show when={visible("weather", "wind_direction")}>
-                              <SortHeader label="Wind Dir" column="wind_direction" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
-                            </Show>
-                            <Show when={visible("weather", "wind_gust")}>
-                              <SortHeader label="Gust" column="wind_gust" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
-                            </Show>
-                            <Show when={visible("weather", "cloud_cover")}>
-                              <SortHeader label="Clouds" column="cloud_cover" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
-                            </Show>
-                            <Show when={visible("weather", "sky_quality")}>
-                              <SortHeader label="SQM" column="sky_quality" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
-                            </Show>
-                            <Show when={visible("mount", "airmass")}>
-                              <SortHeader label="Airmass" column="airmass" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
-                            </Show>
-                            <Show when={visible("mount", "pier_side")}>
-                              <SortHeader label="Pier" column="pier_side" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="center" />
-                            </Show>
-                            <Show when={visible("mount", "rotator_position")}>
-                              <SortHeader label="Rotator" column="rotator_position" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
-                            </Show>
-                            <SortHeader label="Temp" column="sensor_temp" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
-                            <SortHeader label="Gain" column="gain" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="right" />
-                            <th class="text-right py-1.5 px-2 font-normal">File</th>
-                          </tr>
-                        </thead>
-                        <tbody>
-                          <For each={sortedFrames()}>
-                            {(frame) => (
-                              <tr class={`border-b border-theme-border/30 hover:bg-theme-hover transition-colors duration-100 ${isOutlier(frame) ? "bg-theme-error/20" : ""}`}>
-                                <td class="py-1 px-2 text-theme-text-primary">{formatTimeUtil(frame.timestamp, settingsCtx.timezone())}</td>
-                                <td class="py-1 px-2 text-theme-text-primary text-center">{frame.filter_used ?? "—"}</td>
-                                <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.exposure_time ?? "—"}s</td>
-                                <Show when={visible("quality", "hfr")}>
-                                  <td class={`py-1 px-2 text-right tabular-nums ${isOutlier(frame) ? "text-theme-error font-bold" : "text-theme-text-primary"}`}>
-                                    {frame.median_hfr?.toFixed(2) ?? "\u2014"}
-                                  </td>
-                                </Show>
-                                <Show when={visible("quality", "eccentricity")}>
-                                  <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.eccentricity?.toFixed(2) ?? "\u2014"}</td>
-                                </Show>
-                                <Show when={visible("quality", "fwhm")}>
-                                  <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.fwhm?.toFixed(2) ?? "\u2014"}</td>
-                                </Show>
-                                <Show when={visible("quality", "detected_stars")}>
-                                  <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.detected_stars ?? "\u2014"}</td>
-                                </Show>
-                                <Show when={visible("guiding", "rms_total")}>
-                                  <td class="py-1 px-2 text-theme-text-primary text-right">
-                                    {frame.guiding_rms_arcsec !== null ? `${frame.guiding_rms_arcsec?.toFixed(2)}"` : "\u2014"}
-                                  </td>
-                                </Show>
-                                <Show when={visible("guiding", "rms_ra")}>
-                                  <td class="py-1 px-2 text-theme-text-primary text-right">
-                                    {frame.guiding_rms_ra_arcsec !== null ? `${frame.guiding_rms_ra_arcsec?.toFixed(2)}"` : "\u2014"}
-                                  </td>
-                                </Show>
-                                <Show when={visible("guiding", "rms_dec")}>
-                                  <td class="py-1 px-2 text-theme-text-primary text-right">
-                                    {frame.guiding_rms_dec_arcsec !== null ? `${frame.guiding_rms_dec_arcsec?.toFixed(2)}"` : "\u2014"}
-                                  </td>
-                                </Show>
-                                <Show when={visible("adu", "mean")}>
-                                  <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.adu_mean?.toFixed(2) ?? "\u2014"}</td>
-                                </Show>
-                                <Show when={visible("adu", "median")}>
-                                  <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.adu_median?.toFixed(2) ?? "\u2014"}</td>
-                                </Show>
-                                <Show when={visible("adu", "stdev")}>
-                                  <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.adu_stdev?.toFixed(2) ?? "\u2014"}</td>
-                                </Show>
-                                <Show when={visible("adu", "min")}>
-                                  <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.adu_min ?? "\u2014"}</td>
-                                </Show>
-                                <Show when={visible("adu", "max")}>
-                                  <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.adu_max ?? "\u2014"}</td>
-                                </Show>
-                                <Show when={visible("focuser", "position")}>
-                                  <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.focuser_position ?? "\u2014"}</td>
-                                </Show>
-                                <Show when={visible("focuser", "temp")}>
-                                  <td class="py-1 px-2 text-theme-text-primary text-right">
-                                    {frame.focuser_temp !== null ? `${frame.focuser_temp?.toFixed(1)}\u00b0` : "\u2014"}
-                                  </td>
-                                </Show>
-                                <Show when={visible("weather", "ambient_temp")}>
-                                  <td class="py-1 px-2 text-theme-text-primary text-right">
-                                    {frame.ambient_temp !== null ? `${frame.ambient_temp?.toFixed(1)}\u00b0` : "\u2014"}
-                                  </td>
-                                </Show>
-                                <Show when={visible("weather", "dew_point")}>
-                                  <td class="py-1 px-2 text-theme-text-primary text-right">
-                                    {frame.dew_point !== null ? `${frame.dew_point?.toFixed(1)}\u00b0` : "\u2014"}
-                                  </td>
-                                </Show>
-                                <Show when={visible("weather", "humidity")}>
-                                  <td class="py-1 px-2 text-theme-text-primary text-right">
-                                    {frame.humidity !== null ? `${frame.humidity?.toFixed(1)}%` : "\u2014"}
-                                  </td>
-                                </Show>
-                                <Show when={visible("weather", "pressure")}>
-                                  <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.pressure?.toFixed(2) ?? "\u2014"}</td>
-                                </Show>
-                                <Show when={visible("weather", "wind_speed")}>
-                                  <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.wind_speed?.toFixed(1) ?? "\u2014"}</td>
-                                </Show>
-                                <Show when={visible("weather", "wind_direction")}>
-                                  <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.wind_direction?.toFixed(1) ?? "\u2014"}</td>
-                                </Show>
-                                <Show when={visible("weather", "wind_gust")}>
-                                  <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.wind_gust?.toFixed(1) ?? "\u2014"}</td>
-                                </Show>
-                                <Show when={visible("weather", "cloud_cover")}>
-                                  <td class="py-1 px-2 text-theme-text-primary text-right">
-                                    {frame.cloud_cover !== null ? `${frame.cloud_cover?.toFixed(1)}%` : "\u2014"}
-                                  </td>
-                                </Show>
-                                <Show when={visible("weather", "sky_quality")}>
-                                  <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.sky_quality?.toFixed(2) ?? "\u2014"}</td>
-                                </Show>
-                                <Show when={visible("mount", "airmass")}>
-                                  <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.airmass?.toFixed(2) ?? "\u2014"}</td>
-                                </Show>
-                                <Show when={visible("mount", "pier_side")}>
-                                  <td class="py-1 px-2 text-theme-text-primary text-center">{frame.pier_side ?? "\u2014"}</td>
-                                </Show>
-                                <Show when={visible("mount", "rotator_position")}>
-                                  <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.rotator_position?.toFixed(2) ?? "\u2014"}</td>
-                                </Show>
-                                <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.sensor_temp?.toFixed(0) ?? "—"}°C</td>
-                                <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.gain ?? "—"}</td>
-                                <td class="py-1 px-2 text-theme-text-secondary text-right truncate max-w-[150px]">{frame.file_name}</td>
-                              </tr>
-                            )}
-                          </For>
-                        </tbody>
-                      </table>
-                    </div>
+                    <Show when={isMultiRig()} fallback={
+                      <div class="bg-theme-base rounded-[var(--radius-md)] overflow-x-auto max-h-[600px] overflow-y-auto mt-2">
+                        {renderFrameTable(props.detail!.frames)}
+                      </div>
+                    }>
+                      <For each={props.detail!.rigs}>
+                        {(rig, index) => (
+                          <Show when={enabledRigs().includes(rig.rig_label)}>
+                            <div class="mt-2">
+                              <div class="flex items-center gap-2 mb-1">
+                                <span class="w-2 h-2 rounded-full inline-block"
+                                  style={{ "background-color": rigColor(index()) }} />
+                                <span class="text-xs font-semibold text-theme-text-primary">{rig.rig_label}</span>
+                                <span class="text-tiny text-theme-text-tertiary">{rig.frame_count} frames</span>
+                              </div>
+                              <div class="bg-theme-base rounded-[var(--radius-md)] overflow-x-auto max-h-[600px] overflow-y-auto">
+                                {renderFrameTable(rig.frames)}
+                              </div>
+                            </div>
+                          </Show>
+                        )}
+                      </For>
+                    </Show>
                   </Show>
                 </div>
 

--- a/frontend/src/components/SessionAccordionCard.tsx
+++ b/frontend/src/components/SessionAccordionCard.tsx
@@ -5,7 +5,7 @@ import ReferenceThumbnail from "./ReferenceThumbnail";
 import RawHeaderAccordion from "./RawHeaderAccordion";
 import FilterBadges from "./FilterBadges";
 import SessionMetricsChart from "./SessionMetricsChart";
-import RigTogglePills, { rigColor } from "./RigTogglePills";
+import { rigColor } from "./RigTogglePills";
 import { useSettingsContext } from "./SettingsProvider";
 import { isFieldVisible } from "../utils/displaySettings";
 import { formatTime as formatTimeUtil, timezoneLabel } from "../utils/dateTime";
@@ -538,26 +538,21 @@ const SessionAccordionCard: Component<{
 
                 {/* Per-rig summary (multi-rig only) */}
                 <Show when={isMultiRig()}>
-                  <div class="mt-2">
-                    <RigTogglePills rigs={rigLabels()} enabledRigs={enabledRigs()} onToggle={toggleRig} />
-                    <div class="flex flex-wrap gap-3 mt-2 text-label">
-                      <For each={props.detail!.rigs}>
-                        {(rig, index) => (
-                          <Show when={enabledRigs().includes(rig.rig_label)}>
-                            <span class="flex items-center gap-1.5">
-                              <span
-                                class="w-2 h-2 rounded-full inline-block"
-                                style={{ "background-color": rigColor(index()) }}
-                              />
-                              <span class="text-theme-text-secondary">{rig.rig_label}:</span>
-                              <span class="font-bold text-theme-text-primary">
-                                {rig.frame_count} fr · {formatIntegration(rig.integration_seconds)}
-                              </span>
-                            </span>
-                          </Show>
-                        )}
-                      </For>
-                    </div>
+                  <div class="flex flex-wrap gap-3 mt-2 text-label">
+                    <For each={props.detail!.rigs}>
+                      {(rig, index) => (
+                        <span class="flex items-center gap-1.5">
+                          <span
+                            class="w-2 h-2 rounded-full inline-block"
+                            style={{ "background-color": rigColor(index()) }}
+                          />
+                          <span class="text-theme-text-secondary">{rig.rig_label}:</span>
+                          <span class="font-bold text-theme-text-primary">
+                            {rig.frame_count} fr · {formatIntegration(rig.integration_seconds)}
+                          </span>
+                        </span>
+                      )}
+                    </For>
                   </div>
                 </Show>
 
@@ -689,12 +684,7 @@ const SessionAccordionCard: Component<{
 
                 {/* Session Metrics Chart */}
                 <div class="border-t border-theme-border/50 pt-3">
-                  <Show when={isMultiRig() && !showSummary()}>
-                    <div class="mb-2">
-                      <RigTogglePills rigs={rigLabels()} enabledRigs={enabledRigs()} onToggle={toggleRig} />
-                    </div>
-                  </Show>
-                  <SessionMetricsChart detail={detail()} enabledRigs={enabledRigs()} />
+                  <SessionMetricsChart detail={detail()} enabledRigs={enabledRigs()} onToggleRig={toggleRig} />
                 </div>
 
                 {/* Row 4: Per-Frame Table (collapsed) */}

--- a/frontend/src/components/SessionAccordionCard.tsx
+++ b/frontend/src/components/SessionAccordionCard.tsx
@@ -481,9 +481,9 @@ const SessionAccordionCard: Component<{
             {(detail) => (
               <div class="space-y-3 pt-3">
                 {/* Session Summary (collapsible) */}
-                <div>
+                <div class="bg-theme-base rounded-[var(--radius-md)]">
                   <button
-                    class="flex justify-between items-center w-full text-xs py-2 px-3 rounded-[var(--radius-md)] bg-theme-base hover:bg-theme-hover hover:text-theme-text-primary transition-colors cursor-pointer"
+                    class="flex justify-between items-center w-full text-xs py-2 px-3 hover:bg-theme-hover rounded-[var(--radius-md)] hover:text-theme-text-primary transition-colors cursor-pointer"
                     classList={{ "text-theme-text-primary": showSummary(), "text-theme-text-secondary": !showSummary() }}
                     onClick={() => setShowSummary((v) => !v)}
                   >
@@ -496,8 +496,8 @@ const SessionAccordionCard: Component<{
                       <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
                     </svg>
                   </button>
-                </div>
                 <Show when={showSummary()}>
+                <div class="px-3 pb-3">
                 {/* Single-value metrics + Astrobin export */}
                 <div class="flex flex-wrap items-center gap-x-4 gap-y-1 text-label">
                   <span>
@@ -647,13 +647,15 @@ const SessionAccordionCard: Component<{
                     </div>
                   </div>
                 </div>
+                </div>
                 </Show>
+                </div>
 
                 {/* Session Insights */}
                 <Show when={detail().insights.length > 0}>
-                  <div class="border-t border-theme-border/50 pt-3">
+                  <div class="bg-theme-base rounded-[var(--radius-md)]">
                     <button
-                      class="flex justify-between items-center w-full text-xs py-2 px-3 rounded-[var(--radius-md)] bg-theme-base hover:bg-theme-hover hover:text-theme-text-primary transition-colors cursor-pointer"
+                      class="flex justify-between items-center w-full text-xs py-2 px-3 hover:bg-theme-hover rounded-[var(--radius-md)] hover:text-theme-text-primary transition-colors cursor-pointer"
                       classList={{ "text-theme-text-primary": showInsights(), "text-theme-text-secondary": !showInsights() }}
                       onClick={() => setShowInsights((v) => !v)}
                     >
@@ -669,7 +671,7 @@ const SessionAccordionCard: Component<{
                       </svg>
                     </button>
                     <Show when={showInsights()}>
-                      <div class="bg-theme-base rounded-[var(--radius-md)] p-3 space-y-1 mt-2">
+                      <div class="px-3 pb-3 space-y-1">
                         <For each={detail().insights}>
                           {(insight) => (
                             <div class={`text-xs ${INSIGHT_STYLES[insight.level]}`}>
@@ -683,14 +685,12 @@ const SessionAccordionCard: Component<{
                 </Show>
 
                 {/* Session Metrics Chart */}
-                <div class="border-t border-theme-border/50 pt-3">
-                  <SessionMetricsChart detail={detail()} enabledRigs={enabledRigs()} onToggleRig={toggleRig} />
-                </div>
+                <SessionMetricsChart detail={detail()} enabledRigs={enabledRigs()} onToggleRig={toggleRig} />
 
                 {/* Row 4: Per-Frame Table (collapsed) */}
-                <div class="border-t border-theme-border/50 pt-3">
+                <div class="bg-theme-base rounded-[var(--radius-md)]">
                   <button
-                    class="flex justify-between items-center w-full text-xs py-2 px-3 rounded-[var(--radius-md)] bg-theme-base hover:bg-theme-hover hover:text-theme-text-primary transition-colors cursor-pointer"
+                    class="flex justify-between items-center w-full text-xs py-2 px-3 hover:bg-theme-hover rounded-[var(--radius-md)] hover:text-theme-text-primary transition-colors cursor-pointer"
                     classList={{ "text-theme-text-primary": showFrames(), "text-theme-text-secondary": !showFrames() }}
                     onClick={() => setShowFrames(!showFrames())}
                   >
@@ -706,22 +706,23 @@ const SessionAccordionCard: Component<{
                     </svg>
                   </button>
                   <Show when={showFrames()}>
+                    <div class="px-3 pb-3">
                     <Show when={isMultiRig()} fallback={
-                      <div class="bg-theme-base rounded-[var(--radius-md)] overflow-x-auto max-h-[600px] overflow-y-auto mt-2">
+                      <div class="overflow-x-auto max-h-[600px] overflow-y-auto">
                         {renderFrameTable(props.detail!.frames)}
                       </div>
                     }>
                       <For each={props.detail!.rigs}>
                         {(rig, index) => (
                           <Show when={enabledRigs().includes(rig.rig_label)}>
-                            <div class="mt-2">
+                            <div class="mt-2 first:mt-0">
                               <div class="flex items-center gap-2 mb-1">
                                 <span class="w-2 h-2 rounded-full inline-block"
                                   style={{ "background-color": rigColor(index()) }} />
                                 <span class="text-xs font-semibold text-theme-text-primary">{rig.rig_label}</span>
                                 <span class="text-tiny text-theme-text-tertiary">{rig.frame_count} frames</span>
                               </div>
-                              <div class="bg-theme-base rounded-[var(--radius-md)] overflow-x-auto max-h-[600px] overflow-y-auto">
+                              <div class="overflow-x-auto max-h-[600px] overflow-y-auto">
                                 {renderFrameTable(rig.frames)}
                               </div>
                             </div>
@@ -729,18 +730,17 @@ const SessionAccordionCard: Component<{
                         )}
                       </For>
                     </Show>
+                    </div>
                   </Show>
                 </div>
 
                 {/* Row 5: FITS Headers */}
-                <div class="border-t border-theme-border/50 pt-3">
-                  <RawHeaderAccordion headers={detail().raw_reference_header} />
-                </div>
+                <RawHeaderAccordion headers={detail().raw_reference_header} />
 
                 {/* Session Notes */}
-                <div class="border-t border-theme-border/50 pt-3">
+                <div class="bg-theme-base rounded-[var(--radius-md)]">
                   <button
-                    class="flex justify-between items-center w-full text-xs py-2 px-3 rounded-[var(--radius-md)] bg-theme-base hover:bg-theme-hover hover:text-theme-text-primary transition-colors cursor-pointer"
+                    class="flex justify-between items-center w-full text-xs py-2 px-3 hover:bg-theme-hover rounded-[var(--radius-md)] hover:text-theme-text-primary transition-colors cursor-pointer"
                     classList={{ "text-theme-text-primary": showNotes(), "text-theme-text-secondary": !showNotes() }}
                     onClick={() => setShowNotes((v) => !v)}
                   >
@@ -764,16 +764,18 @@ const SessionAccordionCard: Component<{
                     </div>
                   </button>
                   <Show when={showNotes()}>
-                    <textarea
-                      class="w-full bg-theme-elevated border border-theme-border rounded px-3 py-2 text-sm text-theme-text-primary placeholder-theme-text-secondary resize-y min-h-[50px] mt-2"
-                      placeholder="Add notes for this session..."
-                      value={sessionNote()}
-                      onInput={(e) => {
-                        const val = e.currentTarget.value;
-                        setSessionNote(val);
-                        saveSessionNote(val);
-                      }}
-                    />
+                    <div class="px-3 pb-3">
+                      <textarea
+                        class="w-full bg-theme-elevated border border-theme-border rounded px-3 py-2 text-sm text-theme-text-primary placeholder-theme-text-secondary resize-y min-h-[50px]"
+                        placeholder="Add notes for this session..."
+                        value={sessionNote()}
+                        onInput={(e) => {
+                          const val = e.currentTarget.value;
+                          setSessionNote(val);
+                          saveSessionNote(val);
+                        }}
+                      />
+                    </div>
                   </Show>
                 </div>
               </div>

--- a/frontend/src/components/SessionAccordionCard.tsx
+++ b/frontend/src/components/SessionAccordionCard.tsx
@@ -108,14 +108,39 @@ const SessionAccordionCard: Component<{
     const d = props.detail;
     if (!d) return;
     const header = "date,filter,number,duration,binning,gain,sensorCooling,fNumber,bortle,meanSqm,meanFwhm,temperature";
-    const rows = d.filter_details.map((f) => {
-      const duration = f.exposure_time ?? "";
-      const gain = d.gain !== null ? d.gain : "";
-      const sensorCooling = d.sensor_temp !== null ? Math.round(d.sensor_temp) : "";
-      const meanFwhm = d.median_fwhm !== null ? d.median_fwhm.toFixed(2) : "";
-      const temperature = d.median_ambient_temp !== null ? d.median_ambient_temp.toFixed(2) : "";
-      return `${d.session_date},,${f.frame_count},${duration},,${gain},${sensorCooling},,,,${meanFwhm},${temperature}`;
-    });
+
+    const median = (vals: number[]) => {
+      if (vals.length === 0) return null;
+      const s = [...vals].sort((a, b) => a - b);
+      const mid = Math.floor(s.length / 2);
+      return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+    };
+
+    const buildRows = (filterDetails: typeof d.filter_details, gain: number | null, sensorTemp: number | null, fwhm: number | null, ambientTemp: number | null) => {
+      return filterDetails.map((f) => {
+        const duration = f.exposure_time ?? "";
+        const g = gain !== null ? gain : "";
+        const cooling = sensorTemp !== null ? Math.round(sensorTemp) : "";
+        const mFwhm = fwhm !== null ? fwhm.toFixed(2) : "";
+        const temp = ambientTemp !== null ? ambientTemp.toFixed(2) : "";
+        return `${d.session_date},,${f.frame_count},${duration},,${g},${cooling},,,,${mFwhm},${temp}`;
+      });
+    };
+
+    let rows: string[];
+    if (isMultiRig()) {
+      rows = [];
+      for (const rig of d.rigs) {
+        if (!enabledRigs().includes(rig.rig_label)) continue;
+        const temps = rig.frames.map(f => f.sensor_temp).filter((t): t is number => t !== null);
+        const fwhms = rig.frames.map(f => f.fwhm).filter((v): v is number => v !== null);
+        const ambTemps = rig.frames.map(f => f.ambient_temp).filter((v): v is number => v !== null);
+        rows.push(...buildRows(rig.filter_details, rig.gain, median(temps), median(fwhms), median(ambTemps)));
+      }
+    } else {
+      rows = buildRows(d.filter_details, d.gain, d.sensor_temp, d.median_fwhm, d.median_ambient_temp);
+    }
+
     const csv = [header, ...rows].join("\n");
     navigator.clipboard.writeText(csv).then(() => {
       setCsvCopied(true);

--- a/frontend/src/components/SessionAccordionCard.tsx
+++ b/frontend/src/components/SessionAccordionCard.tsx
@@ -58,6 +58,7 @@ const SessionAccordionCard: Component<{
 
   const [sessionNote, setSessionNote] = createSignal(props.detail?.notes || "");
   const [showNotes, setShowNotes] = createSignal(false);
+  const [showDetails, setShowDetails] = createSignal(false);
   const [noteSaving, setNoteSaving] = createSignal(false);
   let noteTimer: ReturnType<typeof setTimeout> | undefined;
 
@@ -498,7 +499,7 @@ const SessionAccordionCard: Component<{
                   </button>
                 <Show when={showSummary()}>
                 <div class="px-3 pb-3">
-                {/* Single-value metrics + Astrobin export */}
+                {/* Headline stats row */}
                 <div class="flex flex-wrap items-center gap-x-4 gap-y-1 text-label">
                   <span>
                     <span class="text-theme-text-tertiary">Integration:</span>{" "}
@@ -512,12 +513,6 @@ const SessionAccordionCard: Component<{
                     <span class="text-theme-text-tertiary">Gain / Offset:</span>{" "}
                     <span class="font-bold text-metric-gain">
                       {detail().gain !== null ? detail().gain : "—"} / {detail().offset !== null ? detail().offset : "—"}
-                    </span>
-                  </span>
-                  <span>
-                    <span class="text-theme-text-tertiary">Exp:</span>{" "}
-                    <span class="font-bold text-metric-gain">
-                      {detail().exposure_times.length > 0 ? detail().exposure_times.map(e => e + "s").join(", ") : "—"}
                     </span>
                   </span>
                   <span>
@@ -536,117 +531,132 @@ const SessionAccordionCard: Component<{
                   </span>
                 </div>
 
-                {/* Per-rig summary (multi-rig only) */}
-                <Show when={isMultiRig()}>
-                  <div class="flex flex-wrap gap-3 mt-2 text-label">
-                    <For each={props.detail!.rigs}>
-                      {(rig, index) => (
-                        <span class="flex items-center gap-1.5">
-                          <span
-                            class="w-2 h-2 rounded-full inline-block"
-                            style={{ "background-color": rigColor(index()) }}
-                          />
-                          <span class="text-theme-text-secondary">{rig.rig_label}:</span>
-                          <span class="font-bold text-theme-text-primary">
-                            {rig.frame_count} fr · {formatIntegration(rig.integration_seconds)}
-                          </span>
-                        </span>
-                      )}
-                    </For>
-                  </div>
-                </Show>
-
-                {/* Metrics table + thumbnail */}
-                <div class="grid gap-4 grid-cols-1 md:grid-cols-[1fr_200px]">
-                  <div class="bg-theme-base rounded-[var(--radius-md)] overflow-x-auto">
-                    <table class="w-full text-xs table-fixed" style={{ "border-collapse": "collapse" }}>
-                      <colgroup>
-                        <col style={{ width: "100px" }} />
-                        <col style={{ width: "70px" }} />
-                        <col style={{ width: "70px" }} />
-                        <col style={{ width: "70px" }} />
-                        <col style={{ width: "28px" }} />
-                        <col style={{ width: "80px" }} />
-                        <col style={{ width: "50px" }} />
-                        <col style={{ width: "50px" }} />
-                        <col style={{ width: "50px" }} />
-                      </colgroup>
-                      <thead>
-                        <tr class="text-tiny text-theme-text-tertiary uppercase tracking-wider border-b border-theme-border">
-                          <th class="text-left px-3 pb-1.5 pt-2.5" colspan={4}>Metrics</th>
-                          <th class="text-left px-2 pb-1.5 pt-2.5 border-l border-theme-border" colspan={5}>Filters</th>
-                        </tr>
-                        <tr class="text-tiny text-theme-text-tertiary border-b border-theme-border">
-                          <th class="px-3 pb-1 text-left"></th>
-                          <th class="px-2 pb-1 text-right">Avg</th>
-                          <th class="px-2 pb-1 text-right">Min</th>
-                          <th class="px-2 pb-1 text-right">Max</th>
-                          <th class="px-2 pb-1 border-l border-theme-border"></th>
-                          <th class="px-2 pb-1 text-left">Frames</th>
-                          <th class="px-2 pb-1 text-right">Med. HFR</th>
-                          <th class="px-2 pb-1 text-right">Med. Ecc</th>
-                          <th class="px-2 pb-1 text-right">Exp</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {(() => {
-                          const metrics = [
-                            { label: "HFR", avg: detail().median_hfr?.toFixed(2) ?? "—", min: detail().min_hfr?.toFixed(2) ?? "—", max: detail().max_hfr?.toFixed(2) ?? "—", color: "text-metric-hfr" },
-                            { label: "Eccentricity", avg: detail().median_eccentricity?.toFixed(2) ?? "—", min: detail().min_eccentricity?.toFixed(2) ?? "—", max: detail().max_eccentricity?.toFixed(2) ?? "—", color: "text-metric-eccentricity" },
-                            { label: "FWHM", avg: detail().median_fwhm?.toFixed(2) ?? "—", min: detail().min_fwhm?.toFixed(2) ?? "—", max: detail().max_fwhm?.toFixed(2) ?? "—", color: "text-metric-fwhm" },
-                            { label: "Sensor Temp", avg: detail().sensor_temp !== null ? `${detail().sensor_temp?.toFixed(0)}°C` : "—", min: detail().sensor_temp_min !== null ? `${detail().sensor_temp_min?.toFixed(0)}°C` : "—", max: detail().sensor_temp_max !== null ? `${detail().sensor_temp_max?.toFixed(0)}°C` : "—", color: "text-metric-temp" },
-                            { label: "Guide RMS", avg: detail().median_guiding_rms !== null ? `${detail().median_guiding_rms?.toFixed(2)}"` : "—", min: detail().min_guiding_rms !== null ? `${detail().min_guiding_rms?.toFixed(2)}"` : "—", max: detail().max_guiding_rms !== null ? `${detail().max_guiding_rms?.toFixed(2)}"` : "—", color: "text-metric-guiding" },
-                          ];
-                          const filters = detail().filter_details;
-                          const maxRows = Math.max(metrics.length, filters.length);
-                          const rows = [];
-                          for (let i = 0; i < maxRows; i++) {
-                            const m = metrics[i];
-                            const f = filters[i];
-                            rows.push(
-                              <tr class="border-b border-theme-border hover:bg-theme-hover transition-colors duration-100">
-                                {m ? (
-                                  <>
-                                    <td class={`py-1.5 px-3 text-theme-text-secondary`}>{m.label}</td>
-                                    <td class={`py-1.5 px-2 text-right font-bold ${m.color}`}>{m.avg}</td>
-                                    <td class="py-1.5 px-2 text-right text-theme-text-tertiary">{m.min}</td>
-                                    <td class="py-1.5 px-2 text-right text-theme-text-tertiary">{m.max}</td>
-                                  </>
-                                ) : (
-                                  <>
-                                    <td class="py-1.5 px-3"></td>
-                                    <td class="py-1.5 px-2"></td>
-                                    <td class="py-1.5 px-2"></td>
-                                    <td class="py-1.5 px-2"></td>
-                                  </>
-                                )}
-                                {f ? (
-                                  <>
-                                    <td class="py-1.5 px-2 font-bold text-theme-text-primary border-l border-theme-border">{f.filter_name}</td>
-                                    <td class="py-1.5 px-2 text-theme-text-secondary">{f.frame_count} · {formatIntegration(f.integration_seconds)}</td>
-                                    <td class="py-1.5 px-2 text-right text-metric-hfr">{f.median_hfr?.toFixed(1) ?? "—"}</td>
-                                    <td class="py-1.5 px-2 text-right text-metric-eccentricity">{f.median_eccentricity?.toFixed(2) ?? "—"}</td>
-                                    <td class="py-1.5 px-2 text-right text-theme-text-secondary">{f.exposure_time ?? "—"}s</td>
-                                  </>
-                                ) : (
-                                  <>
-                                    <td class="py-1.5 border-l border-theme-border" colspan={5}></td>
-                                  </>
-                                )}
-                              </tr>
-                            );
-                          }
-                          return rows;
-                        })()}
-                      </tbody>
-                    </table>
-                  </div>
-                  <div class="relative h-[150px] md:h-auto">
-                    <div class="absolute inset-0 overflow-hidden">
+                {/* Per-rig overview with thumbnails */}
+                <Show when={isMultiRig()} fallback={
+                  /* Single-rig: compact one-liner + thumbnail */
+                  <div class="flex gap-3 mt-3 items-start">
+                    <div class="flex-1 space-y-1">
+                      <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-label">
+                        <span><span class="text-theme-text-tertiary">Exp:</span> <span class="font-bold text-metric-gain">{detail().exposure_times.length > 0 ? detail().exposure_times.map(e => e + "s").join(", ") : "—"}</span></span>
+                        <span><span class="text-theme-text-tertiary">HFR:</span> <span class="font-bold text-metric-hfr">{detail().median_hfr?.toFixed(2) ?? "—"}</span></span>
+                        <span><span class="text-theme-text-tertiary">Ecc:</span> <span class="font-bold text-metric-eccentricity">{detail().median_eccentricity?.toFixed(2) ?? "—"}</span></span>
+                        <span><span class="text-theme-text-tertiary">FWHM:</span> <span class="font-bold text-metric-fwhm">{detail().median_fwhm?.toFixed(2) ?? "—"}</span></span>
+                        <span><span class="text-theme-text-tertiary">RMS:</span> <span class="font-bold text-metric-guiding">{detail().median_guiding_rms !== null ? `${detail().median_guiding_rms?.toFixed(2)}"` : "—"}</span></span>
+                      </div>
+                      <div class="flex flex-wrap gap-1.5">
+                        <For each={detail().filter_details}>
+                          {(f) => (
+                            <span class="text-tiny px-1.5 py-0.5 rounded bg-theme-hover text-theme-text-secondary">
+                              <b>{f.filter_name}</b> {f.frame_count} · {f.exposure_time ?? "—"}s
+                            </span>
+                          )}
+                        </For>
+                      </div>
+                    </div>
+                    <div class="w-[140px] h-[100px] flex-shrink-0 rounded overflow-hidden">
                       <ReferenceThumbnail url={detail().thumbnail_url} fill />
                     </div>
                   </div>
-                </div>
+                }>
+                  {/* Multi-rig: per-rig rows with key metrics + thumbnail */}
+                  <For each={detail().rigs}>
+                    {(rig, index) => (
+                      <div class="flex gap-3 mt-3 items-start">
+                        <div class="flex-1">
+                          <div class="flex items-center gap-2 mb-1">
+                            <span class="w-2 h-2 rounded-full inline-block flex-shrink-0" style={{ "background-color": rigColor(index()) }} />
+                            <span class="text-xs font-semibold text-theme-text-primary">{rig.rig_label}</span>
+                            <span class="text-tiny text-theme-text-tertiary">{rig.frame_count} fr · {formatIntegration(rig.integration_seconds)}</span>
+                          </div>
+                          <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-label ml-4">
+                            <span><span class="text-theme-text-tertiary">HFR:</span> <span class="font-bold text-metric-hfr">{rig.median_hfr?.toFixed(2) ?? "—"}</span></span>
+                            <span><span class="text-theme-text-tertiary">Ecc:</span> <span class="font-bold text-metric-eccentricity">{rig.median_eccentricity?.toFixed(2) ?? "—"}</span></span>
+                            <span><span class="text-theme-text-tertiary">FWHM:</span> <span class="font-bold text-metric-fwhm">{rig.median_fwhm?.toFixed(2) ?? "—"}</span></span>
+                            <span><span class="text-theme-text-tertiary">RMS:</span> <span class="font-bold text-metric-guiding">{rig.median_guiding_rms !== null ? `${rig.median_guiding_rms?.toFixed(2)}"` : "—"}</span></span>
+                          </div>
+                          <div class="flex flex-wrap gap-1.5 mt-1 ml-4">
+                            <For each={rig.filter_details}>
+                              {(f) => (
+                                <span class="text-tiny px-1.5 py-0.5 rounded bg-theme-hover text-theme-text-secondary">
+                                  <b>{f.filter_name}</b> {f.frame_count} · {f.exposure_time ?? "—"}s
+                                </span>
+                              )}
+                            </For>
+                          </div>
+                        </div>
+                        <div class="w-[140px] h-[100px] flex-shrink-0 rounded overflow-hidden">
+                          <ReferenceThumbnail url={rig.thumbnail_url ?? null} fill />
+                        </div>
+                      </div>
+                    )}
+                  </For>
+                </Show>
+
+                {/* Expandable detail table */}
+                <Show when={showDetails()}>
+                  <div class="mt-3 overflow-x-auto">
+                    <table class="w-full text-xs" style={{ "border-collapse": "collapse" }}>
+                      <thead>
+                        <tr class="text-tiny text-theme-text-tertiary uppercase tracking-wider border-b border-theme-border">
+                          <Show when={isMultiRig()}><th class="text-left px-2 pb-1.5 pt-2.5">Rig</th></Show>
+                          <th class="text-left px-2 pb-1.5 pt-2.5">Filter</th>
+                          <th class="text-right px-2 pb-1.5 pt-2.5">Frames</th>
+                          <th class="text-right px-2 pb-1.5 pt-2.5">Integration</th>
+                          <th class="text-right px-2 pb-1.5 pt-2.5">HFR</th>
+                          <th class="text-right px-2 pb-1.5 pt-2.5">Ecc</th>
+                          <th class="text-right px-2 pb-1.5 pt-2.5">Exp</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <Show when={isMultiRig()} fallback={
+                          <For each={detail().filter_details}>
+                            {(f) => (
+                              <tr class="border-b border-theme-border/50 hover:bg-theme-hover transition-colors duration-100">
+                                <td class="py-1.5 px-2 font-bold text-theme-text-primary">{f.filter_name}</td>
+                                <td class="py-1.5 px-2 text-right text-theme-text-primary">{f.frame_count}</td>
+                                <td class="py-1.5 px-2 text-right text-theme-text-secondary">{formatIntegration(f.integration_seconds)}</td>
+                                <td class="py-1.5 px-2 text-right text-metric-hfr">{f.median_hfr?.toFixed(2) ?? "—"}</td>
+                                <td class="py-1.5 px-2 text-right text-metric-eccentricity">{f.median_eccentricity?.toFixed(2) ?? "—"}</td>
+                                <td class="py-1.5 px-2 text-right text-theme-text-secondary">{f.exposure_time ?? "—"}s</td>
+                              </tr>
+                            )}
+                          </For>
+                        }>
+                          <For each={detail().rigs}>
+                            {(rig, index) => (
+                              <For each={rig.filter_details}>
+                                {(f, fi) => (
+                                  <tr class={`border-b border-theme-border/50 hover:bg-theme-hover transition-colors duration-100 ${fi() === 0 && index() > 0 ? "border-t-2 border-t-theme-border" : ""}`}>
+                                    {fi() === 0 ? (
+                                      <td class="py-1.5 px-2 text-theme-text-secondary align-top" rowSpan={rig.filter_details.length}>
+                                        <span class="flex items-center gap-1.5">
+                                          <span class="w-2 h-2 rounded-full inline-block flex-shrink-0" style={{ "background-color": rigColor(index()) }} />
+                                          <span class="text-tiny">{rig.telescope ?? ""}</span>
+                                        </span>
+                                      </td>
+                                    ) : null}
+                                    <td class="py-1.5 px-2 font-bold text-theme-text-primary">{f.filter_name}</td>
+                                    <td class="py-1.5 px-2 text-right text-theme-text-primary">{f.frame_count}</td>
+                                    <td class="py-1.5 px-2 text-right text-theme-text-secondary">{formatIntegration(f.integration_seconds)}</td>
+                                    <td class="py-1.5 px-2 text-right text-metric-hfr">{f.median_hfr?.toFixed(2) ?? "—"}</td>
+                                    <td class="py-1.5 px-2 text-right text-metric-eccentricity">{f.median_eccentricity?.toFixed(2) ?? "—"}</td>
+                                    <td class="py-1.5 px-2 text-right text-theme-text-secondary">{f.exposure_time ?? "—"}s</td>
+                                  </tr>
+                                )}
+                              </For>
+                            )}
+                          </For>
+                        </Show>
+                      </tbody>
+                    </table>
+                  </div>
+                </Show>
+                <button
+                  class="text-label text-theme-accent hover:text-theme-text-primary transition-colors cursor-pointer mt-2"
+                  onClick={() => setShowDetails((v) => !v)}
+                >
+                  {showDetails() ? "▾ Hide Details" : "▸ Show Details"}
+                </button>
                 </div>
                 </Show>
                 </div>

--- a/frontend/src/components/SessionAccordionCard.tsx
+++ b/frontend/src/components/SessionAccordionCard.tsx
@@ -54,7 +54,7 @@ const SessionAccordionCard: Component<{
   const [showFrames, setShowFrames] = createSignal(false);
   const [sortColumn, setSortColumn] = createSignal<keyof FrameRecord>("timestamp");
   const [sortAsc, setSortAsc] = createSignal(true);
-  const [csvCopied, setCsvCopied] = createSignal(false);
+  const [csvCopiedRig, setCsvCopiedRig] = createSignal<string | null>(null);
 
   const [sessionNote, setSessionNote] = createSignal(props.detail?.notes || "");
   const [showNotes, setShowNotes] = createSignal(false);
@@ -105,7 +105,7 @@ const SessionAccordionCard: Component<{
     }, 1000);
   };
 
-  const copyAstrobinCsv = () => {
+  const copyAstrobinCsv = (rigLabel?: string) => {
     const d = props.detail;
     if (!d) return;
     const header = "date,filter,number,duration,binning,gain,sensorCooling,fNumber,bortle,meanSqm,meanFwhm,temperature";
@@ -129,23 +129,21 @@ const SessionAccordionCard: Component<{
     };
 
     let rows: string[];
-    if (isMultiRig()) {
-      rows = [];
-      for (const rig of d.rigs) {
-        if (!enabledRigs().includes(rig.rig_label)) continue;
-        const temps = rig.frames.map(f => f.sensor_temp).filter((t): t is number => t !== null);
-        const fwhms = rig.frames.map(f => f.fwhm).filter((v): v is number => v !== null);
-        const ambTemps = rig.frames.map(f => f.ambient_temp).filter((v): v is number => v !== null);
-        rows.push(...buildRows(rig.filter_details, rig.gain, median(temps), median(fwhms), median(ambTemps)));
-      }
+    const targetRig = rigLabel ? d.rigs.find(r => r.rig_label === rigLabel) : null;
+    if (targetRig) {
+      const temps = targetRig.frames.map(f => f.sensor_temp).filter((t): t is number => t !== null);
+      const fwhms = targetRig.frames.map(f => f.fwhm).filter((v): v is number => v !== null);
+      const ambTemps = targetRig.frames.map(f => f.ambient_temp).filter((v): v is number => v !== null);
+      rows = buildRows(targetRig.filter_details, targetRig.gain, median(temps), median(fwhms), median(ambTemps));
     } else {
       rows = buildRows(d.filter_details, d.gain, d.sensor_temp, d.median_fwhm, d.median_ambient_temp);
     }
 
     const csv = [header, ...rows].join("\n");
+    const key = rigLabel ?? "__all__";
     navigator.clipboard.writeText(csv).then(() => {
-      setCsvCopied(true);
-      setTimeout(() => setCsvCopied(false), 2000);
+      setCsvCopiedRig(key);
+      setTimeout(() => setCsvCopiedRig(null), 2000);
     });
   };
 
@@ -521,14 +519,6 @@ const SessionAccordionCard: Component<{
                       {detail().first_frame_time ? `${formatTimeUtil(detail().first_frame_time!, settingsCtx.timezone())} → ${detail().last_frame_time ? formatTimeUtil(detail().last_frame_time!, settingsCtx.timezone()) : ""}` : "—"}
                     </span>
                   </span>
-                  <span class="ml-auto">
-                    <button
-                      class="text-label px-2.5 py-1 border border-theme-border-em rounded text-theme-text-secondary hover:text-theme-text-primary hover:border-theme-accent transition-colors cursor-pointer"
-                      onClick={copyAstrobinCsv}
-                    >
-                      {csvCopied() ? "Copied!" : "Copy Astrobin CSV"}
-                    </button>
-                  </span>
                 </div>
 
                 {/* Per-rig overview with thumbnails */}
@@ -542,6 +532,12 @@ const SessionAccordionCard: Component<{
                         <span><span class="text-theme-text-tertiary">Ecc:</span> <span class="font-bold text-metric-eccentricity">{detail().median_eccentricity?.toFixed(2) ?? "—"}</span></span>
                         <span><span class="text-theme-text-tertiary">FWHM:</span> <span class="font-bold text-metric-fwhm">{detail().median_fwhm?.toFixed(2) ?? "—"}</span></span>
                         <span><span class="text-theme-text-tertiary">RMS:</span> <span class="font-bold text-metric-guiding">{detail().median_guiding_rms !== null ? `${detail().median_guiding_rms?.toFixed(2)}"` : "—"}</span></span>
+                        <button
+                          class="text-tiny px-1.5 py-0.5 border border-theme-border rounded text-theme-text-tertiary hover:text-theme-text-primary hover:border-theme-accent transition-colors cursor-pointer"
+                          onClick={() => copyAstrobinCsv()}
+                        >
+                          {csvCopiedRig() === "__all__" ? "Copied!" : "Astrobin CSV"}
+                        </button>
                       </div>
                       <div class="flex flex-wrap gap-1.5">
                         <For each={detail().filter_details}>
@@ -567,6 +563,12 @@ const SessionAccordionCard: Component<{
                             <span class="w-2 h-2 rounded-full inline-block flex-shrink-0" style={{ "background-color": rigColor(index()) }} />
                             <span class="text-xs font-semibold text-theme-text-primary">{rig.rig_label}</span>
                             <span class="text-tiny text-theme-text-tertiary">{rig.frame_count} fr · {formatIntegration(rig.integration_seconds)}</span>
+                            <button
+                              class="text-tiny px-1.5 py-0.5 border border-theme-border rounded text-theme-text-tertiary hover:text-theme-text-primary hover:border-theme-accent transition-colors cursor-pointer"
+                              onClick={() => copyAstrobinCsv(rig.rig_label)}
+                            >
+                              {csvCopiedRig() === rig.rig_label ? "Copied!" : "Astrobin CSV"}
+                            </button>
                           </div>
                           <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-label ml-4">
                             <span><span class="text-theme-text-tertiary">HFR:</span> <span class="font-bold text-metric-hfr">{rig.median_hfr?.toFixed(2) ?? "—"}</span></span>

--- a/frontend/src/components/SessionAccordionCard.tsx
+++ b/frontend/src/components/SessionAccordionCard.tsx
@@ -483,7 +483,7 @@ const SessionAccordionCard: Component<{
                 {/* Session Summary (collapsible) */}
                 <div>
                   <button
-                    class="flex justify-between items-center w-full text-xs py-2 px-0 hover:text-theme-text-primary transition-colors cursor-pointer"
+                    class="flex justify-between items-center w-full text-xs py-2 px-3 rounded-[var(--radius-md)] bg-theme-base hover:bg-theme-hover hover:text-theme-text-primary transition-colors cursor-pointer"
                     classList={{ "text-theme-text-primary": showSummary(), "text-theme-text-secondary": !showSummary() }}
                     onClick={() => setShowSummary((v) => !v)}
                   >
@@ -653,7 +653,7 @@ const SessionAccordionCard: Component<{
                 <Show when={detail().insights.length > 0}>
                   <div class="border-t border-theme-border/50 pt-3">
                     <button
-                      class="flex justify-between items-center w-full text-xs py-2 px-0 hover:text-theme-text-primary transition-colors cursor-pointer"
+                      class="flex justify-between items-center w-full text-xs py-2 px-3 rounded-[var(--radius-md)] bg-theme-base hover:bg-theme-hover hover:text-theme-text-primary transition-colors cursor-pointer"
                       classList={{ "text-theme-text-primary": showInsights(), "text-theme-text-secondary": !showInsights() }}
                       onClick={() => setShowInsights((v) => !v)}
                     >
@@ -690,7 +690,7 @@ const SessionAccordionCard: Component<{
                 {/* Row 4: Per-Frame Table (collapsed) */}
                 <div class="border-t border-theme-border/50 pt-3">
                   <button
-                    class="flex justify-between items-center w-full text-xs py-2 px-0 hover:text-theme-text-primary transition-colors cursor-pointer"
+                    class="flex justify-between items-center w-full text-xs py-2 px-3 rounded-[var(--radius-md)] bg-theme-base hover:bg-theme-hover hover:text-theme-text-primary transition-colors cursor-pointer"
                     classList={{ "text-theme-text-primary": showFrames(), "text-theme-text-secondary": !showFrames() }}
                     onClick={() => setShowFrames(!showFrames())}
                   >
@@ -740,7 +740,7 @@ const SessionAccordionCard: Component<{
                 {/* Session Notes */}
                 <div class="border-t border-theme-border/50 pt-3">
                   <button
-                    class="flex justify-between items-center w-full text-xs py-2 px-0 hover:text-theme-text-primary transition-colors cursor-pointer"
+                    class="flex justify-between items-center w-full text-xs py-2 px-3 rounded-[var(--radius-md)] bg-theme-base hover:bg-theme-hover hover:text-theme-text-primary transition-colors cursor-pointer"
                     classList={{ "text-theme-text-primary": showNotes(), "text-theme-text-secondary": !showNotes() }}
                     onClick={() => setShowNotes((v) => !v)}
                   >

--- a/frontend/src/components/SessionAccordionCard.tsx
+++ b/frontend/src/components/SessionAccordionCard.tsx
@@ -664,7 +664,12 @@ const SessionAccordionCard: Component<{
 
                 {/* Session Metrics Chart */}
                 <div class="border-t border-theme-border/50 pt-3">
-                  <SessionMetricsChart detail={detail()} />
+                  <Show when={isMultiRig() && !showSummary()}>
+                    <div class="mb-2">
+                      <RigTogglePills rigs={rigLabels()} enabledRigs={enabledRigs()} onToggle={toggleRig} />
+                    </div>
+                  </Show>
+                  <SessionMetricsChart detail={detail()} enabledRigs={enabledRigs()} />
                 </div>
 
                 {/* Row 4: Per-Frame Table (collapsed) */}

--- a/frontend/src/components/SessionAccordionCard.tsx
+++ b/frontend/src/components/SessionAccordionCard.tsx
@@ -177,12 +177,23 @@ const SessionAccordionCard: Component<{
     }
   };
 
-  const isOutlier = (frame: FrameRecord): boolean => {
-    if (!props.detail?.median_hfr || !frame.median_hfr) return false;
-    return frame.median_hfr > props.detail.median_hfr * 1.5;
+  const isHfrOutlier = (frame: FrameRecord, medianHfr?: number | null): boolean => {
+    const med = medianHfr ?? props.detail?.median_hfr;
+    if (!med || !frame.median_hfr) return false;
+    return frame.median_hfr > med * 1.5;
   };
 
-  const renderFrameTable = (frames: FrameRecord[]) => (
+  const isEccOutlier = (frame: FrameRecord, medianEcc?: number | null): boolean => {
+    const med = medianEcc ?? props.detail?.median_eccentricity;
+    if (!med || !frame.eccentricity) return false;
+    return frame.eccentricity > med * 1.5;
+  };
+
+  const isOutlier = (frame: FrameRecord, medianHfr?: number | null, medianEcc?: number | null): boolean => {
+    return isHfrOutlier(frame, medianHfr) || isEccOutlier(frame, medianEcc);
+  };
+
+  const renderFrameTable = (frames: FrameRecord[], medianHfr?: number | null, medianEcc?: number | null) => (
     <table class="w-full text-label">
       <thead class="sticky top-0 bg-theme-base">
         <tr class="text-theme-text-secondary border-b border-theme-border">
@@ -275,17 +286,17 @@ const SessionAccordionCard: Component<{
       <tbody>
         <For each={sortedFrames(frames)}>
           {(frame) => (
-            <tr class={`border-b border-theme-border/30 hover:bg-theme-hover transition-colors duration-100 ${isOutlier(frame) ? "bg-theme-error/20" : ""}`}>
+            <tr class={`border-b border-theme-border/30 hover:bg-theme-hover transition-colors duration-100 ${isOutlier(frame, medianHfr, medianEcc) ? "bg-theme-error/20" : ""}`}>
               <td class="py-1 px-2 text-theme-text-primary">{formatTimeUtil(frame.timestamp, settingsCtx.timezone())}</td>
               <td class="py-1 px-2 text-theme-text-primary text-center">{frame.filter_used ?? "—"}</td>
               <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.exposure_time ?? "—"}s</td>
               <Show when={visible("quality", "hfr")}>
-                <td class={`py-1 px-2 text-right tabular-nums ${isOutlier(frame) ? "text-theme-error font-bold" : "text-theme-text-primary"}`}>
+                <td class={`py-1 px-2 text-right tabular-nums ${isHfrOutlier(frame, medianHfr) ? "text-theme-error font-bold" : "text-theme-text-primary"}`}>
                   {frame.median_hfr?.toFixed(2) ?? "\u2014"}
                 </td>
               </Show>
               <Show when={visible("quality", "eccentricity")}>
-                <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.eccentricity?.toFixed(2) ?? "\u2014"}</td>
+                <td class={`py-1 px-2 text-right tabular-nums ${isEccOutlier(frame, medianEcc) ? "text-theme-error font-bold" : "text-theme-text-primary"}`}>{frame.eccentricity?.toFixed(2) ?? "\u2014"}</td>
               </Show>
               <Show when={visible("quality", "fwhm")}>
                 <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.fwhm?.toFixed(2) ?? "\u2014"}</td>
@@ -549,7 +560,7 @@ const SessionAccordionCard: Component<{
                         </For>
                       </div>
                     </div>
-                    <div class="w-[140px] h-[100px] flex-shrink-0 rounded overflow-hidden">
+                    <div class="w-[140px] h-[100px] flex-shrink-0 ml-auto rounded overflow-hidden">
                       <ReferenceThumbnail url={detail().thumbnail_url} fill />
                     </div>
                   </div>
@@ -586,7 +597,7 @@ const SessionAccordionCard: Component<{
                             </For>
                           </div>
                         </div>
-                        <div class="w-[140px] h-[100px] flex-shrink-0 rounded overflow-hidden">
+                        <div class="w-[140px] h-[100px] flex-shrink-0 ml-auto rounded overflow-hidden">
                           <ReferenceThumbnail url={rig.thumbnail_url ?? null} fill />
                         </div>
                       </div>
@@ -721,7 +732,7 @@ const SessionAccordionCard: Component<{
                     <div class="px-3 pb-3">
                     <Show when={isMultiRig()} fallback={
                       <div class="overflow-x-auto max-h-[600px] overflow-y-auto">
-                        {renderFrameTable(props.detail!.frames)}
+                        {renderFrameTable(props.detail!.frames, props.detail!.median_hfr, props.detail!.median_eccentricity)}
                       </div>
                     }>
                       <For each={props.detail!.rigs}>
@@ -735,7 +746,7 @@ const SessionAccordionCard: Component<{
                                 <span class="text-tiny text-theme-text-tertiary">{rig.frame_count} frames</span>
                               </div>
                               <div class="overflow-x-auto max-h-[600px] overflow-y-auto">
-                                {renderFrameTable(rig.frames)}
+                                {renderFrameTable(rig.frames, rig.median_hfr, rig.median_eccentricity)}
                               </div>
                             </div>
                           </Show>

--- a/frontend/src/components/SessionMetricsChart.tsx
+++ b/frontend/src/components/SessionMetricsChart.tsx
@@ -220,7 +220,7 @@ export default function SessionMetricsChart(props: Props) {
   return (
     <div>
       <button
-        class="flex justify-between items-center w-full text-xs py-2 px-0 hover:text-theme-text-primary transition-colors cursor-pointer"
+        class="flex justify-between items-center w-full text-xs py-2 px-3 rounded-[var(--radius-md)] bg-theme-base hover:bg-theme-hover hover:text-theme-text-primary transition-colors cursor-pointer"
         classList={{ "text-theme-text-primary": expanded(), "text-theme-text-secondary": !expanded() }}
         onClick={toggleExpanded}
       >

--- a/frontend/src/components/SessionMetricsChart.tsx
+++ b/frontend/src/components/SessionMetricsChart.tsx
@@ -6,11 +6,13 @@ import { formatTime } from "../utils/dateTime";
 import { METRIC_DEFINITIONS, getMetricColor, getMetricDef, chartFontSize } from "../utils/chartConfig";
 import MetricTogglePills from "./MetricTogglePills";
 import FilterTogglePills from "./FilterTogglePills";
+import { rigColor } from "./RigTogglePills";
 
 Chart.register(LineController, CategoryScale, LinearScale, PointElement, LineElement, Tooltip);
 
 interface Props {
   detail: SessionDetail;
+  enabledRigs?: string[];
 }
 
 export default function SessionMetricsChart(props: Props) {
@@ -26,10 +28,13 @@ export default function SessionMetricsChart(props: Props) {
   const buildDatasets = () => {
     const enabledMetrics = graphSettings().enabled_metrics;
     const enabledFilters = graphSettings().enabled_filters;
-    const frames = [...props.detail.frames].sort(
+    const rigs = props.detail.rigs ?? [];
+    const multiRig = rigs.length > 1 && props.enabledRigs && props.enabledRigs.length > 0;
+
+    const allFrames = [...props.detail.frames].sort(
       (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
     );
-    const labels = frames.map((f) => {
+    const labels = allFrames.map((f) => {
       const d = new Date(f.timestamp);
       return formatTime(d, settingsCtx.timezone());
     });
@@ -39,41 +44,88 @@ export default function SessionMetricsChart(props: Props) {
     for (const metricKey of enabledMetrics) {
       const def = getMetricDef(metricKey);
       if (!def) continue;
-      const color = getMetricColor(def.colorVar);
       const field = def.frameField as keyof FrameRecord;
 
-      if (enabledFilters.includes("overall")) {
-        datasets.push({
-          label: def.label,
-          data: frames.map((f) => (f[field] as number | null) ?? null),
-          borderColor: color,
-          backgroundColor: `${color}33`,
-          borderWidth: 1.5,
-          pointRadius: 0,
-          pointHitRadius: 8,
-          tension: 0.3,
-          spanGaps: true,
-          yAxisID: def.yAxisId,
-        });
-      }
+      if (multiRig) {
+        for (let ri = 0; ri < rigs.length; ri++) {
+          const rig = rigs[ri];
+          if (!props.enabledRigs!.includes(rig.rig_label)) continue;
+          const color = rigColor(ri);
 
-      for (const filterName of enabledFilters) {
-        if (filterName === "overall") continue;
-        datasets.push({
-          label: `${def.label} (${filterName})`,
-          data: frames.map((f) =>
-            f.filter_used === filterName ? ((f[field] as number | null) ?? null) : null
-          ),
-          borderColor: color,
-          backgroundColor: `${color}33`,
-          borderWidth: 1.5,
-          pointRadius: 0,
-          pointHitRadius: 8,
-          tension: 0.3,
-          spanGaps: false,
-          yAxisID: def.yAxisId,
-          borderDash: [4, 2],
-        });
+          if (enabledFilters.includes("overall")) {
+            datasets.push({
+              label: `${def.label} (${rig.rig_label})`,
+              data: allFrames.map((f) =>
+                f.rig === rig.rig_label ? ((f[field] as number | null) ?? null) : null
+              ),
+              borderColor: color,
+              backgroundColor: `${color}33`,
+              borderWidth: 1.5,
+              pointRadius: 0,
+              pointHitRadius: 8,
+              tension: 0.3,
+              spanGaps: true,
+              yAxisID: def.yAxisId,
+            });
+          }
+
+          for (const filterName of enabledFilters) {
+            if (filterName === "overall") continue;
+            datasets.push({
+              label: `${def.label} (${rig.rig_label} / ${filterName})`,
+              data: allFrames.map((f) =>
+                f.rig === rig.rig_label && f.filter_used === filterName
+                  ? ((f[field] as number | null) ?? null)
+                  : null
+              ),
+              borderColor: color,
+              backgroundColor: `${color}33`,
+              borderWidth: 1.5,
+              pointRadius: 0,
+              pointHitRadius: 8,
+              tension: 0.3,
+              spanGaps: false,
+              yAxisID: def.yAxisId,
+              borderDash: [4, 2],
+            });
+          }
+        }
+      } else {
+        const color = getMetricColor(def.colorVar);
+
+        if (enabledFilters.includes("overall")) {
+          datasets.push({
+            label: def.label,
+            data: allFrames.map((f) => (f[field] as number | null) ?? null),
+            borderColor: color,
+            backgroundColor: `${color}33`,
+            borderWidth: 1.5,
+            pointRadius: 0,
+            pointHitRadius: 8,
+            tension: 0.3,
+            spanGaps: true,
+            yAxisID: def.yAxisId,
+          });
+        }
+
+        for (const filterName of enabledFilters) {
+          if (filterName === "overall") continue;
+          datasets.push({
+            label: `${def.label} (${filterName})`,
+            data: allFrames.map((f) =>
+              f.filter_used === filterName ? ((f[field] as number | null) ?? null) : null
+            ),
+            borderColor: color,
+            backgroundColor: `${color}33`,
+            borderWidth: 1.5,
+            pointRadius: 0,
+            pointHitRadius: 8,
+            tension: 0.3,
+            spanGaps: false,
+            yAxisID: def.yAxisId,
+            borderDash: [4, 2],
+          });
+        }
       }
     }
 
@@ -140,6 +192,7 @@ export default function SessionMetricsChart(props: Props) {
   createEffect(() => {
     // Track reactive dependencies
     graphSettings();
+    props.enabledRigs;
     if (pendingRAF !== null) cancelAnimationFrame(pendingRAF);
     if (expanded()) {
       pendingRAF = requestAnimationFrame(() => {

--- a/frontend/src/components/SessionMetricsChart.tsx
+++ b/frontend/src/components/SessionMetricsChart.tsx
@@ -196,8 +196,14 @@ export default function SessionMetricsChart(props: Props) {
     props.enabledRigs;
     if (pendingRAF !== null) cancelAnimationFrame(pendingRAF);
     if (expanded()) {
+      // Use setTimeout to ensure <Show> has mounted the canvas DOM node
       pendingRAF = requestAnimationFrame(() => {
         pendingRAF = null;
+        if (!canvasRef) {
+          // Canvas not yet in DOM — retry after next frame
+          setTimeout(() => buildChart(), 0);
+          return;
+        }
         buildChart();
       });
     }
@@ -219,8 +225,9 @@ export default function SessionMetricsChart(props: Props) {
 
   return (
     <div>
+      <div class="bg-theme-base rounded-[var(--radius-md)]">
       <button
-        class="flex justify-between items-center w-full text-xs py-2 px-3 rounded-[var(--radius-md)] bg-theme-base hover:bg-theme-hover hover:text-theme-text-primary transition-colors cursor-pointer"
+        class="flex justify-between items-center w-full text-xs py-2 px-3 hover:bg-theme-hover rounded-[var(--radius-md)] hover:text-theme-text-primary transition-colors cursor-pointer"
         classList={{ "text-theme-text-primary": expanded(), "text-theme-text-secondary": !expanded() }}
         onClick={toggleExpanded}
       >
@@ -234,7 +241,7 @@ export default function SessionMetricsChart(props: Props) {
         </svg>
       </button>
       <Show when={expanded()}>
-        <div class="border border-theme-border rounded-[var(--radius-md)] p-3 bg-theme-base mt-2">
+        <div class="p-3">
           <div class="flex justify-between items-start gap-4 mb-2">
             <div class="text-tiny text-theme-text-tertiary uppercase tracking-wider">Metrics</div>
             <MetricTogglePills />
@@ -256,6 +263,7 @@ export default function SessionMetricsChart(props: Props) {
           </div>
         </div>
       </Show>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/SessionMetricsChart.tsx
+++ b/frontend/src/components/SessionMetricsChart.tsx
@@ -6,13 +6,14 @@ import { formatTime } from "../utils/dateTime";
 import { METRIC_DEFINITIONS, getMetricColor, getMetricDef, chartFontSize } from "../utils/chartConfig";
 import MetricTogglePills from "./MetricTogglePills";
 import FilterTogglePills from "./FilterTogglePills";
-import { rigColor } from "./RigTogglePills";
+import RigTogglePills, { rigColor } from "./RigTogglePills";
 
 Chart.register(LineController, CategoryScale, LinearScale, PointElement, LineElement, Tooltip);
 
 interface Props {
   detail: SessionDetail;
   enabledRigs?: string[];
+  onToggleRig?: (rig: string) => void;
 }
 
 export default function SessionMetricsChart(props: Props) {
@@ -241,6 +242,15 @@ export default function SessionMetricsChart(props: Props) {
           <div class="mb-3">
             <FilterTogglePills filters={filters()} />
           </div>
+          <Show when={(props.detail.rigs?.length ?? 0) > 1 && props.enabledRigs && props.onToggleRig}>
+            <div class="mb-3">
+              <RigTogglePills
+                rigs={props.detail.rigs.map(r => r.rig_label)}
+                enabledRigs={props.enabledRigs!}
+                onToggle={props.onToggleRig!}
+              />
+            </div>
+          </Show>
           <div style={{ height: "200px" }}>
             <canvas ref={canvasRef} />
           </div>

--- a/frontend/src/components/SessionMetricsChart.tsx
+++ b/frontend/src/components/SessionMetricsChart.tsx
@@ -196,16 +196,26 @@ export default function SessionMetricsChart(props: Props) {
     props.enabledRigs;
     if (pendingRAF !== null) cancelAnimationFrame(pendingRAF);
     if (expanded()) {
-      // Use setTimeout to ensure <Show> has mounted the canvas DOM node
+      // <Show> unmounts the canvas when collapsed, so the old chartInstance
+      // is stale. Destroy it so a fresh chart is created on the new canvas.
+      if (chartInstance) {
+        chartInstance.destroy();
+        chartInstance = null;
+      }
       pendingRAF = requestAnimationFrame(() => {
         pendingRAF = null;
         if (!canvasRef) {
-          // Canvas not yet in DOM — retry after next frame
           setTimeout(() => buildChart(), 0);
           return;
         }
         buildChart();
       });
+    } else {
+      // Collapsed — clean up the chart instance
+      if (chartInstance) {
+        chartInstance.destroy();
+        chartInstance = null;
+      }
     }
   });
 

--- a/frontend/src/components/TargetMetricsChart.tsx
+++ b/frontend/src/components/TargetMetricsChart.tsx
@@ -6,6 +6,7 @@ import { formatTime } from "../utils/dateTime";
 import { METRIC_DEFINITIONS, getMetricColor, getMetricDef, chartFontSize } from "../utils/chartConfig";
 import MetricTogglePills from "./MetricTogglePills";
 import FilterTogglePills from "./FilterTogglePills";
+import { rigColor } from "./RigTogglePills";
 
 Chart.register(LineController, CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Filler);
 
@@ -45,6 +46,21 @@ export default function TargetMetricsChart(props: Props) {
     }
     return [...filterSet].sort();
   });
+
+  const allRigs = createMemo(() => {
+    const rigSet = new Set<string>();
+    for (const date of props.selectedDates) {
+      const detail = props.sessionDetails[date];
+      if (detail) {
+        for (const frame of detail.frames) {
+          if (frame.rig) rigSet.add(frame.rig);
+        }
+      }
+    }
+    return [...rigSet].sort();
+  });
+
+  const isMultiRig = () => allRigs().length > 1;
 
   /** Build arrays of labels + per-metric data, with gaps between sessions */
   const chartFrameData = createMemo(() => {
@@ -129,42 +145,88 @@ export default function TargetMetricsChart(props: Props) {
     for (const metricKey of enabledMetrics) {
       const def = getMetricDef(metricKey);
       if (!def) continue;
-      const color = getMetricColor(def.colorVar);
       const field = def.frameField as keyof FrameRecord;
+      const metricColor = getMetricColor(def.colorVar);
 
-      if (enabledFilters.includes("overall")) {
-        datasets.push({
-          label: def.label,
-          data: framesByIndex.map((f) => f ? ((f[field] as number | null) ?? null) : null),
-          borderColor: color,
-          backgroundColor: `${color}33`,
-          borderWidth: 1.5,
-          pointRadius: 0,
-          pointHitRadius: 8,
-          tension: 0.3,
-          spanGaps: false,
-          yAxisID: def.yAxisId,
-        });
-      }
+      if (isMultiRig()) {
+        const rigs = allRigs();
+        for (let ri = 0; ri < rigs.length; ri++) {
+          const rig = rigs[ri];
+          const color = rigColor(ri);
 
-      for (const filterName of enabledFilters) {
-        if (filterName === "overall") continue;
-        const fColor = filterColorMap()[filterName] ?? color;
-        datasets.push({
-          label: `${def.label} (${filterName})`,
-          data: framesByIndex.map((f) =>
-            f && f.filter_used === filterName ? ((f[field] as number | null) ?? null) : null
-          ),
-          borderColor: fColor,
-          backgroundColor: `${fColor}33`,
-          borderWidth: 1.5,
-          pointRadius: 0,
-          pointHitRadius: 8,
-          tension: 0.3,
-          spanGaps: false,
-          yAxisID: def.yAxisId,
-          borderDash: [4, 2],
-        });
+          if (enabledFilters.includes("overall")) {
+            datasets.push({
+              label: `${def.label} (${rig})`,
+              data: framesByIndex.map((f) =>
+                f && f.rig === rig ? ((f[field] as number | null) ?? null) : null
+              ),
+              borderColor: color,
+              backgroundColor: `${color}33`,
+              borderWidth: 1.5,
+              pointRadius: 0,
+              pointHitRadius: 8,
+              tension: 0.3,
+              spanGaps: false,
+              yAxisID: def.yAxisId,
+            });
+          }
+
+          for (const filterName of enabledFilters) {
+            if (filterName === "overall") continue;
+            datasets.push({
+              label: `${def.label} (${rig} / ${filterName})`,
+              data: framesByIndex.map((f) =>
+                f && f.rig === rig && f.filter_used === filterName
+                  ? ((f[field] as number | null) ?? null)
+                  : null
+              ),
+              borderColor: color,
+              backgroundColor: `${color}33`,
+              borderWidth: 1.5,
+              pointRadius: 0,
+              pointHitRadius: 8,
+              tension: 0.3,
+              spanGaps: false,
+              yAxisID: def.yAxisId,
+              borderDash: [4, 2],
+            });
+          }
+        }
+      } else {
+        if (enabledFilters.includes("overall")) {
+          datasets.push({
+            label: def.label,
+            data: framesByIndex.map((f) => f ? ((f[field] as number | null) ?? null) : null),
+            borderColor: metricColor,
+            backgroundColor: `${metricColor}33`,
+            borderWidth: 1.5,
+            pointRadius: 0,
+            pointHitRadius: 8,
+            tension: 0.3,
+            spanGaps: false,
+            yAxisID: def.yAxisId,
+          });
+        }
+
+        for (const filterName of enabledFilters) {
+          if (filterName === "overall") continue;
+          const fColor = filterColorMap()[filterName] ?? metricColor;
+          datasets.push({
+            label: `${def.label} (${filterName})`,
+            data: framesByIndex.map((f) =>
+              f && f.filter_used === filterName ? ((f[field] as number | null) ?? null) : null
+            ),
+            borderColor: fColor,
+            backgroundColor: `${fColor}33`,
+            borderWidth: 1.5,
+            pointRadius: 0,
+            pointHitRadius: 8,
+            tension: 0.3,
+            spanGaps: false,
+            yAxisID: def.yAxisId,
+            borderDash: [4, 2],
+          });
+        }
       }
     }
 

--- a/frontend/src/components/TargetTable.tsx
+++ b/frontend/src/components/TargetTable.tsx
@@ -1,11 +1,9 @@
-import { Component, For, createMemo, createSignal } from "solid-js";
+import { Component, For, createMemo } from "solid-js";
 import type { TargetAggregation } from "../types";
 import TargetRow from "./TargetRow";
 import { useSettingsContext } from "./SettingsProvider";
 import { timezoneLabel } from "../utils/dateTime";
-
-type SortKey = "name" | "integration" | "lastSession" | "equipment";
-type SortDir = "asc" | "desc";
+import { useDashboardFilters, type SortKey } from "./DashboardFilterProvider";
 
 function getLastSession(t: TargetAggregation): string {
   if (t.sessions.length === 0) return "";
@@ -19,58 +17,21 @@ function getDisplayName(t: TargetAggregation): string {
 const TargetTable: Component<{ targets: TargetAggregation[] }> = (props) => {
   const ctx = useSettingsContext();
   const tzLabel = () => timezoneLabel(ctx.timezone());
-  let initial: { key: SortKey; dir: SortDir } = { key: "integration", dir: "desc" };
-  try {
-    const stored = localStorage.getItem("dashboard_sort");
-    if (stored) initial = JSON.parse(stored);
-  } catch { /* ignore corrupt localStorage */ }
-
-  const [sortKey, setSortKey] = createSignal<SortKey>(initial.key);
-  const [sortDir, setSortDir] = createSignal<SortDir>(initial.dir);
-
-  const persistSort = (key: SortKey, dir: SortDir) => {
-    localStorage.setItem("dashboard_sort", JSON.stringify({ key, dir }));
-  };
-
-  const toggleSort = (key: SortKey) => {
-    if (sortKey() === key) {
-      const newDir = sortDir() === "asc" ? "desc" : "asc";
-      setSortDir(newDir);
-      persistSort(key, newDir);
-    } else {
-      const newDir = key === "name" ? "asc" : "desc";
-      setSortKey(key);
-      setSortDir(newDir);
-      persistSort(key, newDir);
-    }
-  };
+  const { sortKey, sortDir, toggleSort } = useDashboardFilters();
 
   const UNCATEGORIZED_ID = "obj:__uncategorized__";
 
+  // Client-side sort only for "equipment" (no backend support);
+  // other sort keys are handled server-side, so just pass through.
   const sortedTargets = createMemo(() => {
     const key = sortKey();
     const dir = sortDir();
+    if (key !== "equipment") return props.targets;
+
     const sorted = [...props.targets].sort((a, b) => {
-      // Pin uncategorized to bottom for non-name sorts
-      if (key !== "name") {
-        if (a.target_id === UNCATEGORIZED_ID) return 1;
-        if (b.target_id === UNCATEGORIZED_ID) return -1;
-      }
-      let cmp = 0;
-      switch (key) {
-        case "name":
-          cmp = getDisplayName(a).localeCompare(getDisplayName(b));
-          break;
-        case "integration":
-          cmp = a.total_integration_seconds - b.total_integration_seconds;
-          break;
-        case "lastSession":
-          cmp = getLastSession(a).localeCompare(getLastSession(b));
-          break;
-        case "equipment":
-          cmp = a.equipment.join(" ").localeCompare(b.equipment.join(" "));
-          break;
-      }
+      if (a.target_id === UNCATEGORIZED_ID) return 1;
+      if (b.target_id === UNCATEGORIZED_ID) return -1;
+      const cmp = a.equipment.join(" ").localeCompare(b.equipment.join(" "));
       return dir === "asc" ? cmp : -cmp;
     });
     return sorted;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -81,6 +81,7 @@ export interface SessionDetail {
   median_humidity: number | null;
   median_cloud_cover: number | null;
   notes: string | null;
+  rigs: RigDetail[];
 }
 
 // === Target Detail (Deep Dive Page) ===
@@ -108,6 +109,7 @@ export interface SessionOverview {
   median_guiding_rms_arcsec: number | null;
   filter_medians: FilterMedian[];
   has_notes: boolean;
+  rig_count: number;
 }
 
 export interface TargetDetailResponse {
@@ -137,6 +139,24 @@ export interface TargetDetailResponse {
   avg_guiding_rms_arcsec: number | null;
   avg_detected_stars: number | null;
   notes: string | null;
+}
+
+export interface RigDetail {
+  rig_label: string;
+  telescope: string | null;
+  camera: string | null;
+  frame_count: number;
+  integration_seconds: number;
+  median_hfr: number | null;
+  median_eccentricity: number | null;
+  median_fwhm: number | null;
+  median_guiding_rms: number | null;
+  median_detected_stars: number | null;
+  gain: number | null;
+  offset: number | null;
+  exposure_times: number[];
+  filter_details: FilterDetail[];
+  frames: FrameRecord[];
 }
 
 export interface FilterDetail {
@@ -187,6 +207,7 @@ export interface FrameRecord {
   wind_gust: number | null;
   cloud_cover: number | null;
   sky_quality: number | null;
+  rig: string | null;
 }
 
 // === Equipment ===

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -157,6 +157,7 @@ export interface RigDetail {
   exposure_times: number[];
   filter_details: FilterDetail[];
   frames: FrameRecord[];
+  thumbnail_url: string | null;
 }
 
 export interface FilterDetail {


### PR DESCRIPTION
**Summary**:
This PR implements per-rig data breakdown in session details, adds new charts and tables, introduces Astrobin export functionality, and includes several UI redesigns and fixes.

**Changes**:
*   Redesigned the session summary with a compact per-rig overview.
*   Introduced per-rig frame tables and rig toggles in session detail.
*   Added per-rig series and coloring to session and target-level metrics charts.
*   Implemented a `RigTogglePills` component for rig visibility control.
*   Displays a multi-rig badge in the session list collapsed row.
*   Added per-rig breakdown to the session detail API response.
*   Extended frontend interfaces and backend schemas to support rig types and details.
*   Added a per-rig Astrobin CSV export button to each rig header.
*   Scan completion now reports the number of newly discovered files.
*   Added sortable columns to the target table, with sort state persisted across sessions.
*   Made collapsible section headers visually distinct.
*   Right-justified thumbnails and highlights HFR+eccentricity outliers.
*   Fixed issues with collapsible sections, chart loading, and per-rig insights.
*   Ensures stale chart instances are destroyed when session metrics sections collapse.
*   Moved rig toggle pills into the Session Metrics chart section.
*   Improved Docker Hub image cleanup for dev RC and stable release tags.

**Impact**:
This PR affects backend API endpoints and data schemas for sessions and targets, frontend UI components including session and target displays, charts, and tables, and the CI/CD workflow for Docker image management.