### PR TITLE
Fix: Skip merge commits in PR description generation

### DIFF
--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
           MERGE_BASE=$(git merge-base "origin/$BASE_BRANCH" HEAD)
-          COMMITS=$(git log --pretty=format:"- %s (%h)" "$MERGE_BASE"..HEAD 2>/dev/null || echo "Unable to retrieve commits")
+          COMMITS=$(git log --no-merges --pretty=format:"- %s (%h)" "$MERGE_BASE"..HEAD 2>/dev/null || echo "Unable to retrieve commits")
           FILES_CHANGED=$(git diff --stat "$MERGE_BASE"...HEAD -- . ':!package-lock.json' ':!*.lock' 2>/dev/null || echo "Unable to get file stats")
           {
             echo "COMMITS:"


### PR DESCRIPTION
**Summary**:
This pull request modifies the PR description generation workflow to skip merge commits.

**Changes**:
*   Updated `.github/workflows/pr-description.yml` to filter out merge commits during PR description generation.

**Impact**:
This change affects the GitHub Actions workflow responsible for generating pull request descriptions.