### PR TITLE
Hide raw exception details in backup restore errors

### DIFF
--- a/backend/app/api/backup.py
+++ b/backend/app/api/backup.py
@@ -119,5 +119,5 @@ async def restore_backup_endpoint(
             "applied": {},
             "temporary_passwords": {},
             "warnings": [],
-            "error": f"Restore failed: {e}",
+            "error": "Restore failed — see server logs for details.",
         }


### PR DESCRIPTION
**Summary**
This PR prevents raw exception details from being exposed in backup restore error responses, improving security and user experience by providing a standardized error message.

**Changes**
*   Stops exposing raw exception details in backup restore error responses.

**Impact**
*   Affects error handling for backup restore operations within `backend/app/api/backup.py`.
*   Changes the content of error responses returned by the backup restore API endpoint.