### PR TITLE
Fix filter alias persistence and deduplication

### DIFF
--- a/backend/app/api/settings.py
+++ b/backend/app/api/settings.py
@@ -305,7 +305,14 @@ async def get_discovered(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(get_current_user),
 ):
-    """Return all distinct raw values from DB with frame counts for a section."""
+    """Return all distinct values from DB with frame counts for a section.
+
+    For filters/cameras/telescopes, raw DB values are normalized through
+    the user-configured alias maps so that e.g. "Ha" and "ha" are merged
+    into a single canonical entry.
+    """
+    from app.services.normalization import load_alias_maps, normalize_filter, normalize_equipment
+
     column_map = {
         DiscoveredSection.filters: Image.filter_used,
         DiscoveredSection.cameras: Image.camera,
@@ -320,8 +327,24 @@ async def get_discovered(
     )
     result = await session.execute(q)
     rows = result.all()
+
+    filter_map, cam_map, tel_map = await load_alias_maps(session)
+    normalize_map = {
+        DiscoveredSection.filters: lambda n: normalize_filter(n, filter_map),
+        DiscoveredSection.cameras: lambda n: normalize_equipment(n, cam_map),
+        DiscoveredSection.telescopes: lambda n: normalize_equipment(n, tel_map),
+    }
+    normalize = normalize_map[section]
+
+    # Merge counts for names that normalize to the same canonical form
+    merged: dict[str, int] = {}
+    for name, count in rows:
+        canonical = normalize(name) or name
+        merged[canonical] = merged.get(canonical, 0) + count
+
+    items = sorted(merged.items(), key=lambda x: x[1], reverse=True)
     return DiscoveredResponse(
-        items=[DiscoveredItem(name=name, count=count) for name, count in rows]
+        items=[DiscoveredItem(name=name, count=count) for name, count in items]
     )
 
 

--- a/frontend/src/components/settings/FiltersTab.tsx
+++ b/frontend/src/components/settings/FiltersTab.tsx
@@ -126,11 +126,16 @@ export const FiltersTab: Component = () => {
         }
       }
       // Also include any discovered ungrouped filters not yet in the payload
-      // so their default colors get persisted on first save
+      // so their default colors get persisted on first save.
+      // Skip names already covered as aliases in existing groups.
       const defaults = getFilterColorMap(settings());
       const knownNames = new Set(Object.keys(filtersPayload));
+      const coveredAliases = new Set<string>();
+      for (const cfg of Object.values(filtersPayload)) {
+        for (const alias of cfg.aliases) coveredAliases.add(alias);
+      }
       for (const item of discovered()) {
-        if (!knownNames.has(item.name)) {
+        if (!knownNames.has(item.name) && !coveredAliases.has(item.name)) {
           filtersPayload[item.name] = {
             color: ungroupedColors()[item.name] || defaults[item.name] || "#808080",
             aliases: [],


### PR DESCRIPTION
**Summary**
This PR corrects issues with filter alias persistence on save and ensures discovered filters are properly normalized to prevent duplicates.

**Changes**
*   Prevent alias names from persisting as standalone filter groups during save operations.
*   Normalize discovered filters through the alias map to merge duplicate entries.

**Impact**
*   Backend filter processing and persistence logic in `backend/app/api/settings.py`.
*   Frontend filter display and interaction within the settings tab in `frontend/src/components/settings/FiltersTab.tsx`.