### PR TITLE
Fix None Filter Handling and Refactor Imports

### DIFF
--- a/backend/app/api/settings.py
+++ b/backend/app/api/settings.py
@@ -11,6 +11,7 @@ from app.api.deps import get_current_user, require_admin
 from app.models.user import User
 from app.models.user_settings import UserSettings, SETTINGS_ROW_ID
 from app.models import Image
+from app.services.normalization import load_alias_maps, normalize_filter, normalize_equipment
 from app.schemas.settings import (
     GeneralSettings, FilterConfig, EquipmentConfig, EquipmentAliases,
     SettingsResponse, SuggestionsResponse, SuggestionGroup,
@@ -311,8 +312,6 @@ async def get_discovered(
     the user-configured alias maps so that e.g. "Ha" and "ha" are merged
     into a single canonical entry.
     """
-    from app.services.normalization import load_alias_maps, normalize_filter, normalize_equipment
-
     column_map = {
         DiscoveredSection.filters: Image.filter_used,
         DiscoveredSection.cameras: Image.camera,

--- a/backend/app/api/stats.py
+++ b/backend/app/api/stats.py
@@ -204,7 +204,9 @@ async def get_stats(session: AsyncSession = Depends(get_session), user: User = D
     for r in perf_result.all():
         tel = normalize_equipment(r.telescope, tel_map) or r.telescope
         cam = normalize_equipment(r.camera, cam_map) or r.camera
-        filt = normalize_filter(r.filter_used, filter_map) or r.filter_used or "Unknown"
+        filt = normalize_filter(r.filter_used, filter_map) or r.filter_used
+        if filt is None:
+            continue
         key = (tel, cam)
 
         if key not in combo_data:
@@ -303,7 +305,7 @@ async def get_stats(session: AsyncSession = Depends(get_session), user: User = D
             median_eccentricity=weighted_median_approx(cd["ecc_vals"]),
             median_fwhm=weighted_median_approx(cd["fwhm_vals"]),
             grouped=len(cd["raw_telescopes"]) > 1 or len(cd["raw_cameras"]) > 1,
-            filters=sorted(f for f in cd["filters"] if f is not None),
+            filters=sorted(cd["filters"]),
             filter_breakdown=build_filter_metrics(cd["filter_rows"]),
         ))
 

--- a/backend/app/api/stats.py
+++ b/backend/app/api/stats.py
@@ -204,7 +204,7 @@ async def get_stats(session: AsyncSession = Depends(get_session), user: User = D
     for r in perf_result.all():
         tel = normalize_equipment(r.telescope, tel_map) or r.telescope
         cam = normalize_equipment(r.camera, cam_map) or r.camera
-        filt = normalize_filter(r.filter_used, filter_map) or r.filter_used
+        filt = normalize_filter(r.filter_used, filter_map) or r.filter_used or "Unknown"
         key = (tel, cam)
 
         if key not in combo_data:


### PR DESCRIPTION
**Summary**
This PR corrects inconsistent `None` filter handling across API endpoints and refactors an inline import for improved code structure.

**Changes**
*   Moved an inline import from `backend/app/api/settings.py` to the module level.
*   Corrected inconsistent `None` filter handling logic in relevant API endpoints.
*   Addressed `None` `filter_used` handling within the equipment performance breakdown statistics in `backend/app/api/stats.py`.

**Impact**
*   API endpoints within `backend/app/api/settings.py` are affected by the import refactoring and filter handling adjustments.
*   API endpoints within `backend/app/api/stats.py` are affected by the `None` `filter_used` handling fix for statistics calculations.