### PR TITLE
Skip merge commits in PR description workflow

### DIFF
--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
           MERGE_BASE=$(git merge-base "origin/$BASE_BRANCH" HEAD)
-          COMMITS=$(git log --pretty=format:"- %s (%h)" "$MERGE_BASE"..HEAD 2>/dev/null || echo "Unable to retrieve commits")
+          COMMITS=$(git log --no-merges --pretty=format:"- %s (%h)" "$MERGE_BASE"..HEAD 2>/dev/null || echo "Unable to retrieve commits")
           FILES_CHANGED=$(git diff --stat "$MERGE_BASE"...HEAD -- . ':!package-lock.json' ':!*.lock' 2>/dev/null || echo "Unable to get file stats")
           {
             echo "COMMITS:"


### PR DESCRIPTION
**Summary**
This PR updates the PR description generation workflow to prevent merge commits from being included in the generated description.

**Changes**
*   Modified the `.github/workflows/pr-description.yml` workflow to skip merge commits when generating the pull request description.

**Impact**
This change affects the automated PR description generation process, ensuring that only direct commits, and not merge commits, contribute to the generated description.