### PR TITLE
Implement Scan Filters: UI, API, and Scanner Integration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,36 @@
+* text=auto
+
+*.sh            text eol=lf
+*.bash          text eol=lf
+entrypoint.sh   text eol=lf
+Dockerfile      text eol=lf
+Dockerfile.*    text eol=lf
+*.dockerfile    text eol=lf
+
+*.py            text eol=lf
+*.ts            text eol=lf
+*.tsx           text eol=lf
+*.js            text eol=lf
+*.jsx           text eol=lf
+*.json          text eol=lf
+*.yml           text eol=lf
+*.yaml          text eol=lf
+*.toml          text eol=lf
+*.md            text eol=lf
+*.html          text eol=lf
+*.css           text eol=lf
+*.sql           text eol=lf
+
+*.png           binary
+*.jpg           binary
+*.jpeg          binary
+*.gif           binary
+*.ico           binary
+*.webp          binary
+*.fits          binary
+*.fit           binary
+*.fts           binary
+*.xisf          binary
+*.tar           binary
+*.tar.gz        binary
+*.zip           binary

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -90,6 +90,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -97,6 +98,70 @@ jobs:
           tags: ${{ steps.version.outputs.docker_tags }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
+
+      - name: Report image size
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          TAG="chvvkumar/galactilog:${VERSION}"
+          {
+            echo "### Image size"
+            echo ""
+            echo "| Tag | Platform | Compressed size |"
+            echo "| --- | --- | ---: |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          IMAGE_TAG="$TAG" IMAGE_DIGEST="$IMAGE_DIGEST" python3 - <<'PYEOF' >> "$GITHUB_STEP_SUMMARY"
+          import json, os, subprocess
+
+          tag = os.environ["IMAGE_TAG"]
+          digest = os.environ.get("IMAGE_DIGEST", "")
+
+          def inspect_raw(ref: str) -> dict:
+              return json.loads(subprocess.check_output(
+                  ["docker", "buildx", "imagetools", "inspect", ref, "--raw"]
+              ))
+
+          def fmt(n: int) -> str:
+              if n < 1024 * 1024:
+                  return f"{n / 1024:.1f} KiB"
+              if n < 1024 * 1024 * 1024:
+                  return f"{n / 1024 / 1024:.1f} MiB"
+              return f"{n / 1024 / 1024 / 1024:.2f} GiB"
+
+          def layer_total(manifest: dict) -> int:
+              total = sum(l.get("size", 0) for l in manifest.get("layers", []))
+              cfg = manifest.get("config")
+              if isinstance(cfg, dict):
+                  total += cfg.get("size", 0)
+              return total
+
+          ref = f"{tag.split(':')[0]}@{digest}" if digest else tag
+          m = inspect_raw(ref)
+
+          rows = []
+          if "layers" in m:
+              rows.append(("linux/amd64", layer_total(m)))
+          elif "manifests" in m:
+              for sub in m["manifests"]:
+                  if "platform" not in sub:
+                      continue
+                  plat = sub["platform"]
+                  if plat.get("architecture") == "unknown":
+                      continue
+                  parch = f"{plat.get('os', '?')}/{plat.get('architecture', '?')}"
+                  sub_ref = f"{tag.split(':')[0]}@{sub['digest']}"
+                  try:
+                      sub_m = inspect_raw(sub_ref)
+                      rows.append((parch, layer_total(sub_m)))
+                  except Exception:
+                      rows.append((parch, sub.get("size", 0)))
+
+          for name, size in rows:
+              print(f"| `{tag}` | {name} | {fmt(size)} |")
+          PYEOF
 
       - name: Create and push git tag
         run: |

--- a/.github/workflows/build-snd.yml
+++ b/.github/workflows/build-snd.yml
@@ -30,6 +30,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -37,3 +38,66 @@ jobs:
           tags: chvvkumar/galactilog:snd
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
+
+      - name: Report image size
+        shell: bash
+        env:
+          IMAGE_TAG: chvvkumar/galactilog:snd
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          {
+            echo "### Image size"
+            echo ""
+            echo "| Tag | Platform | Compressed size |"
+            echo "| --- | --- | ---: |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          python3 - <<'PYEOF' >> "$GITHUB_STEP_SUMMARY"
+          import json, os, subprocess
+
+          tag = os.environ["IMAGE_TAG"]
+          digest = os.environ.get("IMAGE_DIGEST", "")
+
+          def inspect_raw(ref: str) -> dict:
+              return json.loads(subprocess.check_output(
+                  ["docker", "buildx", "imagetools", "inspect", ref, "--raw"]
+              ))
+
+          def fmt(n: int) -> str:
+              if n < 1024 * 1024:
+                  return f"{n / 1024:.1f} KiB"
+              if n < 1024 * 1024 * 1024:
+                  return f"{n / 1024 / 1024:.1f} MiB"
+              return f"{n / 1024 / 1024 / 1024:.2f} GiB"
+
+          def layer_total(manifest: dict) -> int:
+              total = sum(l.get("size", 0) for l in manifest.get("layers", []))
+              cfg = manifest.get("config")
+              if isinstance(cfg, dict):
+                  total += cfg.get("size", 0)
+              return total
+
+          ref = f"{tag.split(':')[0]}@{digest}" if digest else tag
+          m = inspect_raw(ref)
+
+          rows = []
+          if "layers" in m:
+              rows.append(("linux/amd64", layer_total(m)))
+          elif "manifests" in m:
+              for sub in m["manifests"]:
+                  if "platform" not in sub:
+                      continue
+                  plat = sub["platform"]
+                  if plat.get("architecture") == "unknown":
+                      continue
+                  parch = f"{plat.get('os', '?')}/{plat.get('architecture', '?')}"
+                  sub_ref = f"{tag.split(':')[0]}@{sub['digest']}"
+                  try:
+                      sub_m = inspect_raw(sub_ref)
+                      rows.append((parch, layer_total(sub_m)))
+                  except Exception:
+                      rows.append((parch, sub.get("size", 0)))
+
+          for name, size in rows:
+              print(f"| `{tag}` | {name} | {fmt(size)} |")
+          PYEOF

--- a/backend/app/api/scan.py
+++ b/backend/app/api/scan.py
@@ -1,15 +1,22 @@
 import asyncio
 import logging
+import os
+from pathlib import Path as FsPath
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config import async_redis
+from app.config import async_redis, settings as app_settings
 from app.database import get_session
 from app.api.deps import get_current_user, require_admin
 from app.models.user import User
 from app.models import Image, Target
+from app.models.user_settings import UserSettings, SETTINGS_ROW_ID
+from app.schemas.scan_filters import (
+    ScanFiltersIn, ScanFiltersOut, TestPathIn, TestPathOut, BrowseEntry, ApplyNowOut,
+)
+from app.services.scan_filters import ScanFilterConfig
 from app.services.scan_state import (
     get_scan_state, get_failed_files, start_scanning, set_ingesting, set_idle, reset_scan,
     get_rebuild_state, request_cancel,
@@ -425,3 +432,160 @@ async def set_autoscan(
         "enabled": enabled,
         "interval_minutes": interval_minutes,
     }
+
+
+@router.get("/filters", response_model=ScanFiltersOut)
+async def get_scan_filters(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(get_current_user),
+):
+    result = await session.execute(
+        select(UserSettings).where(UserSettings.id == SETTINGS_ROW_ID)
+    )
+    row = result.scalar_one_or_none()
+    general = (row.general if row else {}) or {}
+    sf = general.get("scan_filters") or {
+        "include_paths": [], "exclude_paths": [], "name_rules": [],
+    }
+    return ScanFiltersOut(
+        configured=bool(general.get("scan_filters_configured")),
+        filters=ScanFiltersIn(**sf),
+        fits_root=str(FsPath(app_settings.fits_data_path).resolve()),
+    )
+
+
+@router.put("/filters", response_model=ScanFiltersOut)
+async def put_scan_filters(
+    payload: ScanFiltersIn,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_admin),
+):
+    fits_root = FsPath(app_settings.fits_data_path)
+    # Validate by constructing the config
+    try:
+        ScanFilterConfig.from_settings(
+            {"scan_filters": payload.model_dump()}, fits_root,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    result = await session.execute(
+        select(UserSettings).where(UserSettings.id == SETTINGS_ROW_ID)
+    )
+    row = result.scalar_one_or_none()
+    if row is None:
+        row = UserSettings(id=SETTINGS_ROW_ID)
+        session.add(row)
+    row.general = {
+        **(row.general or {}),
+        "scan_filters": payload.model_dump(),
+        "scan_filters_configured": True,
+    }
+    await session.commit()
+    return ScanFiltersOut(
+        configured=True,
+        filters=payload,
+        fits_root=str(fits_root.resolve()),
+    )
+
+
+@router.post("/filters/test", response_model=TestPathOut)
+async def test_scan_filter_path(
+    payload: TestPathIn,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(get_current_user),
+):
+    fits_root = FsPath(app_settings.fits_data_path)
+    result = await session.execute(
+        select(UserSettings).where(UserSettings.id == SETTINGS_ROW_ID)
+    )
+    row = result.scalar_one_or_none()
+    general = (row.general if row else {}) or {}
+    try:
+        cfg = ScanFilterConfig.from_settings(general, fits_root)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    test_result = cfg.test_path(FsPath(payload.path), fits_root)
+    return TestPathOut(
+        verdict=test_result.verdict,
+        matched_rule_ids=test_result.matched_rule_ids,
+    )
+
+
+@router.post("/filters/apply-now", response_model=ApplyNowOut)
+async def apply_filters_now(
+    dry_run: bool = Query(True),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_admin),
+):
+    fits_root = FsPath(app_settings.fits_data_path)
+    result = await session.execute(
+        select(UserSettings).where(UserSettings.id == SETTINGS_ROW_ID)
+    )
+    row = result.scalar_one_or_none()
+    general = (row.general if row else {}) or {}
+    try:
+        cfg = ScanFilterConfig.from_settings(general, fits_root)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    # Pull file paths and evaluate in Python (keeps rule logic in one place)
+    paths_result = await session.execute(select(Image.id, Image.file_path))
+    matched_ids: list = []
+    for image_id, file_path in paths_result.all():
+        if not file_path:
+            continue
+        if not cfg.should_include_file(FsPath(file_path), fits_root):
+            matched_ids.append(image_id)
+
+    if not dry_run and matched_ids:
+        await session.execute(
+            text("DELETE FROM images WHERE id = ANY(:ids)"),
+            {"ids": matched_ids},
+        )
+        await session.commit()
+
+    return ApplyNowOut(dry_run=dry_run, matched=len(matched_ids))
+
+
+@router.get("/browse", response_model=list[BrowseEntry])
+async def browse_folders(
+    path: str | None = Query(None),
+    user: User = Depends(get_current_user),
+):
+    fits_root = FsPath(app_settings.fits_data_path).resolve()
+    target = FsPath(path).resolve() if path else fits_root
+    try:
+        target.relative_to(fits_root)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="path outside configured data path")
+    if not target.exists() or not target.is_dir():
+        raise HTTPException(status_code=404, detail="directory not found")
+
+    entries: list[BrowseEntry] = []
+    try:
+        with os.scandir(target) as it:
+            for entry in it:
+                try:
+                    if not entry.is_dir(follow_symlinks=True):
+                        continue
+                    has_children = False
+                    try:
+                        with os.scandir(entry.path) as sub_it:
+                            for sub in sub_it:
+                                if sub.is_dir(follow_symlinks=True):
+                                    has_children = True
+                                    break
+                    except OSError:
+                        pass
+                    entries.append(BrowseEntry(
+                        name=entry.name,
+                        path=str(FsPath(entry.path).resolve()),
+                        has_children=has_children,
+                    ))
+                except OSError:
+                    continue
+    except OSError as exc:
+        raise HTTPException(status_code=500, detail=f"cannot read directory: {exc}")
+    entries.sort(key=lambda e: e.name.lower())
+    return entries

--- a/backend/app/api/scan.py
+++ b/backend/app/api/scan.py
@@ -20,7 +20,7 @@ from app.services.scan_filters import ScanFilterConfig
 from app.services.scan_state import (
     get_scan_state, get_failed_files, start_scanning, set_ingesting, set_idle, reset_scan,
     get_rebuild_state, request_cancel,
-    get_activity, clear_activity,
+    get_activity, clear_activity, append_activity,
 )
 from app.services.simbad import resolve_target_name, normalize_object_name
 from app.worker.tasks import regenerate_thumbnail, run_scan, rebuild_targets, smart_rebuild_targets, retry_unresolved, backfill_csv_metrics
@@ -546,6 +546,26 @@ async def apply_filters_now(
             {"ids": matched_ids},
         )
         await session.commit()
+
+        import time as _time
+        async with async_redis() as r:
+            await append_activity(r, {
+                "type": "scan_filters_applied",
+                "message": (
+                    f"Scan filters applied: {len(matched_ids)} image row"
+                    f"{'s' if len(matched_ids) != 1 else ''} removed "
+                    f"(by {user.username})"
+                ),
+                "details": {
+                    "removed": len(matched_ids),
+                    "by_user": user.username,
+                },
+                "timestamp": _time.time(),
+            })
+        logger.info(
+            "scan_filters_applied: removed %d image rows by user %s",
+            len(matched_ids), user.username,
+        )
 
     return ApplyNowOut(dry_run=dry_run, matched=len(matched_ids))
 

--- a/backend/app/api/scan.py
+++ b/backend/app/api/scan.py
@@ -505,7 +505,9 @@ async def test_scan_filter_path(
         cfg = ScanFilterConfig.from_settings(general, fits_root)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
-    test_result = cfg.test_path(FsPath(payload.path), fits_root)
+    test_result = cfg.test_path(
+        FsPath(payload.path), fits_root, target_kind=payload.target_kind,
+    )
     return TestPathOut(
         verdict=test_result.verdict,
         matched_rule_ids=test_result.matched_rule_ids,
@@ -551,10 +553,19 @@ async def apply_filters_now(
 @router.get("/browse", response_model=list[BrowseEntry])
 async def browse_folders(
     path: str | None = Query(None),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_admin),
 ):
     fits_root = FsPath(app_settings.fits_data_path).resolve()
-    target = FsPath(path).resolve() if path else fits_root
+
+    # Reject relative paths so we never resolve against the process CWD.
+    if path is not None:
+        candidate = FsPath(path)
+        if not candidate.is_absolute():
+            raise HTTPException(status_code=400, detail="path must be absolute")
+        target = candidate.resolve()
+    else:
+        target = fits_root
+
     try:
         target.relative_to(fits_root)
     except ValueError:
@@ -567,25 +578,35 @@ async def browse_folders(
         with os.scandir(target) as it:
             for entry in it:
                 try:
-                    if not entry.is_dir(follow_symlinks=True):
+                    # Do NOT follow symlinks: a symlink inside fits_root
+                    # could otherwise point outside and enumerate host dirs.
+                    if not entry.is_dir(follow_symlinks=False):
+                        continue
+                    # Defence in depth: re-check containment on the resolved
+                    # child so a TOCTOU race or mount change cannot escape.
+                    resolved_child = FsPath(entry.path).resolve()
+                    try:
+                        resolved_child.relative_to(fits_root)
+                    except ValueError:
                         continue
                     has_children = False
                     try:
                         with os.scandir(entry.path) as sub_it:
                             for sub in sub_it:
-                                if sub.is_dir(follow_symlinks=True):
+                                if sub.is_dir(follow_symlinks=False):
                                     has_children = True
                                     break
                     except OSError:
                         pass
                     entries.append(BrowseEntry(
                         name=entry.name,
-                        path=str(FsPath(entry.path).resolve()),
+                        path=str(resolved_child),
                         has_children=has_children,
                     ))
                 except OSError:
                     continue
     except OSError as exc:
-        raise HTTPException(status_code=500, detail=f"cannot read directory: {exc}")
+        logger.warning("browse_folders: cannot read %s: %s", target, exc)
+        raise HTTPException(status_code=500, detail="cannot read directory")
     entries.sort(key=lambda e: e.name.lower())
     return entries

--- a/backend/app/schemas/scan_filters.py
+++ b/backend/app/schemas/scan_filters.py
@@ -1,6 +1,16 @@
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+
+# Reject control characters and null bytes in user-entered strings.
+_FORBIDDEN_CHARS = set("\x00\r\n")
+
+
+def _no_control_chars(value: str, field_name: str) -> str:
+    if any(c in _FORBIDDEN_CHARS for c in value):
+        raise ValueError(f"{field_name} contains disallowed control characters")
+    return value
 
 
 class NameRuleIn(BaseModel):
@@ -11,11 +21,39 @@ class NameRuleIn(BaseModel):
     target: Literal["file", "folder"]
     enabled: bool = True
 
+    @field_validator("pattern")
+    @classmethod
+    def _pattern_clean(cls, v: str) -> str:
+        return _no_control_chars(v.strip(), "pattern")
+
+    @field_validator("id")
+    @classmethod
+    def _id_clean(cls, v: str) -> str:
+        return _no_control_chars(v, "id")
+
 
 class ScanFiltersIn(BaseModel):
-    include_paths: list[str] = Field(default_factory=list)
-    exclude_paths: list[str] = Field(default_factory=list)
-    name_rules: list[NameRuleIn] = Field(default_factory=list)
+    include_paths: list[str] = Field(default_factory=list, max_length=256)
+    exclude_paths: list[str] = Field(default_factory=list, max_length=256)
+    name_rules: list[NameRuleIn] = Field(default_factory=list, max_length=512)
+
+    @field_validator("include_paths", "exclude_paths")
+    @classmethod
+    def _paths_clean(cls, v: list[str]) -> list[str]:
+        cleaned: list[str] = []
+        for p in v:
+            stripped = p.strip()
+            if not stripped:
+                raise ValueError("path entries must be non-empty")
+            cleaned.append(_no_control_chars(stripped, "path"))
+        return cleaned
+
+    @model_validator(mode="after")
+    def _unique_rule_ids(self) -> "ScanFiltersIn":
+        ids = [r.id for r in self.name_rules]
+        if len(ids) != len(set(ids)):
+            raise ValueError("name_rules contain duplicate ids")
+        return self
 
 
 class ScanFiltersOut(BaseModel):
@@ -25,7 +63,13 @@ class ScanFiltersOut(BaseModel):
 
 
 class TestPathIn(BaseModel):
-    path: str
+    path: str = Field(min_length=1, max_length=4096)
+    target_kind: Literal["auto", "file", "folder"] = "auto"
+
+    @field_validator("path")
+    @classmethod
+    def _path_clean(cls, v: str) -> str:
+        return _no_control_chars(v.strip(), "path")
 
 
 class TestPathOut(BaseModel):

--- a/backend/app/schemas/scan_filters.py
+++ b/backend/app/schemas/scan_filters.py
@@ -1,0 +1,46 @@
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class NameRuleIn(BaseModel):
+    id: str = Field(min_length=1, max_length=64)
+    action: Literal["include", "exclude"]
+    type: Literal["glob", "substring", "regex"]
+    pattern: str = Field(min_length=1, max_length=512)
+    target: Literal["file", "folder"]
+    enabled: bool = True
+
+
+class ScanFiltersIn(BaseModel):
+    include_paths: list[str] = Field(default_factory=list)
+    exclude_paths: list[str] = Field(default_factory=list)
+    name_rules: list[NameRuleIn] = Field(default_factory=list)
+
+
+class ScanFiltersOut(BaseModel):
+    configured: bool
+    filters: ScanFiltersIn
+    fits_root: str
+
+
+class TestPathIn(BaseModel):
+    path: str
+
+
+class TestPathOut(BaseModel):
+    verdict: Literal[
+        "included", "excluded_by_path", "excluded_by_rule", "excluded_by_missing_include"
+    ]
+    matched_rule_ids: list[str]
+
+
+class BrowseEntry(BaseModel):
+    name: str
+    path: str
+    has_children: bool
+
+
+class ApplyNowOut(BaseModel):
+    dry_run: bool
+    matched: int

--- a/backend/app/services/scan_filters.py
+++ b/backend/app/services/scan_filters.py
@@ -47,3 +47,37 @@ class NameRule:
             assert self._regex is not None
             return bool(self._regex.search(value))
         return False
+
+
+@dataclass
+class ScanFilterConfig:
+    include_paths: list[Path]
+    exclude_paths: list[Path]
+    name_rules: list[NameRule]
+
+    @classmethod
+    def from_settings(cls, general: dict, fits_root: Path) -> "ScanFilterConfig":
+        raw = (general or {}).get("scan_filters") or {}
+        root = fits_root.resolve()
+
+        def _validate(path_str: str) -> Path:
+            p = Path(path_str).resolve()
+            try:
+                p.relative_to(root)
+            except ValueError as exc:
+                raise ValueError(
+                    f"path {path_str} is outside configured data path {root}"
+                ) from exc
+            return p
+
+        include_paths = [_validate(p) for p in raw.get("include_paths", [])]
+        exclude_paths = [_validate(p) for p in raw.get("exclude_paths", [])]
+        name_rules = [NameRule(**r) for r in raw.get("name_rules", [])]
+        return cls(
+            include_paths=include_paths,
+            exclude_paths=exclude_paths,
+            name_rules=name_rules,
+        )
+
+    def roots(self, fits_root: Path) -> list[Path]:
+        return list(self.include_paths) if self.include_paths else [fits_root]

--- a/backend/app/services/scan_filters.py
+++ b/backend/app/services/scan_filters.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import fnmatch
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+Action = Literal["include", "exclude"]
+RuleType = Literal["glob", "substring", "regex"]
+Target = Literal["file", "folder"]
+
+
+@dataclass
+class NameRule:
+    id: str
+    action: Action
+    type: RuleType
+    pattern: str
+    target: Target
+    enabled: bool = True
+    _regex: re.Pattern | None = field(default=None, init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if self.action not in ("include", "exclude"):
+            raise ValueError(f"invalid action: {self.action}")
+        if self.type not in ("glob", "substring", "regex"):
+            raise ValueError(f"invalid type: {self.type}")
+        if self.target not in ("file", "folder"):
+            raise ValueError(f"invalid target: {self.target}")
+        if not self.pattern:
+            raise ValueError("pattern must not be empty")
+        if self.type == "regex":
+            try:
+                self._regex = re.compile(self.pattern)
+            except re.error as exc:
+                raise ValueError(f"invalid regex: {exc}") from exc
+
+    def matches(self, value: str) -> bool:
+        if not self.enabled:
+            return False
+        if self.type == "glob":
+            return fnmatch.fnmatchcase(value, self.pattern)
+        if self.type == "substring":
+            return self.pattern.casefold() in value.casefold()
+        if self.type == "regex":
+            assert self._regex is not None
+            return bool(self._regex.search(value))
+        return False

--- a/backend/app/services/scan_filters.py
+++ b/backend/app/services/scan_filters.py
@@ -122,6 +122,21 @@ class ScanFilterConfig:
             except ValueError:
                 pass
 
+        # Include-paths narrowing: when set, the file must live under one
+        # of them. This matches the scan walker, which uses include_paths
+        # as effective roots.
+        if self.include_paths:
+            under_include = False
+            for inc in self.include_paths:
+                try:
+                    resolved.relative_to(inc)
+                    under_include = True
+                    break
+                except ValueError:
+                    pass
+            if not under_include:
+                return False
+
         # Collect ancestor folder segments under fits_root
         root = fits_root.resolve()
         try:
@@ -162,6 +177,20 @@ class ScanFilterConfig:
                 return TestResult("excluded_by_path", [])
             except ValueError:
                 pass
+
+        # Include-paths narrowing: when set, the path must live under one
+        # of them, otherwise the walker would never reach it.
+        if self.include_paths:
+            under_include = False
+            for inc in self.include_paths:
+                try:
+                    resolved.relative_to(inc)
+                    under_include = True
+                    break
+                except ValueError:
+                    pass
+            if not under_include:
+                return TestResult("excluded_by_path", [])
 
         try:
             rel = resolved.relative_to(root)

--- a/backend/app/services/scan_filters.py
+++ b/backend/app/services/scan_filters.py
@@ -9,6 +9,19 @@ from typing import Literal
 Action = Literal["include", "exclude"]
 RuleType = Literal["glob", "substring", "regex"]
 Target = Literal["file", "folder"]
+Verdict = Literal[
+    "included", "excluded_by_path", "excluded_by_rule", "excluded_by_missing_include",
+]
+
+
+@dataclass
+class TestResult:
+    verdict: Verdict
+    matched_rule_ids: list[str]
+
+
+# Prevent pytest from collecting TestResult as a test class
+TestResult.__test__ = False
 
 
 @dataclass
@@ -139,3 +152,51 @@ class ScanFilterConfig:
         ):
             return False
         return True
+
+    def test_path(self, path: Path, fits_root: Path) -> TestResult:
+        resolved = path  # do NOT resolve - test paths may not exist
+        root = fits_root.resolve()
+        for excluded in self.exclude_paths:
+            try:
+                resolved.relative_to(excluded)
+                return TestResult("excluded_by_path", [])
+            except ValueError:
+                pass
+
+        try:
+            rel = resolved.relative_to(root)
+        except ValueError:
+            try:
+                rel = resolved.relative_to(fits_root)
+            except ValueError:
+                return TestResult("excluded_by_path", [])
+
+        parts = rel.parts
+        segments = list(parts[:-1]) if len(parts) > 1 else []
+        filename = parts[-1] if parts else ""
+
+        matched: list[str] = []
+        for rule in self.name_rules:
+            if rule.action != "exclude":
+                continue
+            if rule.target == "file" and rule.matches(filename):
+                matched.append(rule.id)
+                return TestResult("excluded_by_rule", matched)
+            if rule.target == "folder" and any(rule.matches(s) for s in segments):
+                matched.append(rule.id)
+                return TestResult("excluded_by_rule", matched)
+
+        file_includes = [r for r in self.name_rules
+                         if r.action == "include" and r.target == "file"]
+        folder_includes = [r for r in self.name_rules
+                           if r.action == "include" and r.target == "folder"]
+        file_hits = [r.id for r in file_includes if r.matches(filename)]
+        folder_hits = [r.id for r in folder_includes
+                       if any(r.matches(s) for s in segments)]
+
+        if file_includes and not file_hits:
+            return TestResult("excluded_by_missing_include", [])
+        if folder_includes and not folder_hits:
+            return TestResult("excluded_by_missing_include", [])
+
+        return TestResult("included", file_hits + folder_hits)

--- a/backend/app/services/scan_filters.py
+++ b/backend/app/services/scan_filters.py
@@ -103,12 +103,22 @@ class ScanFilterConfig:
                 return False
             except ValueError:
                 pass
-        # Folder name-rules apply to the segment name itself
-        segment = dir_path.name
+
+        # Folder exclude name-rules: check every segment between fits_root
+        # and dir_path (inclusive of dir_path itself). This lets the walker
+        # prune as early as possible even when starting from an include_path
+        # that sits deep in the tree.
+        root = fits_root.resolve()
+        try:
+            rel = resolved.relative_to(root)
+            segments = list(rel.parts)
+        except ValueError:
+            segments = [dir_path.name]
+
         for rule in self.name_rules:
             if rule.target != "folder" or rule.action != "exclude":
                 continue
-            if rule.matches(segment):
+            if any(rule.matches(s) for s in segments):
                 return False
         return True
 
@@ -168,9 +178,37 @@ class ScanFilterConfig:
             return False
         return True
 
-    def test_path(self, path: Path, fits_root: Path) -> TestResult:
-        resolved = path  # do NOT resolve - test paths may not exist
+    def test_path(
+        self,
+        path: Path,
+        fits_root: Path,
+        target_kind: str = "auto",
+    ) -> TestResult:
+        """Explain how the current config would treat `path`.
+
+        `target_kind` is "file", "folder", or "auto". In auto mode the
+        on-disk type is used when the path exists; otherwise a trailing
+        dot-extension hints at a file, else we treat it as a folder.
+        """
+        # Resolve to normalize `..`, drive letters, and symlinks so the
+        # verdict matches what should_include_file would decide. Resolve
+        # does not require the path to exist in modern Python.
+        try:
+            resolved = path.resolve()
+        except (OSError, RuntimeError):
+            resolved = path
+
         root = fits_root.resolve()
+
+        # Decide whether to treat this as a file or a folder.
+        if target_kind == "auto":
+            if resolved.exists():
+                kind = "folder" if resolved.is_dir() else "file"
+            else:
+                kind = "file" if resolved.suffix else "folder"
+        else:
+            kind = target_kind
+
         for excluded in self.exclude_paths:
             try:
                 resolved.relative_to(excluded)
@@ -201,14 +239,20 @@ class ScanFilterConfig:
                 return TestResult("excluded_by_path", [])
 
         parts = rel.parts
-        segments = list(parts[:-1]) if len(parts) > 1 else []
-        filename = parts[-1] if parts else ""
+        if kind == "folder":
+            # For a folder path the trailing component is a folder too,
+            # so every segment is a folder to evaluate. No filename.
+            segments = list(parts)
+            filename = ""
+        else:
+            segments = list(parts[:-1])
+            filename = parts[-1] if parts else ""
 
         matched: list[str] = []
         for rule in self.name_rules:
             if rule.action != "exclude":
                 continue
-            if rule.target == "file" and rule.matches(filename):
+            if rule.target == "file" and kind == "file" and rule.matches(filename):
                 matched.append(rule.id)
                 return TestResult("excluded_by_rule", matched)
             if rule.target == "folder" and any(rule.matches(s) for s in segments):
@@ -219,13 +263,14 @@ class ScanFilterConfig:
                          if r.action == "include" and r.target == "file"]
         folder_includes = [r for r in self.name_rules
                            if r.action == "include" and r.target == "folder"]
-        file_hits = [r.id for r in file_includes if r.matches(filename)]
+        file_hits = [r.id for r in file_includes if kind == "file" and r.matches(filename)]
         folder_hits = [r.id for r in folder_includes
                        if any(r.matches(s) for s in segments)]
 
-        if file_includes and not file_hits:
+        # File-include rules only narrow file tests; folder tests ignore them.
+        if kind == "file" and file_includes and not file_hits:
             return TestResult("excluded_by_missing_include", [])
-        if folder_includes and not folder_hits:
+        if folder_includes and segments and not folder_hits:
             return TestResult("excluded_by_missing_include", [])
 
         return TestResult("included", file_hits + folder_hits)

--- a/backend/app/services/scan_filters.py
+++ b/backend/app/services/scan_filters.py
@@ -81,3 +81,61 @@ class ScanFilterConfig:
 
     def roots(self, fits_root: Path) -> list[Path]:
         return list(self.include_paths) if self.include_paths else [fits_root]
+
+    def should_walk_dir(self, dir_path: Path, fits_root: Path) -> bool:
+        resolved = dir_path.resolve()
+        for excluded in self.exclude_paths:
+            try:
+                resolved.relative_to(excluded)
+                return False
+            except ValueError:
+                pass
+        # Folder name-rules apply to the segment name itself
+        segment = dir_path.name
+        for rule in self.name_rules:
+            if rule.target != "folder" or rule.action != "exclude":
+                continue
+            if rule.matches(segment):
+                return False
+        return True
+
+    def should_include_file(self, file_path: Path, fits_root: Path) -> bool:
+        # Path-based excludes
+        resolved = file_path.resolve()
+        for excluded in self.exclude_paths:
+            try:
+                resolved.relative_to(excluded)
+                return False
+            except ValueError:
+                pass
+
+        # Collect ancestor folder segments under fits_root
+        root = fits_root.resolve()
+        try:
+            rel = resolved.relative_to(root)
+        except ValueError:
+            return False
+        segments = list(rel.parts[:-1])  # exclude filename
+        filename = rel.parts[-1] if rel.parts else file_path.name
+
+        # Exclude name-rules (file + folder)
+        for rule in self.name_rules:
+            if rule.action != "exclude":
+                continue
+            if rule.target == "file" and rule.matches(filename):
+                return False
+            if rule.target == "folder" and any(rule.matches(s) for s in segments):
+                return False
+
+        # Include-narrowing, per target type
+        file_includes = [r for r in self.name_rules
+                         if r.action == "include" and r.target == "file"]
+        folder_includes = [r for r in self.name_rules
+                           if r.action == "include" and r.target == "folder"]
+        if file_includes and not any(r.matches(filename) for r in file_includes):
+            return False
+        if folder_includes and not any(
+            r.matches(s) for s in segments for r in folder_includes
+        ):
+            return False
+        return True

--- a/backend/app/services/scan_state.py
+++ b/backend/app/services/scan_state.py
@@ -156,6 +156,13 @@ async def clear_activity(r: aioredis.Redis) -> None:
     await r.delete(SCAN_ACTIVITY_KEY)
 
 
+async def append_activity(r: aioredis.Redis, entry: dict) -> None:
+    """Append an activity entry (newest first) and cap at SCAN_ACTIVITY_MAX."""
+    import json
+    await r.lpush(SCAN_ACTIVITY_KEY, json.dumps(entry))
+    await r.ltrim(SCAN_ACTIVITY_KEY, 0, SCAN_ACTIVITY_MAX - 1)
+
+
 async def set_idle(r: aioredis.Redis) -> None:
     """Mark scan as complete with zero files (nothing to do)."""
     await r.hset(SCAN_KEY, mapping={

--- a/backend/app/services/scanner.py
+++ b/backend/app/services/scanner.py
@@ -8,6 +8,7 @@ from typing import Any, Iterator
 import fitsio
 
 from app.services.csv_metadata import get_csv_metrics
+from app.services.scan_filters import ScanFilterConfig
 
 logger = logging.getLogger(__name__)
 
@@ -20,23 +21,46 @@ FITS_EXTENSIONS = SUPPORTED_EXTENSIONS
 CALIBRATION_FRAME_TYPES = {"BIAS", "DARK", "FLAT", "DARKFLAT", "BIASFLAT"}
 
 
-def _walk_supported_files(root: Path) -> Iterator[Path]:
+def _walk_supported_files(
+    root: Path,
+    filter_config: "ScanFilterConfig | None" = None,
+    fits_root: "Path | None" = None,
+) -> Iterator[Path]:
     """Yield supported image files using os.scandir for better NFS performance.
 
     os.scandir batches readdir calls per directory and caches DirEntry.name,
     avoiding the per-entry stat() overhead of Path.rglob on network filesystems.
+
+    When filter_config is provided, subtrees that fail should_walk_dir are
+    pruned before descent, and files that fail should_include_file are
+    dropped. fits_root is the effective data root used for relative-path
+    segment extraction; defaults to root when not provided.
     """
+    effective_root = fits_root or root
     try:
         with os.scandir(root) as entries:
             for entry in entries:
                 try:
                     if entry.is_dir(follow_symlinks=True):
-                        yield from _walk_supported_files(Path(entry.path))
+                        sub = Path(entry.path)
+                        if filter_config and not filter_config.should_walk_dir(
+                            sub, effective_root
+                        ):
+                            continue
+                        yield from _walk_supported_files(
+                            sub, filter_config, effective_root
+                        )
                     elif entry.is_file(follow_symlinks=True):
                         # entry.name is already cached - no extra stat
                         _, ext = os.path.splitext(entry.name)
-                        if ext in SUPPORTED_EXTENSIONS:
-                            yield Path(entry.path)
+                        if ext not in SUPPORTED_EXTENSIONS:
+                            continue
+                        path = Path(entry.path)
+                        if filter_config and not filter_config.should_include_file(
+                            path, effective_root
+                        ):
+                            continue
+                        yield path
                 except OSError as exc:
                     # Handle stale NFS handles, permission errors, etc.
                     logger.warning("Skipping inaccessible entry %s: %s", entry.path, exc)
@@ -52,6 +76,8 @@ def scan_directory(
     is_cancelled: "callable | None" = None,
     on_new_file: "callable | None" = None,
     on_changed_file: "callable | None" = None,
+    filter_config: "ScanFilterConfig | None" = None,
+    fits_root: "Path | None" = None,
 ) -> tuple[list[Path], list[Path], set[str]]:
     """Walk a directory tree finding new and changed image files.
 
@@ -73,7 +99,7 @@ def scan_directory(
     changed_files: list[Path] = []
     all_disk_paths: set[str] = set()
     discovered = 0
-    for path in _walk_supported_files(root):
+    for path in _walk_supported_files(root, filter_config, fits_root or root):
         if is_cancelled and is_cancelled():
             break
         path_str = str(path)

--- a/backend/app/worker/tasks.py
+++ b/backend/app/worker/tasks.py
@@ -71,6 +71,19 @@ def run_scan(self, include_calibration: bool = True) -> dict:
 
     fits_root = Path(settings.fits_data_path)
 
+    # Load scan filters from user settings
+    from app.services.scan_filters import ScanFilterConfig
+    with Session(_sync_engine) as session:
+        us = session.execute(
+            select(UserSettings).where(UserSettings.id == SETTINGS_ROW_ID)
+        ).scalar_one_or_none()
+        general = (us.general if us else {}) or {}
+    try:
+        filter_config = ScanFilterConfig.from_settings(general, fits_root)
+    except ValueError as exc:
+        logger.error("Invalid scan filters, scanning with no filters: %s", exc)
+        filter_config = ScanFilterConfig(include_paths=[], exclude_paths=[], name_rules=[])
+
     # Dispatch ingest tasks as files are discovered (parallel discovery + ingestion)
     # Calibration filtering is deferred to the ingest phase to avoid opening
     # every file during discovery (costly on NFS).
@@ -81,13 +94,27 @@ def run_scan(self, include_calibration: bool = True) -> dict:
         """Re-ingest a known file whose size or mtime changed on disk."""
         reingest_changed_file.delay(str(path), include_calibration=include_calibration)
 
-    new_files, changed_files, all_disk_paths = scan_directory(
-        fits_root, known_paths=known_paths, known_file_stats=known_file_stats,
-        on_progress=lambda count: set_discovered_sync(_redis, count),
-        is_cancelled=lambda: is_cancel_requested_sync(_redis),
-        on_new_file=_queue_file,
-        on_changed_file=_queue_changed_file,
-    )
+    new_files: list[Path] = []
+    changed_files: list[Path] = []
+    all_disk_paths: set[str] = set()
+
+    for scan_root in filter_config.roots(fits_root):
+        if is_cancel_requested_sync(_redis):
+            break
+        nf, cf, paths = scan_directory(
+            scan_root,
+            known_paths=known_paths,
+            known_file_stats=known_file_stats,
+            on_progress=lambda count: set_discovered_sync(_redis, count),
+            is_cancelled=lambda: is_cancel_requested_sync(_redis),
+            on_new_file=_queue_file,
+            on_changed_file=_queue_changed_file,
+            filter_config=filter_config,
+            fits_root=fits_root,
+        )
+        new_files.extend(nf)
+        changed_files.extend(cf)
+        all_disk_paths.update(paths)
 
     if is_cancel_requested_sync(_redis):
         set_cancelled_sync(_redis)

--- a/backend/app/worker/tasks.py
+++ b/backend/app/worker/tasks.py
@@ -228,6 +228,12 @@ def auto_scan_tick():
     if row is None or not (row.general or {}).get("auto_scan_enabled", True):
         return
 
+    # Gate auto-scan on first boot until the user has reviewed scan filters.
+    # The onboarding banner lets them either configure rules or explicitly
+    # accept defaults, which flips this flag. Manual scans remain unaffected.
+    if not (row.general or {}).get("scan_filters_configured"):
+        return
+
     interval_minutes = (row.general or {}).get("auto_scan_interval", 240)
     last_run_str = _redis.get("autoscan:last_run")
     now = time.time()

--- a/backend/app/worker/tasks.py
+++ b/backend/app/worker/tasks.py
@@ -135,10 +135,18 @@ def run_scan(self, include_calibration: bool = True) -> dict:
             "timestamp": time.time(),
         })
 
-    # Detect and remove orphaned DB records (files deleted from disk)
-    orphaned_paths = known_paths - all_disk_paths
+    # Detect and remove orphaned DB records (files deleted from disk).
+    # CRITICAL: only consider rows the walker would have actually visited
+    # under the current filter config. When include_paths or excludes narrow
+    # the scan, out-of-scope rows appear "missing from disk" even though the
+    # walker never looked for them. Those must NOT be treated as orphans.
+    in_scope_known_paths = {
+        p for p in known_paths
+        if p and filter_config.should_include_file(Path(p), fits_root)
+    }
+    orphaned_paths = in_scope_known_paths - all_disk_paths
     removed = 0
-    if orphaned_paths and len(orphaned_paths) < len(known_paths) * 0.5:
+    if orphaned_paths and len(orphaned_paths) < max(1, len(in_scope_known_paths)) * 0.5:
         # Safety: only clean up if less than 50% of files appear missing
         # (protects against unmounted shares / unreachable storage)
         with Session(_sync_engine) as session:
@@ -171,14 +179,14 @@ def run_scan(self, include_calibration: bool = True) -> dict:
             })
     elif orphaned_paths:
         logger.warning(
-            "Skipped orphan cleanup: %d of %d files missing (>50%%) - "
+            "Skipped orphan cleanup: %d of %d in-scope files missing (>50%%) - "
             "possible unmounted share or unreachable storage",
-            len(orphaned_paths), len(known_paths),
+            len(orphaned_paths), len(in_scope_known_paths),
         )
         append_activity_sync(_redis, {
             "type": "orphan_warning",
-            "message": f"Orphan cleanup skipped: {len(orphaned_paths)} of {len(known_paths)} files missing (>50%) - possible unmounted share",
-            "details": {"missing": len(orphaned_paths), "total_known": len(known_paths)},
+            "message": f"Orphan cleanup skipped: {len(orphaned_paths)} of {len(in_scope_known_paths)} in-scope files missing (>50%) - possible unmounted share",
+            "details": {"missing": len(orphaned_paths), "total_known": len(in_scope_known_paths)},
             "timestamp": time.time(),
         })
 

--- a/backend/tests/test_scan_filters.py
+++ b/backend/tests/test_scan_filters.py
@@ -99,6 +99,71 @@ def test_roots_returns_fits_root_when_includes_empty(tmp_path):
     assert cfg.roots(tmp_path) == [tmp_path]
 
 
+def _cfg(include_paths=None, exclude_paths=None, rules=None):
+    return ScanFilterConfig(
+        include_paths=include_paths or [],
+        exclude_paths=exclude_paths or [],
+        name_rules=rules or [],
+    )
+
+
+def test_should_walk_dir_prunes_exclude_paths(tmp_path):
+    (tmp_path / "rejected").mkdir()
+    cfg = _cfg(exclude_paths=[tmp_path / "rejected"])
+    assert not cfg.should_walk_dir(tmp_path / "rejected", tmp_path)
+    assert not cfg.should_walk_dir(tmp_path / "rejected" / "sub", tmp_path)
+    assert cfg.should_walk_dir(tmp_path / "kept", tmp_path)
+
+
+def test_should_walk_dir_exclude_folder_name_rule(tmp_path):
+    cfg = _cfg(rules=[_rule(
+        type="substring", pattern="rejected", target="folder", action="exclude",
+    )])
+    (tmp_path / "2025_rejected").mkdir()
+    assert not cfg.should_walk_dir(tmp_path / "2025_rejected", tmp_path)
+    assert cfg.should_walk_dir(tmp_path / "2025_kept", tmp_path)
+
+
+def test_should_include_file_exclude_wins(tmp_path):
+    cfg = _cfg(rules=[
+        _rule(id="i1", action="include", type="glob",
+              pattern="*.fits", target="file"),
+        _rule(id="e1", action="exclude", type="glob",
+              pattern="*_bad.fits", target="file"),
+    ])
+    assert cfg.should_include_file(tmp_path / "frame.fits", tmp_path)
+    assert not cfg.should_include_file(tmp_path / "frame_bad.fits", tmp_path)
+
+
+def test_should_include_file_include_narrowing(tmp_path):
+    # An include rule exists for 'file' target, so files must match at least one
+    cfg = _cfg(rules=[
+        _rule(id="i1", action="include", type="regex",
+              pattern=r"^M\d+_.*\.fits$", target="file"),
+    ])
+    assert cfg.should_include_file(tmp_path / "M31_L.fits", tmp_path)
+    assert not cfg.should_include_file(tmp_path / "NGC7000_L.fits", tmp_path)
+
+
+def test_should_include_file_no_includes_passes_all(tmp_path):
+    cfg = _cfg(rules=[
+        _rule(id="e1", action="exclude", type="substring",
+              pattern="tmp", target="file"),
+    ])
+    assert cfg.should_include_file(tmp_path / "frame.fits", tmp_path)
+    assert not cfg.should_include_file(tmp_path / "frame.tmp", tmp_path)
+
+
+def test_should_include_file_folder_rule_applies_to_ancestors(tmp_path):
+    (tmp_path / "rejected" / "sub").mkdir(parents=True)
+    cfg = _cfg(rules=[_rule(
+        id="e1", action="exclude", type="substring", pattern="rejected",
+        target="folder",
+    )])
+    f = tmp_path / "rejected" / "sub" / "frame.fits"
+    assert not cfg.should_include_file(f, tmp_path)
+
+
 def test_roots_returns_includes_when_set(tmp_path):
     (tmp_path / "a").mkdir()
     (tmp_path / "b").mkdir()

--- a/backend/tests/test_scan_filters.py
+++ b/backend/tests/test_scan_filters.py
@@ -224,3 +224,59 @@ def test_should_include_file_respects_include_paths(tmp_path):
     cfg = _cfg(include_paths=[tmp_path / "kept"])
     assert cfg.should_include_file(tmp_path / "kept" / "x.fits", tmp_path)
     assert not cfg.should_include_file(tmp_path / "other" / "x.fits", tmp_path)
+
+
+def test_test_path_folder_target_uses_full_segments(tmp_path):
+    """When target_kind is folder, the trailing component is a segment too."""
+    (tmp_path / "M31").mkdir()
+    cfg = _cfg(rules=[_rule(
+        id="i1", action="include", type="regex",
+        pattern=r"^M\d+$", target="folder",
+    )])
+    # As a folder test, M31 matches the folder-include rule
+    assert cfg.test_path(tmp_path / "M31", tmp_path, target_kind="folder").verdict == "included"
+    # As a file test on the same path, M31 is treated as a filename and the
+    # include rule (which targets folders) does not narrow it
+    assert cfg.test_path(tmp_path / "M31", tmp_path, target_kind="file").verdict == "included"
+
+
+def test_test_path_folder_target_matches_exclude_folder_rule(tmp_path):
+    cfg = _cfg(rules=[_rule(
+        id="e1", action="exclude", type="substring",
+        pattern="rejected", target="folder",
+    )])
+    r = cfg.test_path(tmp_path / "rejected", tmp_path, target_kind="folder")
+    assert r.verdict == "excluded_by_rule"
+    assert "e1" in r.matched_rule_ids
+
+
+def test_test_path_auto_detects_dir_on_disk(tmp_path):
+    (tmp_path / "kept").mkdir()
+    cfg = _cfg(rules=[_rule(
+        id="e1", action="exclude", type="substring",
+        pattern="kept", target="folder",
+    )])
+    # auto mode should detect the existing dir and evaluate as folder
+    assert cfg.test_path(tmp_path / "kept", tmp_path).verdict == "excluded_by_rule"
+
+
+def test_test_path_resolves_dotdot(tmp_path):
+    (tmp_path / "a").mkdir()
+    cfg = _cfg()
+    # /root/a/../a/x.fits should resolve to /root/a/x.fits and pass
+    r = cfg.test_path(tmp_path / "a" / ".." / "a" / "x.fits", tmp_path)
+    assert r.verdict == "included"
+
+
+def test_should_walk_dir_prunes_on_ancestor_segment(tmp_path):
+    (tmp_path / "rejected" / "inner" / "deep").mkdir(parents=True)
+    cfg = _cfg(rules=[_rule(
+        id="e1", action="exclude", type="substring",
+        pattern="rejected", target="folder",
+    )])
+    # "inner" name alone doesn't match, but an ancestor "rejected" does
+    assert not cfg.should_walk_dir(tmp_path / "rejected" / "inner", tmp_path)
+    assert not cfg.should_walk_dir(tmp_path / "rejected" / "inner" / "deep", tmp_path)
+    # A sibling without the ancestor should still be walkable
+    (tmp_path / "kept").mkdir()
+    assert cfg.should_walk_dir(tmp_path / "kept", tmp_path)

--- a/backend/tests/test_scan_filters.py
+++ b/backend/tests/test_scan_filters.py
@@ -206,3 +206,21 @@ def test_test_path_excluded_by_missing_include(tmp_path):
     )])
     result = cfg.test_path(tmp_path / "NGC7000.fits", tmp_path)
     assert result.verdict == "excluded_by_missing_include"
+
+
+def test_test_path_excluded_when_outside_include_paths(tmp_path):
+    (tmp_path / "kept").mkdir()
+    (tmp_path / "other").mkdir()
+    cfg = _cfg(include_paths=[tmp_path / "kept"])
+    assert cfg.test_path(tmp_path / "kept" / "x.fits", tmp_path).verdict == "included"
+    assert cfg.test_path(tmp_path / "other" / "x.fits", tmp_path).verdict == "excluded_by_path"
+    # The fits_root itself, when include_paths is set, is not under any include
+    assert cfg.test_path(tmp_path, tmp_path).verdict == "excluded_by_path"
+
+
+def test_should_include_file_respects_include_paths(tmp_path):
+    (tmp_path / "kept").mkdir()
+    (tmp_path / "other").mkdir()
+    cfg = _cfg(include_paths=[tmp_path / "kept"])
+    assert cfg.should_include_file(tmp_path / "kept" / "x.fits", tmp_path)
+    assert not cfg.should_include_file(tmp_path / "other" / "x.fits", tmp_path)

--- a/backend/tests/test_scan_filters.py
+++ b/backend/tests/test_scan_filters.py
@@ -1,7 +1,7 @@
 import pytest
 from pathlib import Path
 
-from app.services.scan_filters import NameRule
+from app.services.scan_filters import NameRule, ScanFilterConfig
 
 
 def _rule(**kwargs):
@@ -52,3 +52,59 @@ def test_disabled_rule_never_matches():
 def test_invalid_regex_raises_at_construction():
     with pytest.raises(ValueError, match="invalid regex"):
         _rule(type="regex", pattern="[unclosed")
+
+
+def test_from_settings_empty(tmp_path):
+    cfg = ScanFilterConfig.from_settings({}, tmp_path)
+    assert cfg.include_paths == []
+    assert cfg.exclude_paths == []
+    assert cfg.name_rules == []
+
+
+def test_from_settings_parses_paths_and_rules(tmp_path):
+    (tmp_path / "2025").mkdir()
+    (tmp_path / "2025" / "rejected").mkdir()
+    general = {
+        "scan_filters": {
+            "include_paths": [str(tmp_path / "2025")],
+            "exclude_paths": [str(tmp_path / "2025" / "rejected")],
+            "name_rules": [
+                {"id": "r1", "action": "exclude", "type": "glob",
+                 "pattern": "*_bad.fits", "target": "file", "enabled": True},
+            ],
+        }
+    }
+    cfg = ScanFilterConfig.from_settings(general, tmp_path)
+    assert len(cfg.include_paths) == 1
+    assert len(cfg.exclude_paths) == 1
+    assert len(cfg.name_rules) == 1
+
+
+def test_from_settings_rejects_path_outside_root(tmp_path):
+    outside = tmp_path.parent / "escape"
+    outside.mkdir(exist_ok=True)
+    general = {
+        "scan_filters": {
+            "include_paths": [str(outside)],
+            "exclude_paths": [],
+            "name_rules": [],
+        }
+    }
+    with pytest.raises(ValueError, match="outside configured data path"):
+        ScanFilterConfig.from_settings(general, tmp_path)
+
+
+def test_roots_returns_fits_root_when_includes_empty(tmp_path):
+    cfg = ScanFilterConfig(include_paths=[], exclude_paths=[], name_rules=[])
+    assert cfg.roots(tmp_path) == [tmp_path]
+
+
+def test_roots_returns_includes_when_set(tmp_path):
+    (tmp_path / "a").mkdir()
+    (tmp_path / "b").mkdir()
+    cfg = ScanFilterConfig(
+        include_paths=[tmp_path / "a", tmp_path / "b"],
+        exclude_paths=[],
+        name_rules=[],
+    )
+    assert cfg.roots(tmp_path) == [tmp_path / "a", tmp_path / "b"]

--- a/backend/tests/test_scan_filters.py
+++ b/backend/tests/test_scan_filters.py
@@ -1,7 +1,7 @@
 import pytest
 from pathlib import Path
 
-from app.services.scan_filters import NameRule, ScanFilterConfig
+from app.services.scan_filters import NameRule, ScanFilterConfig, TestResult
 
 
 def _rule(**kwargs):
@@ -173,3 +173,36 @@ def test_roots_returns_includes_when_set(tmp_path):
         name_rules=[],
     )
     assert cfg.roots(tmp_path) == [tmp_path / "a", tmp_path / "b"]
+
+
+def test_test_path_included(tmp_path):
+    cfg = _cfg()
+    result = cfg.test_path(tmp_path / "M31" / "frame.fits", tmp_path)
+    assert result.verdict == "included"
+    assert result.matched_rule_ids == []
+
+
+def test_test_path_excluded_by_path(tmp_path):
+    (tmp_path / "rejected").mkdir()
+    cfg = _cfg(exclude_paths=[tmp_path / "rejected"])
+    result = cfg.test_path(tmp_path / "rejected" / "x.fits", tmp_path)
+    assert result.verdict == "excluded_by_path"
+
+
+def test_test_path_excluded_by_rule(tmp_path):
+    cfg = _cfg(rules=[_rule(
+        id="e1", action="exclude", type="glob",
+        pattern="*_bad.fits", target="file",
+    )])
+    result = cfg.test_path(tmp_path / "frame_bad.fits", tmp_path)
+    assert result.verdict == "excluded_by_rule"
+    assert "e1" in result.matched_rule_ids
+
+
+def test_test_path_excluded_by_missing_include(tmp_path):
+    cfg = _cfg(rules=[_rule(
+        id="i1", action="include", type="glob",
+        pattern="M*.fits", target="file",
+    )])
+    result = cfg.test_path(tmp_path / "NGC7000.fits", tmp_path)
+    assert result.verdict == "excluded_by_missing_include"

--- a/backend/tests/test_scan_filters.py
+++ b/backend/tests/test_scan_filters.py
@@ -1,0 +1,54 @@
+import pytest
+from pathlib import Path
+
+from app.services.scan_filters import NameRule
+
+
+def _rule(**kwargs):
+    defaults = {
+        "id": "r1", "action": "exclude", "type": "glob",
+        "pattern": "*.tmp", "target": "file", "enabled": True,
+    }
+    defaults.update(kwargs)
+    return NameRule(**defaults)
+
+
+def test_glob_matches_filename():
+    r = _rule(type="glob", pattern="*_bad.fits")
+    assert r.matches("frame_bad.fits")
+    assert not r.matches("frame_good.fits")
+
+
+def test_glob_double_star_segment():
+    r = _rule(type="glob", pattern="**/rejected/**", target="folder")
+    # folder rule sees individual segments; ** is not meaningful against a single
+    # segment, so this rule instead must be written as substring or regex.
+    # Glob for folders matches a single segment name.
+    r2 = _rule(type="glob", pattern="rejected", target="folder")
+    assert r2.matches("rejected")
+    assert not r2.matches("accepted")
+
+
+def test_substring_case_insensitive():
+    r = _rule(type="substring", pattern="Rejected", target="folder")
+    assert r.matches("2025_rejected_frames")
+    assert r.matches("REJECTED")
+    assert not r.matches("accepted")
+
+
+def test_regex_anchored():
+    r = _rule(type="regex", pattern=r"^M\d+$", target="folder")
+    assert r.matches("M31")
+    assert r.matches("M101")
+    assert not r.matches("NGC7000")
+    assert not r.matches("M31_v2")
+
+
+def test_disabled_rule_never_matches():
+    r = _rule(type="substring", pattern="bad", enabled=False)
+    assert not r.matches("bad")
+
+
+def test_invalid_regex_raises_at_construction():
+    with pytest.raises(ValueError, match="invalid regex"):
+        _rule(type="regex", pattern="[unclosed")

--- a/backend/tests/test_scan_filters_api.py
+++ b/backend/tests/test_scan_filters_api.py
@@ -1,0 +1,215 @@
+"""API tests for /scan/filters endpoints.
+
+The conftest does not provide an authenticated http client fixture, so each
+test constructs an AsyncClient + ASGITransport and overrides auth/session
+dependencies inline, following the pattern used in test_api_backup.py.
+"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+from app.database import get_session
+from app.api.deps import get_current_user, require_admin
+from app.models.user import User, UserRole
+
+
+@pytest.fixture
+def admin_user():
+    user = MagicMock(spec=User)
+    user.id = "00000000-0000-0000-0000-000000000001"
+    user.username = "admin"
+    user.role = UserRole.admin
+    return user
+
+
+def _override_admin(session_mock, admin_user):
+    async def override_session():
+        yield session_mock
+    app.dependency_overrides[get_session] = override_session
+    app.dependency_overrides[require_admin] = lambda: admin_user
+    app.dependency_overrides[get_current_user] = lambda: admin_user
+
+
+def _scalar_one_or_none(value):
+    result = MagicMock()
+    result.scalar_one_or_none = MagicMock(return_value=value)
+    return result
+
+
+def _make_session(settings_row=None):
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_scalar_one_or_none(settings_row))
+    session.add = MagicMock()
+    session.commit = AsyncMock()
+    return session
+
+
+@pytest.mark.asyncio
+async def test_get_filters_unconfigured_by_default(admin_user):
+    session = _make_session(settings_row=None)
+    _override_admin(session, admin_user)
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            r = await client.get("/api/scan/filters")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["configured"] is False
+        assert body["filters"]["include_paths"] == []
+        assert body["filters"]["exclude_paths"] == []
+        assert body["filters"]["name_rules"] == []
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_put_filters_sets_configured(admin_user):
+    session = _make_session(settings_row=None)
+    _override_admin(session, admin_user)
+    try:
+        payload = {
+            "include_paths": [],
+            "exclude_paths": [],
+            "name_rules": [{
+                "id": "r1", "action": "exclude", "type": "glob",
+                "pattern": "*_bad.fits", "target": "file", "enabled": True,
+            }],
+        }
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            r = await client.put("/api/scan/filters", json=payload)
+        assert r.status_code == 200
+        body = r.json()
+        assert body["configured"] is True
+        assert len(body["filters"]["name_rules"]) == 1
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_put_filters_rejects_invalid_regex(admin_user):
+    session = _make_session(settings_row=None)
+    _override_admin(session, admin_user)
+    try:
+        payload = {
+            "include_paths": [], "exclude_paths": [],
+            "name_rules": [{
+                "id": "r1", "action": "exclude", "type": "regex",
+                "pattern": "[unclosed", "target": "file", "enabled": True,
+            }],
+        }
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            r = await client.put("/api/scan/filters", json=payload)
+        assert r.status_code == 400
+        assert "invalid regex" in r.json()["detail"].lower()
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_put_filters_rejects_path_outside_root(admin_user):
+    session = _make_session(settings_row=None)
+    _override_admin(session, admin_user)
+    try:
+        payload = {
+            "include_paths": ["/etc"],
+            "exclude_paths": [],
+            "name_rules": [],
+        }
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            r = await client.put("/api/scan/filters", json=payload)
+        assert r.status_code == 400
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_put_filters_requires_admin():
+    """Without overriding require_admin, the endpoint must reject."""
+    # Clear any lingering overrides
+    app.dependency_overrides.clear()
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            r = await client.put("/api/scan/filters", json={
+                "include_paths": [], "exclude_paths": [], "name_rules": [],
+            })
+        assert r.status_code in (401, 403)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_test_path_endpoint(admin_user):
+    # Pre-populate the session with an existing scan_filters row so the
+    # endpoint can load them directly (avoids relying on PUT persistence).
+    existing_row = MagicMock()
+    existing_row.general = {
+        "scan_filters": {
+            "include_paths": [],
+            "exclude_paths": [],
+            "name_rules": [{
+                "id": "e1", "action": "exclude", "type": "glob",
+                "pattern": "*_bad.fits", "target": "file", "enabled": True,
+            }],
+        },
+        "scan_filters_configured": True,
+    }
+    session = _make_session(settings_row=existing_row)
+    _override_admin(session, admin_user)
+    try:
+        # Use a path under the configured fits_data_path (/tmp/test_fits per conftest)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            r = await client.post(
+                "/api/scan/filters/test",
+                json={"path": "/tmp/test_fits/frame_bad.fits"},
+            )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["verdict"] == "excluded_by_rule"
+        assert "e1" in body["matched_rule_ids"]
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_apply_now_dry_run(admin_user):
+    # First execute returns the settings row (None), subsequent call returns
+    # paths_result iterable with .all() returning an empty list.
+    empty_rows = MagicMock()
+    empty_rows.all = MagicMock(return_value=[])
+    settings_result = _scalar_one_or_none(None)
+
+    session = AsyncMock()
+    # Sequence: 1) settings lookup, 2) Image paths select
+    session.execute = AsyncMock(side_effect=[settings_result, empty_rows])
+    session.commit = AsyncMock()
+
+    _override_admin(session, admin_user)
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            r = await client.post("/api/scan/filters/apply-now?dry_run=true")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["dry_run"] is True
+        assert body["matched"] == 0
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_browse_rejects_escape(admin_user):
+    session = _make_session(settings_row=None)
+    _override_admin(session, admin_user)
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            r = await client.get("/api/scan/browse", params={"path": "/etc"})
+        assert r.status_code == 400
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/test_scan_filters_api.py
+++ b/backend/tests/test_scan_filters_api.py
@@ -127,6 +127,49 @@ async def test_put_filters_rejects_path_outside_root(admin_user):
 
 
 @pytest.mark.asyncio
+async def test_put_filters_rejects_duplicate_rule_ids(admin_user):
+    session = _make_session(settings_row=None)
+    _override_admin(session, admin_user)
+    try:
+        payload = {
+            "include_paths": [], "exclude_paths": [],
+            "name_rules": [
+                {"id": "dup", "action": "exclude", "type": "glob",
+                 "pattern": "*.tmp", "target": "file", "enabled": True},
+                {"id": "dup", "action": "exclude", "type": "glob",
+                 "pattern": "*.bak", "target": "file", "enabled": True},
+            ],
+        }
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            r = await client.put("/api/scan/filters", json=payload)
+        assert r.status_code == 422
+        assert "duplicate" in r.text.lower()
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_put_filters_rejects_control_chars_in_pattern(admin_user):
+    session = _make_session(settings_row=None)
+    _override_admin(session, admin_user)
+    try:
+        payload = {
+            "include_paths": [], "exclude_paths": [],
+            "name_rules": [{
+                "id": "r1", "action": "exclude", "type": "substring",
+                "pattern": "bad\x00pattern", "target": "file", "enabled": True,
+            }],
+        }
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            r = await client.put("/api/scan/filters", json=payload)
+        assert r.status_code == 422
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
 async def test_put_filters_requires_admin():
     """Without overriding require_admin, the endpoint must reject."""
     # Clear any lingering overrides

--- a/backend/tests/test_scanner_with_filters.py
+++ b/backend/tests/test_scanner_with_filters.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+
+from app.services.scanner import scan_directory
+from app.services.scan_filters import ScanFilterConfig, NameRule
+
+
+def _touch(p: Path) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(b"")
+
+
+def _make_tree(root: Path) -> None:
+    _touch(root / "2025" / "M31" / "frame_01.fits")
+    _touch(root / "2025" / "M31" / "frame_bad.fits")
+    _touch(root / "2025" / "rejected" / "frame_02.fits")
+    _touch(root / "2024" / "M42" / "frame_03.fits")
+    _touch(root / "calibration" / "darks" / "dark_01.fits")
+
+
+def test_scan_without_filters_finds_all(tmp_path):
+    _make_tree(tmp_path)
+    new_files, _, _ = scan_directory(tmp_path)
+    assert len(new_files) == 5
+
+
+def test_scan_with_exclude_path_prunes_subtree(tmp_path):
+    _make_tree(tmp_path)
+    cfg = ScanFilterConfig(
+        include_paths=[],
+        exclude_paths=[(tmp_path / "calibration").resolve()],
+        name_rules=[],
+    )
+    new_files, _, _ = scan_directory(tmp_path, filter_config=cfg)
+    names = {f.name for f in new_files}
+    assert "dark_01.fits" not in names
+    assert len(new_files) == 4
+
+
+def test_scan_with_file_exclude_rule(tmp_path):
+    _make_tree(tmp_path)
+    cfg = ScanFilterConfig(
+        include_paths=[],
+        exclude_paths=[],
+        name_rules=[NameRule(
+            id="e1", action="exclude", type="glob",
+            pattern="*_bad.fits", target="file", enabled=True,
+        )],
+    )
+    new_files, _, _ = scan_directory(tmp_path, filter_config=cfg)
+    names = {f.name for f in new_files}
+    assert "frame_bad.fits" not in names
+    assert "frame_01.fits" in names
+
+
+def test_scan_with_folder_exclude_rule_prunes(tmp_path):
+    _make_tree(tmp_path)
+    cfg = ScanFilterConfig(
+        include_paths=[],
+        exclude_paths=[],
+        name_rules=[NameRule(
+            id="e1", action="exclude", type="substring",
+            pattern="rejected", target="folder", enabled=True,
+        )],
+    )
+    new_files, _, _ = scan_directory(tmp_path, filter_config=cfg)
+    assert not any("rejected" in str(f) for f in new_files)

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -131,7 +131,7 @@ async function extractApiError(resp: Response, fallback: string): Promise<ApiErr
   return new ApiError(resp.status, message);
 }
 
-async function fetchJson<T>(path: string, init?: RequestInit, signal?: AbortSignal): Promise<T> {
+export async function fetchJson<T>(path: string, init?: RequestInit, signal?: AbortSignal): Promise<T> {
   const resp = await fetch(`${API_BASE}${path}`, {
     credentials: "same-origin",
     ...init,

--- a/frontend/src/api/scanFilters.ts
+++ b/frontend/src/api/scanFilters.ts
@@ -1,0 +1,76 @@
+import { fetchJson } from "./client";
+
+export type RuleAction = "include" | "exclude";
+export type RuleType = "glob" | "substring" | "regex";
+export type RuleTarget = "file" | "folder";
+
+export interface NameRule {
+  id: string;
+  action: RuleAction;
+  type: RuleType;
+  pattern: string;
+  target: RuleTarget;
+  enabled: boolean;
+}
+
+export interface ScanFilters {
+  include_paths: string[];
+  exclude_paths: string[];
+  name_rules: NameRule[];
+}
+
+export interface ScanFiltersResponse {
+  configured: boolean;
+  filters: ScanFilters;
+  fits_root: string;
+}
+
+export type Verdict =
+  | "included"
+  | "excluded_by_path"
+  | "excluded_by_rule"
+  | "excluded_by_missing_include";
+
+export interface TestResult {
+  verdict: Verdict;
+  matched_rule_ids: string[];
+}
+
+export interface BrowseEntry {
+  name: string;
+  path: string;
+  has_children: boolean;
+}
+
+export interface ApplyNowResult {
+  dry_run: boolean;
+  matched: number;
+}
+
+export const scanFilters = {
+  get: (): Promise<ScanFiltersResponse> =>
+    fetchJson<ScanFiltersResponse>("/scan/filters"),
+
+  put: (filters: ScanFilters): Promise<ScanFiltersResponse> =>
+    fetchJson<ScanFiltersResponse>("/scan/filters", {
+      method: "PUT",
+      body: JSON.stringify(filters),
+    }),
+
+  test: (path: string): Promise<TestResult> =>
+    fetchJson<TestResult>("/scan/filters/test", {
+      method: "POST",
+      body: JSON.stringify({ path }),
+    }),
+
+  applyNow: (dryRun: boolean): Promise<ApplyNowResult> =>
+    fetchJson<ApplyNowResult>(
+      `/scan/filters/apply-now?dry_run=${dryRun}`,
+      { method: "POST" },
+    ),
+
+  browse: (path?: string): Promise<BrowseEntry[]> => {
+    const q = path ? `?path=${encodeURIComponent(path)}` : "";
+    return fetchJson<BrowseEntry[]>(`/scan/browse${q}`);
+  },
+};

--- a/frontend/src/api/scanFilters.ts
+++ b/frontend/src/api/scanFilters.ts
@@ -57,10 +57,13 @@ export const scanFilters = {
       body: JSON.stringify(filters),
     }),
 
-  test: (path: string): Promise<TestResult> =>
+  test: (
+    path: string,
+    targetKind: "auto" | "file" | "folder" = "auto",
+  ): Promise<TestResult> =>
     fetchJson<TestResult>("/scan/filters/test", {
       method: "POST",
-      body: JSON.stringify({ path }),
+      body: JSON.stringify({ path, target_kind: targetKind }),
     }),
 
   applyNow: (dryRun: boolean): Promise<ApplyNowResult> =>

--- a/frontend/src/components/ActivityFeed.tsx
+++ b/frontend/src/components/ActivityFeed.tsx
@@ -92,8 +92,8 @@ const ActivityFeed: Component<{
     formatDateTime(new Date(ts * 1000), settingsCtx.timezone()) + " " + timezoneLabel(settingsCtx.timezone());
 
   return (
-    <div class="bg-theme-surface border border-theme-border rounded-[var(--radius-md)] shadow-[var(--shadow-sm)] p-4 space-y-3">
-      <div class="flex justify-between items-center flex-wrap gap-2">
+    <div class="bg-theme-surface border border-theme-border rounded-[var(--radius-md)] shadow-[var(--shadow-sm)] p-4 flex flex-col h-full min-h-0">
+      <div class="flex justify-between items-center flex-wrap gap-2 mb-3">
         <h3 class="text-theme-text-primary font-medium">Activity</h3>
         <Show when={activity().length > 0 && !isActive()}>
           <button
@@ -105,6 +105,7 @@ const ActivityFeed: Component<{
         </Show>
       </div>
 
+      <div class="flex-1 min-h-0 overflow-y-auto space-y-3">
       <Show when={props.scanError}>
         <p class="text-xs text-theme-error">{props.scanError}</p>
       </Show>
@@ -233,6 +234,7 @@ const ActivityFeed: Component<{
       <Show when={!isActive() && props.rebuildStatus.state !== "running" && props.scanStatus.state !== "stalled" && activity().length === 0 && !props.scanError}>
         <p class="text-xs text-theme-text-secondary">No recent activity</p>
       </Show>
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/FolderBrowserModal.tsx
+++ b/frontend/src/components/FolderBrowserModal.tsx
@@ -1,4 +1,4 @@
-import { Component, createSignal, createEffect, Show, For } from "solid-js";
+import { Component, createSignal, createEffect, onCleanup, Show, For } from "solid-js";
 import { scanFilters } from "../api/scanFilters";
 import type { BrowseEntry } from "../api/scanFilters";
 
@@ -14,8 +14,19 @@ interface TreeNode {
   entry: BrowseEntry;
   expanded: boolean;
   loaded: boolean;
+  loading: boolean;
+  error: string | null;
   children: TreeNode[];
 }
+
+const makeNode = (e: BrowseEntry): TreeNode => ({
+  entry: e,
+  expanded: false,
+  loaded: false,
+  loading: false,
+  error: null,
+  children: [],
+});
 
 const FolderBrowserModal: Component<Props> = (props) => {
   const [nodes, setNodes] = createSignal<TreeNode[]>([]);
@@ -28,9 +39,7 @@ const FolderBrowserModal: Component<Props> = (props) => {
     setError(null);
     try {
       const entries = await scanFilters.browse();
-      setNodes(entries.map((e) => ({
-        entry: e, expanded: false, loaded: false, children: [],
-      })));
+      setNodes(entries.map(makeNode));
     } catch (e: any) {
       setError(e?.message ?? "Failed to load folders");
     } finally {
@@ -45,19 +54,31 @@ const FolderBrowserModal: Component<Props> = (props) => {
       return;
     }
     if (!node.loaded) {
+      node.loading = true;
+      node.error = null;
+      setNodes([...nodes()]);
       try {
         const children = await scanFilters.browse(node.entry.path);
-        node.children = children.map((e) => ({
-          entry: e, expanded: false, loaded: false, children: [],
-        }));
+        node.children = children.map(makeNode);
         node.loaded = true;
+        node.error = null;
       } catch (e: any) {
-        setError(e?.message ?? "Failed to load");
+        node.error = e?.message ?? "Failed to load";
+        node.loading = false;
+        setNodes([...nodes()]);
         return;
+      } finally {
+        node.loading = false;
       }
     }
     node.expanded = true;
     setNodes([...nodes()]);
+  };
+
+  const retryLoad = async (node: TreeNode) => {
+    node.loaded = false;
+    node.error = null;
+    await toggle(node);
   };
 
   const toggleSelected = (path: string) => {
@@ -74,6 +95,12 @@ const FolderBrowserModal: Component<Props> = (props) => {
     }
   });
 
+  const onKey = (e: KeyboardEvent) => {
+    if (e.key === "Escape" && props.open) props.onCancel();
+  };
+  window.addEventListener("keydown", onKey);
+  onCleanup(() => window.removeEventListener("keydown", onKey));
+
   const renderNode = (node: TreeNode, depth: number) => (
     <div>
       <div
@@ -89,12 +116,24 @@ const FolderBrowserModal: Component<Props> = (props) => {
           when={node.entry.has_children}
           fallback={<span class="w-4 inline-block" />}
         >
-          <span
-            class="w-4 text-theme-text-secondary select-none"
-            aria-hidden="true"
+          <Show
+            when={!node.loading}
+            fallback={
+              <span
+                class="w-4 inline-block text-theme-text-secondary animate-pulse select-none"
+                aria-hidden="true"
+              >
+                ⋯
+              </span>
+            }
           >
-            {node.expanded ? "▾" : "▸"}
-          </span>
+            <span
+              class="w-4 text-theme-text-secondary select-none"
+              aria-hidden="true"
+            >
+              {node.expanded ? "▾" : "▸"}
+            </span>
+          </Show>
         </Show>
         <input
           type="checkbox"
@@ -104,6 +143,23 @@ const FolderBrowserModal: Component<Props> = (props) => {
         />
         <span class="text-sm text-theme-text-primary truncate">{node.entry.name}</span>
       </div>
+      <Show when={node.error}>
+        <div
+          class="flex items-center gap-2 text-xs text-theme-error"
+          style={{ "padding-left": `${depth * 16 + 28}px` }}
+        >
+          <span>{node.error}</span>
+          <button
+            class="underline hover:no-underline"
+            onClick={(e) => {
+              e.stopPropagation();
+              retryLoad(node);
+            }}
+          >
+            Retry
+          </button>
+        </div>
+      </Show>
       <Show when={node.expanded}>
         <For each={node.children}>
           {(child) => renderNode(child, depth + 1)}
@@ -114,20 +170,38 @@ const FolderBrowserModal: Component<Props> = (props) => {
 
   return (
     <Show when={props.open}>
-      <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+      <div
+        class="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="folder-browser-title"
+      >
         <div class="bg-theme-surface border border-theme-border rounded-[var(--radius-md)] w-full max-w-xl max-h-[80vh] flex flex-col">
           <div class="p-4 border-b border-theme-border">
-            <h3 class="text-sm font-medium text-theme-text-primary">{props.title}</h3>
+            <h3
+              id="folder-browser-title"
+              class="text-sm font-medium text-theme-text-primary"
+            >
+              {props.title}
+            </h3>
             <p class="text-xs text-theme-text-secondary mt-1">
               Browse folders under <code>{props.fitsRoot}</code>
             </p>
           </div>
           <div class="flex-1 overflow-y-auto p-2">
             <Show when={loading()}>
-              <div class="p-4 text-sm">Loading…</div>
+              <div class="p-4 text-sm text-theme-text-secondary">Loading…</div>
             </Show>
             <Show when={error()}>
-              <div class="p-4 text-sm text-red-400">{error()}</div>
+              <div class="p-4 text-sm text-theme-error flex items-center gap-2">
+                <span>{error()}</span>
+                <button
+                  class="underline hover:no-underline"
+                  onClick={() => loadRoot()}
+                >
+                  Retry
+                </button>
+              </div>
             </Show>
             <For each={nodes()}>{(n) => renderNode(n, 0)}</For>
           </div>

--- a/frontend/src/components/FolderBrowserModal.tsx
+++ b/frontend/src/components/FolderBrowserModal.tsx
@@ -1,0 +1,155 @@
+import { Component, createSignal, createEffect, Show, For } from "solid-js";
+import { scanFilters } from "../api/scanFilters";
+import type { BrowseEntry } from "../api/scanFilters";
+
+interface Props {
+  open: boolean;
+  fitsRoot: string;
+  title: string;
+  onCancel: () => void;
+  onConfirm: (paths: string[]) => void;
+}
+
+interface TreeNode {
+  entry: BrowseEntry;
+  expanded: boolean;
+  loaded: boolean;
+  children: TreeNode[];
+}
+
+const FolderBrowserModal: Component<Props> = (props) => {
+  const [nodes, setNodes] = createSignal<TreeNode[]>([]);
+  const [selected, setSelected] = createSignal<Set<string>>(new Set());
+  const [loading, setLoading] = createSignal(false);
+  const [error, setError] = createSignal<string | null>(null);
+
+  const loadRoot = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const entries = await scanFilters.browse();
+      setNodes(entries.map((e) => ({
+        entry: e, expanded: false, loaded: false, children: [],
+      })));
+    } catch (e: any) {
+      setError(e?.message ?? "Failed to load folders");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const toggle = async (node: TreeNode) => {
+    if (node.expanded) {
+      node.expanded = false;
+      setNodes([...nodes()]);
+      return;
+    }
+    if (!node.loaded) {
+      try {
+        const children = await scanFilters.browse(node.entry.path);
+        node.children = children.map((e) => ({
+          entry: e, expanded: false, loaded: false, children: [],
+        }));
+        node.loaded = true;
+      } catch (e: any) {
+        setError(e?.message ?? "Failed to load");
+        return;
+      }
+    }
+    node.expanded = true;
+    setNodes([...nodes()]);
+  };
+
+  const toggleSelected = (path: string) => {
+    const s = new Set<string>(selected());
+    if (s.has(path)) s.delete(path);
+    else s.add(path);
+    setSelected(s);
+  };
+
+  createEffect(() => {
+    if (props.open) {
+      setSelected(new Set<string>());
+      loadRoot();
+    }
+  });
+
+  const renderNode = (node: TreeNode, depth: number) => (
+    <div>
+      <div
+        class="flex items-center gap-2 py-1 px-2 hover:bg-theme-surface-hover rounded"
+        style={{ "padding-left": `${depth * 16 + 8}px` }}
+      >
+        <Show
+          when={node.entry.has_children}
+          fallback={<span class="w-4 inline-block" />}
+        >
+          <button
+            class="w-4 text-theme-text-secondary"
+            onClick={() => toggle(node)}
+            aria-label={node.expanded ? "Collapse" : "Expand"}
+          >
+            {node.expanded ? "▾" : "▸"}
+          </button>
+        </Show>
+        <input
+          type="checkbox"
+          checked={selected().has(node.entry.path)}
+          onChange={() => toggleSelected(node.entry.path)}
+        />
+        <span class="text-sm text-theme-text-primary truncate">{node.entry.name}</span>
+      </div>
+      <Show when={node.expanded}>
+        <For each={node.children}>
+          {(child) => renderNode(child, depth + 1)}
+        </For>
+      </Show>
+    </div>
+  );
+
+  return (
+    <Show when={props.open}>
+      <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+        <div class="bg-theme-surface border border-theme-border rounded-[var(--radius-md)] w-full max-w-xl max-h-[80vh] flex flex-col">
+          <div class="p-4 border-b border-theme-border">
+            <h3 class="text-sm font-medium text-theme-text-primary">{props.title}</h3>
+            <p class="text-xs text-theme-text-secondary mt-1">
+              Browse folders under <code>{props.fitsRoot}</code>
+            </p>
+          </div>
+          <div class="flex-1 overflow-y-auto p-2">
+            <Show when={loading()}>
+              <div class="p-4 text-sm">Loading…</div>
+            </Show>
+            <Show when={error()}>
+              <div class="p-4 text-sm text-red-400">{error()}</div>
+            </Show>
+            <For each={nodes()}>{(n) => renderNode(n, 0)}</For>
+          </div>
+          <div class="p-4 border-t border-theme-border flex items-center justify-between">
+            <span class="text-xs text-theme-text-secondary">
+              {selected().size} folder(s) selected
+            </span>
+            <div class="flex gap-2">
+              <button
+                class="px-3 py-1.5 text-sm rounded border border-theme-border"
+                onClick={props.onCancel}
+              >
+                Cancel
+              </button>
+              <button
+                class="px-3 py-1.5 text-sm rounded bg-theme-accent text-white disabled:opacity-50"
+                disabled={selected().size === 0}
+                onClick={() => props.onConfirm(Array.from(selected()))}
+              >
+                Add {selected().size > 0 ? selected().size : ""}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Show>
+  );
+};
+
+export default FolderBrowserModal;

--- a/frontend/src/components/FolderBrowserModal.tsx
+++ b/frontend/src/components/FolderBrowserModal.tsx
@@ -77,24 +77,29 @@ const FolderBrowserModal: Component<Props> = (props) => {
   const renderNode = (node: TreeNode, depth: number) => (
     <div>
       <div
-        class="flex items-center gap-2 py-1 px-2 hover:bg-theme-surface-hover rounded"
+        class={`flex items-center gap-2 py-1 px-2 rounded ${
+          node.entry.has_children ? "cursor-pointer hover:bg-theme-hover" : ""
+        }`}
         style={{ "padding-left": `${depth * 16 + 8}px` }}
+        onClick={() => {
+          if (node.entry.has_children) toggle(node);
+        }}
       >
         <Show
           when={node.entry.has_children}
           fallback={<span class="w-4 inline-block" />}
         >
-          <button
-            class="w-4 text-theme-text-secondary"
-            onClick={() => toggle(node)}
-            aria-label={node.expanded ? "Collapse" : "Expand"}
+          <span
+            class="w-4 text-theme-text-secondary select-none"
+            aria-hidden="true"
           >
             {node.expanded ? "▾" : "▸"}
-          </button>
+          </span>
         </Show>
         <input
           type="checkbox"
           checked={selected().has(node.entry.path)}
+          onClick={(e) => e.stopPropagation()}
           onChange={() => toggleSelected(node.entry.path)}
         />
         <span class="text-sm text-theme-text-primary truncate">{node.entry.name}</span>
@@ -132,13 +137,13 @@ const FolderBrowserModal: Component<Props> = (props) => {
             </span>
             <div class="flex gap-2">
               <button
-                class="px-3 py-1.5 text-sm rounded border border-theme-border"
+                class="px-4 py-1.5 bg-theme-surface text-theme-text-primary border border-theme-border rounded text-sm font-medium hover:bg-theme-hover transition-colors"
                 onClick={props.onCancel}
               >
                 Cancel
               </button>
               <button
-                class="px-3 py-1.5 text-sm rounded bg-theme-accent text-white disabled:opacity-50"
+                class="px-4 py-1.5 bg-theme-accent/15 text-theme-accent border border-theme-accent/30 rounded text-sm font-medium disabled:opacity-50 hover:bg-theme-accent/25 transition-colors"
                 disabled={selected().size === 0}
                 onClick={() => props.onConfirm(Array.from(selected()))}
               >

--- a/frontend/src/components/ScanControls.tsx
+++ b/frontend/src/components/ScanControls.tsx
@@ -14,30 +14,7 @@ const ScanControls: Component<{
   const { isAdmin } = useAuth();
 
   return (
-    <div class="bg-theme-surface border border-theme-border rounded-[var(--radius-md)] shadow-[var(--shadow-sm)] p-4 space-y-3">
-      <div class="flex justify-between items-center flex-wrap gap-2">
-        <h3 class="text-theme-text-primary font-medium">Scan & Ingest</h3>
-        <Show when={isAdmin()}>
-          <div class="flex gap-2 flex-shrink-0">
-            <Show when={props.isActive}>
-              <button
-                onClick={props.onStopScan}
-                disabled={props.stopping}
-                class="px-4 py-1.5 border border-theme-error/50 text-theme-error rounded text-sm font-medium hover:bg-theme-error/20 transition-colors disabled:opacity-50"
-              >
-                {props.stopping ? "Stopping..." : "Stop"}
-              </button>
-            </Show>
-            <button
-              onClick={props.onStartScan}
-              disabled={props.isActive}
-              class="px-4 py-1.5 bg-theme-accent/15 text-theme-accent border border-theme-accent/30 rounded text-sm font-medium disabled:opacity-50 hover:bg-theme-accent/25 transition-colors"
-            >
-              {props.isActive ? (props.stopping ? "Stopping..." : "Scanning...") : "Scan Directory"}
-            </button>
-          </div>
-        </Show>
-      </div>
+    <>
       <div class="flex items-center gap-4 text-sm flex-wrap">
         <span class="text-theme-text-secondary text-xs">Include:</span>
         <label class="flex items-center gap-1.5 cursor-pointer">
@@ -67,7 +44,27 @@ const ScanControls: Component<{
           </span>
         </label>
       </div>
-    </div>
+      <Show when={isAdmin()}>
+        <div class="flex gap-2 flex-shrink-0 ml-auto">
+          <Show when={props.isActive}>
+            <button
+              onClick={props.onStopScan}
+              disabled={props.stopping}
+              class="px-4 py-1.5 border border-theme-error/50 text-theme-error rounded text-sm font-medium hover:bg-theme-error/20 transition-colors disabled:opacity-50"
+            >
+              {props.stopping ? "Stopping..." : "Stop"}
+            </button>
+          </Show>
+          <button
+            onClick={props.onStartScan}
+            disabled={props.isActive}
+            class="px-4 py-1.5 bg-theme-accent/15 text-theme-accent border border-theme-accent/30 rounded text-sm font-medium disabled:opacity-50 hover:bg-theme-accent/25 transition-colors"
+          >
+            {props.isActive ? (props.stopping ? "Stopping..." : "Scanning...") : "Scan Directory"}
+          </button>
+        </div>
+      </Show>
+    </>
   );
 };
 

--- a/frontend/src/components/ScanFiltersOnboarding.tsx
+++ b/frontend/src/components/ScanFiltersOnboarding.tsx
@@ -1,13 +1,17 @@
 import { Component, createSignal, createEffect, onCleanup, Show } from "solid-js";
+import { A } from "@solidjs/router";
 import { scanFilters } from "../api/scanFilters";
 import { showToast } from "./Toast";
 
 interface Props {
-  onReview: () => void;
+  variant?: "inline" | "global";
+  onReview?: () => void;
 }
 
 const ScanFiltersOnboarding: Component<Props> = (props) => {
   const [show, setShow] = createSignal(false);
+  const [saving, setSaving] = createSignal(false);
+  const variant = () => props.variant ?? "inline";
 
   const load = async () => {
     try {
@@ -23,41 +27,92 @@ const ScanFiltersOnboarding: Component<Props> = (props) => {
   onCleanup(() => window.removeEventListener("scan-filters-configured", onConfigured));
 
   const useDefaults = async () => {
+    setSaving(true);
     try {
       await scanFilters.put({
         include_paths: [], exclude_paths: [], name_rules: [],
       });
       setShow(false);
+      window.dispatchEvent(new CustomEvent("scan-filters-configured"));
       showToast("Scanning everything under the data root");
     } catch (e: any) {
       showToast(e?.message ?? "Failed to save", "error");
+    } finally {
+      setSaving(false);
     }
   };
 
+  const primaryBtnClass =
+    "px-4 py-1.5 bg-theme-accent/15 text-theme-accent border border-theme-accent/30 " +
+    "rounded text-sm font-medium disabled:opacity-50 hover:bg-theme-accent/25 transition-colors";
+  const secondaryBtnClass =
+    "px-4 py-1.5 bg-theme-surface text-theme-text-primary border border-theme-border " +
+    "rounded text-sm font-medium disabled:opacity-50 hover:bg-theme-hover transition-colors";
+
   return (
     <Show when={show()}>
-      <div class="rounded-[var(--radius-md)] border border-amber-500/50 bg-amber-500/10 p-4 space-y-2">
-        <h4 class="text-sm font-medium text-amber-200">Review scan filters</h4>
-        <p class="text-xs text-theme-text-secondary">
-          This install has not been configured with scan filters yet. By default
-          the scanner will walk every folder under the configured data root and
-          ingest every supported file. You can restrict which folders are scanned
-          and which file or folder names are included or excluded. Review the
-          filters below before running your first scan, or accept the defaults
-          to scan everything.
-        </p>
-        <div class="flex gap-2">
-          <button
-            class="px-3 py-1.5 text-xs rounded bg-theme-accent text-white"
-            onClick={props.onReview}
+      <div class="rounded-[var(--radius-md)] border border-theme-accent/40 bg-theme-accent/10 p-4 space-y-3">
+        <div class="flex items-start gap-3">
+          <svg
+            class="w-5 h-5 mt-0.5 text-theme-accent flex-shrink-0"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
           >
-            Review scan filters
-          </button>
+            <circle cx="12" cy="12" r="10" />
+            <line x1="12" y1="8" x2="12" y2="12" />
+            <line x1="12" y1="16" x2="12.01" y2="16" />
+          </svg>
+          <div class="flex-1 space-y-1">
+            <h4 class="text-sm font-medium text-theme-text-primary">
+              Review scan filters before your first scan
+            </h4>
+            <p class="text-xs text-theme-text-secondary">
+              <Show
+                when={variant() === "global"}
+                fallback={
+                  <>
+                    This install has not been configured with scan filters yet. By
+                    default the scanner will walk every folder under the configured
+                    data root and ingest every supported file. Auto-scan is paused
+                    until you either review the filters below or accept the defaults.
+                  </>
+                }
+              >
+                Auto-scan is paused until you configure scan filters. Restrict which
+                folders are scanned and which file or folder names are included or
+                excluded under Settings → Scan & Ingest, or accept the defaults to
+                scan everything under the configured data root.
+              </Show>
+            </p>
+          </div>
+        </div>
+        <div class="flex flex-wrap gap-2 pl-8">
+          <Show
+            when={variant() === "global"}
+            fallback={
+              <button
+                class={primaryBtnClass}
+                onClick={props.onReview}
+              >
+                Review scan filters
+              </button>
+            }
+          >
+            <A href="/settings?tab=scan" class={primaryBtnClass}>
+              Open scan settings
+            </A>
+          </Show>
           <button
-            class="px-3 py-1.5 text-xs rounded border border-theme-border"
+            class={secondaryBtnClass}
+            disabled={saving()}
             onClick={useDefaults}
           >
-            Use defaults (scan everything)
+            {saving() ? "Saving…" : "Use defaults (scan everything)"}
           </button>
         </div>
       </div>

--- a/frontend/src/components/ScanFiltersOnboarding.tsx
+++ b/frontend/src/components/ScanFiltersOnboarding.tsx
@@ -85,7 +85,7 @@ const ScanFiltersOnboarding: Component<Props> = (props) => {
               >
                 Auto-scan is paused until you configure scan filters. Restrict which
                 folders are scanned and which file or folder names are included or
-                excluded under Settings → Scan & Ingest, or accept the defaults to
+                excluded under Settings → Library, or accept the defaults to
                 scan everything under the configured data root.
               </Show>
             </p>

--- a/frontend/src/components/ScanFiltersOnboarding.tsx
+++ b/frontend/src/components/ScanFiltersOnboarding.tsx
@@ -1,0 +1,68 @@
+import { Component, createSignal, createEffect, onCleanup, Show } from "solid-js";
+import { scanFilters } from "../api/scanFilters";
+import { showToast } from "./Toast";
+
+interface Props {
+  onReview: () => void;
+}
+
+const ScanFiltersOnboarding: Component<Props> = (props) => {
+  const [show, setShow] = createSignal(false);
+
+  const load = async () => {
+    try {
+      const r = await scanFilters.get();
+      setShow(!r.configured);
+    } catch { /* ignore */ }
+  };
+
+  createEffect(() => { load(); });
+
+  const onConfigured = () => setShow(false);
+  window.addEventListener("scan-filters-configured", onConfigured);
+  onCleanup(() => window.removeEventListener("scan-filters-configured", onConfigured));
+
+  const useDefaults = async () => {
+    try {
+      await scanFilters.put({
+        include_paths: [], exclude_paths: [], name_rules: [],
+      });
+      setShow(false);
+      showToast("Scanning everything under the data root");
+    } catch (e: any) {
+      showToast(e?.message ?? "Failed to save", "error");
+    }
+  };
+
+  return (
+    <Show when={show()}>
+      <div class="rounded-[var(--radius-md)] border border-amber-500/50 bg-amber-500/10 p-4 space-y-2">
+        <h4 class="text-sm font-medium text-amber-200">Review scan filters</h4>
+        <p class="text-xs text-theme-text-secondary">
+          This install has not been configured with scan filters yet. By default
+          the scanner will walk every folder under the configured data root and
+          ingest every supported file. You can restrict which folders are scanned
+          and which file or folder names are included or excluded. Review the
+          filters below before running your first scan, or accept the defaults
+          to scan everything.
+        </p>
+        <div class="flex gap-2">
+          <button
+            class="px-3 py-1.5 text-xs rounded bg-theme-accent text-white"
+            onClick={props.onReview}
+          >
+            Review scan filters
+          </button>
+          <button
+            class="px-3 py-1.5 text-xs rounded border border-theme-border"
+            onClick={useDefaults}
+          >
+            Use defaults (scan everything)
+          </button>
+        </div>
+      </div>
+    </Show>
+  );
+};
+
+export default ScanFiltersOnboarding;

--- a/frontend/src/components/ScanFiltersPanel.tsx
+++ b/frontend/src/components/ScanFiltersPanel.tsx
@@ -238,10 +238,10 @@ const ScanFiltersPanel: Component<Props> = (props) => {
               <em>Exclude paths</em> prune subtrees that should never be walked.
             </li>
             <li>
-              <strong>Name rules</strong>: glob, substring, or regex patterns that
-              match on file names or folder names. Exclude rules win over includes.
-              When at least one include rule exists for a target (file or folder),
-              that target must match one of them.
+              <strong>Name rules</strong>: wildcard, substring, or regex patterns
+              that match on file names or folder names. Exclude rules win over
+              includes. When at least one include rule exists for a target (file
+              or folder), that target must match one of them.
             </li>
           </ul>
           <p>
@@ -283,9 +283,14 @@ const ScanFiltersPanel: Component<Props> = (props) => {
           <h4 class="text-sm font-medium text-theme-text-primary">Name rules</h4>
           <p class="text-xs text-theme-text-secondary">
             Rules are evaluated in order: excludes first, then include-narrowing.
-            Glob examples: <code>*_bad.fits</code>, <code>*_calibration</code>.
-            Substring examples: <code>rejected</code>, <code>test_</code>. Regex
-            examples: <code>^M\d+$</code>, <code>.*_v[0-9]+\.fits</code>.
+            Three pattern types: <strong>wildcard</strong> uses <code>*</code> for
+            any characters and <code>?</code> for a single character — examples{" "}
+            <code>*_bad.fits</code>, <code>*_calibration</code>.{" "}
+            <strong>Substring</strong> matches if the pattern appears anywhere
+            inside the name (case-insensitive) — examples <code>rejected</code>,{" "}
+            <code>test_</code>. <strong>Regex</strong> is a full regular
+            expression — examples <code>^M\d+$</code>,{" "}
+            <code>.*_v[0-9]+\.fits</code>.
           </p>
           <div class="overflow-x-auto">
             <table class="w-full text-xs">
@@ -337,7 +342,7 @@ const ScanFiltersPanel: Component<Props> = (props) => {
                         }}
                         class="bg-theme-input border border-theme-border rounded px-1"
                       >
-                        <option value="glob">glob</option>
+                        <option value="glob">wildcard</option>
                         <option value="substring">substring</option>
                         <option value="regex">regex</option>
                       </select>
@@ -472,7 +477,13 @@ const ScanFiltersPanel: Component<Props> = (props) => {
             class="px-4 py-1.5 bg-theme-accent/15 text-theme-accent border border-theme-accent/30 rounded text-sm font-medium disabled:opacity-50 hover:bg-theme-accent/25 transition-colors"
             disabled={!canSave()}
             onClick={save}
-            title={anyRuleInvalid() ? "One or more rules have empty or invalid patterns" : anyPathInvalid() ? "One or more paths are outside the data root" : ""}
+            title={
+              anyRuleInvalid()
+                ? "One or more rules have empty or invalid patterns"
+                : anyPathInvalid()
+                ? "One or more paths are outside the data root"
+                : "Store the current filters. Future scans will use them. Does not touch the existing catalog."
+            }
           >
             {saving() ? "Saving…" : "Save filters"}
           </button>
@@ -480,12 +491,14 @@ const ScanFiltersPanel: Component<Props> = (props) => {
             class="px-4 py-1.5 bg-theme-surface text-theme-text-primary border border-theme-border rounded text-sm font-medium disabled:opacity-50 hover:bg-theme-hover transition-colors"
             disabled={!dirty()}
             onClick={revert}
+            title="Discard unsaved changes and reload the last saved filters"
           >
             Revert
           </button>
           <button
             class="px-4 py-1.5 bg-theme-warning/15 text-theme-warning border border-theme-warning/30 rounded text-sm font-medium hover:bg-theme-warning/25 transition-colors"
             onClick={applyNow}
+            title="Remove already-ingested image rows that match the current exclude rules. Destructive. Uses the last SAVED filters, not unsaved edits. You will see a confirmation with the row count before anything is deleted."
           >
             Apply now
           </button>

--- a/frontend/src/components/ScanFiltersPanel.tsx
+++ b/frontend/src/components/ScanFiltersPanel.tsx
@@ -1,0 +1,457 @@
+import { Component, createSignal, createEffect, Show, For } from "solid-js";
+import { scanFilters } from "../api/scanFilters";
+import type {
+  ScanFilters,
+  NameRule,
+  RuleAction,
+  RuleType,
+  RuleTarget,
+  Verdict,
+} from "../api/scanFilters";
+import FolderBrowserModal from "./FolderBrowserModal";
+import { showToast } from "./Toast";
+
+const EMPTY: ScanFilters = { include_paths: [], exclude_paths: [], name_rules: [] };
+
+const VERDICT_LABEL: Record<Verdict, string> = {
+  included: "Included",
+  excluded_by_path: "Excluded by path",
+  excluded_by_rule: "Excluded by rule",
+  excluded_by_missing_include: "Excluded (no include rule matched)",
+};
+
+interface Props {
+  onConfigured?: () => void;
+}
+
+const ScanFiltersPanel: Component<Props> = (props) => {
+  const [filters, setFilters] = createSignal<ScanFilters>(EMPTY);
+  const [original, setOriginal] = createSignal<ScanFilters>(EMPTY);
+  const [fitsRoot, setFitsRoot] = createSignal<string>("");
+  const [dirty, setDirty] = createSignal(false);
+  const [browsing, setBrowsing] = createSignal<null | "include" | "exclude">(null);
+  const [saving, setSaving] = createSignal(false);
+  const [testPath, setTestPath] = createSignal("");
+  const [testResult, setTestResult] = createSignal<
+    null | { verdict: Verdict; matched: string[] }
+  >(null);
+
+  const load = async () => {
+    try {
+      const resp = await scanFilters.get();
+      setFilters(resp.filters);
+      setOriginal(JSON.parse(JSON.stringify(resp.filters)));
+      setFitsRoot(resp.fits_root);
+      setDirty(false);
+    } catch (e: any) {
+      showToast(e?.message ?? "Failed to load scan filters", "error");
+    }
+  };
+
+  createEffect(() => { load(); });
+
+  const markDirty = () => setDirty(true);
+
+  const updateFilters = (patch: Partial<ScanFilters>) => {
+    setFilters({ ...filters(), ...patch });
+    markDirty();
+  };
+
+  const save = async () => {
+    setSaving(true);
+    try {
+      const resp = await scanFilters.put(filters());
+      setFilters(resp.filters);
+      setOriginal(JSON.parse(JSON.stringify(resp.filters)));
+      setDirty(false);
+      showToast("Scan filters saved");
+      props.onConfigured?.();
+      window.dispatchEvent(new CustomEvent("scan-filters-configured"));
+    } catch (e: any) {
+      showToast(e?.message ?? "Failed to save filters", "error");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const revert = () => {
+    setFilters(JSON.parse(JSON.stringify(original())));
+    setDirty(false);
+  };
+
+  const runTest = async () => {
+    if (!testPath().trim()) return;
+    try {
+      const r = await scanFilters.test(testPath().trim());
+      setTestResult({ verdict: r.verdict, matched: r.matched_rule_ids });
+    } catch (e: any) {
+      showToast(e?.message ?? "Test failed", "error");
+    }
+  };
+
+  const applyNow = async () => {
+    try {
+      const dry = await scanFilters.applyNow(true);
+      if (dry.matched === 0) {
+        showToast("No image rows match the current exclude rules");
+        return;
+      }
+      const ok = window.confirm(
+        `This will remove ${dry.matched} image row(s) matching the current ` +
+        `exclude rules. Rows will return on next scan if rules change. Continue?`
+      );
+      if (!ok) return;
+      const res = await scanFilters.applyNow(false);
+      showToast(`Removed ${res.matched} image row(s)`);
+    } catch (e: any) {
+      showToast(e?.message ?? "Apply now failed", "error");
+    }
+  };
+
+  const PathList: Component<{
+    label: string;
+    help: string;
+    values: string[];
+    onRemove: (idx: number) => void;
+    onAdd: (value: string) => void;
+    onBrowse: () => void;
+  }> = (p) => {
+    const [draft, setDraft] = createSignal("");
+    return (
+      <div class="space-y-2">
+        <div class="flex items-center justify-between">
+          <h4 class="text-sm font-medium text-theme-text-primary">{p.label}</h4>
+          <button
+            class="px-2 py-1 text-xs rounded border border-theme-border"
+            onClick={p.onBrowse}
+          >
+            Browse…
+          </button>
+        </div>
+        <p class="text-xs text-theme-text-secondary">{p.help}</p>
+        <Show
+          when={p.values.length > 0}
+          fallback={<p class="text-xs italic text-theme-text-tertiary">None</p>}
+        >
+          <ul class="space-y-1">
+            <For each={p.values}>{(v, i) => (
+              <li class="flex items-center gap-2 text-sm">
+                <code class="flex-1 truncate">{v}</code>
+                <button
+                  class="text-xs text-red-400"
+                  onClick={() => p.onRemove(i())}
+                >
+                  Remove
+                </button>
+              </li>
+            )}</For>
+          </ul>
+        </Show>
+        <div class="flex gap-2">
+          <input
+            type="text"
+            placeholder={`${fitsRoot()}/subfolder`}
+            value={draft()}
+            onInput={(e) => setDraft(e.currentTarget.value)}
+            class="flex-1 px-2 py-1 text-xs bg-theme-input border border-theme-border rounded"
+          />
+          <button
+            class="px-2 py-1 text-xs rounded border border-theme-border"
+            onClick={() => {
+              if (!draft().trim()) return;
+              p.onAdd(draft().trim());
+              setDraft("");
+            }}
+          >
+            Add
+          </button>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <details
+      id="scan-filters-panel"
+      class="rounded-[var(--radius-md)] bg-theme-surface border border-theme-border"
+    >
+      <summary class="p-4 cursor-pointer text-sm font-medium text-theme-text-primary">
+        Scan filters — {filters().include_paths.length} include path(s),{" "}
+        {filters().exclude_paths.length} exclude path(s),{" "}
+        {filters().name_rules.length} name rule(s)
+        <Show when={dirty()}>
+          <span class="ml-2 text-xs text-amber-400">unsaved</span>
+        </Show>
+      </summary>
+
+      <div class="p-4 border-t border-theme-border space-y-6">
+        <div class="text-xs text-theme-text-secondary space-y-2">
+          <p>
+            Scan filters control what the scanner walks and ingests. There are two
+            kinds of rules working together:
+          </p>
+          <ul class="list-disc pl-4 space-y-1">
+            <li>
+              <strong>Paths</strong>: <em>include paths</em> narrow the scan to a
+              subset of the data root (empty means scan everything).{" "}
+              <em>Exclude paths</em> prune subtrees that should never be walked.
+            </li>
+            <li>
+              <strong>Name rules</strong>: glob, substring, or regex patterns that
+              match on file names or folder names. Exclude rules win over includes.
+              When at least one include rule exists for a target (file or folder),
+              that target must match one of them.
+            </li>
+          </ul>
+          <p>
+            Example: include path <code>{fitsRoot() || "/data/fits"}/2025</code>,
+            exclude path <code>{fitsRoot() || "/data/fits"}/2025/rejected</code>,
+            plus a file exclude rule <code>*_bad.fits</code> and a folder include
+            regex <code>^M\d+$</code>. The scanner walks only 2025, skips{" "}
+            <code>rejected</code>, drops any file ending in <code>_bad.fits</code>,
+            and only keeps files whose parent folder name matches an{" "}
+            <code>M</code>-catalog designation.
+          </p>
+        </div>
+
+        <PathList
+          label="Include paths"
+          help="When empty, scans the entire configured data path. When set, scans only these folders (each must resolve inside the data root)."
+          values={filters().include_paths}
+          onRemove={(idx) => {
+            const next = filters().include_paths.filter((_, i) => i !== idx);
+            updateFilters({ include_paths: next });
+          }}
+          onAdd={(v) => updateFilters({ include_paths: [...filters().include_paths, v] })}
+          onBrowse={() => setBrowsing("include")}
+        />
+
+        <PathList
+          label="Exclude paths"
+          help="Subtrees to skip entirely. Exclude always wins over include."
+          values={filters().exclude_paths}
+          onRemove={(idx) => {
+            const next = filters().exclude_paths.filter((_, i) => i !== idx);
+            updateFilters({ exclude_paths: next });
+          }}
+          onAdd={(v) => updateFilters({ exclude_paths: [...filters().exclude_paths, v] })}
+          onBrowse={() => setBrowsing("exclude")}
+        />
+
+        <div class="space-y-2">
+          <h4 class="text-sm font-medium text-theme-text-primary">Name rules</h4>
+          <p class="text-xs text-theme-text-secondary">
+            Rules are evaluated in order: excludes first, then include-narrowing.
+            Glob examples: <code>*_bad.fits</code>, <code>*_calibration</code>.
+            Substring examples: <code>rejected</code>, <code>test_</code>. Regex
+            examples: <code>^M\d+$</code>, <code>.*_v[0-9]+\.fits</code>.
+          </p>
+          <div class="overflow-x-auto">
+            <table class="w-full text-xs">
+              <thead>
+                <tr class="text-theme-text-secondary">
+                  <th class="text-left p-1">On</th>
+                  <th class="text-left p-1">Action</th>
+                  <th class="text-left p-1">Type</th>
+                  <th class="text-left p-1">Target</th>
+                  <th class="text-left p-1">Pattern</th>
+                  <th class="p-1"></th>
+                </tr>
+              </thead>
+              <tbody>
+                <For each={filters().name_rules}>{(rule, i) => (
+                  <tr class="border-t border-theme-border">
+                    <td class="p-1">
+                      <input
+                        type="checkbox"
+                        checked={rule.enabled}
+                        onChange={(e) => {
+                          const next = [...filters().name_rules];
+                          next[i()] = { ...rule, enabled: e.currentTarget.checked };
+                          updateFilters({ name_rules: next });
+                        }}
+                      />
+                    </td>
+                    <td class="p-1">
+                      <select
+                        value={rule.action}
+                        onChange={(e) => {
+                          const next = [...filters().name_rules];
+                          next[i()] = { ...rule, action: e.currentTarget.value as RuleAction };
+                          updateFilters({ name_rules: next });
+                        }}
+                        class="bg-theme-input border border-theme-border rounded px-1"
+                      >
+                        <option value="include">include</option>
+                        <option value="exclude">exclude</option>
+                      </select>
+                    </td>
+                    <td class="p-1">
+                      <select
+                        value={rule.type}
+                        onChange={(e) => {
+                          const next = [...filters().name_rules];
+                          next[i()] = { ...rule, type: e.currentTarget.value as RuleType };
+                          updateFilters({ name_rules: next });
+                        }}
+                        class="bg-theme-input border border-theme-border rounded px-1"
+                      >
+                        <option value="glob">glob</option>
+                        <option value="substring">substring</option>
+                        <option value="regex">regex</option>
+                      </select>
+                    </td>
+                    <td class="p-1">
+                      <select
+                        value={rule.target}
+                        onChange={(e) => {
+                          const next = [...filters().name_rules];
+                          next[i()] = { ...rule, target: e.currentTarget.value as RuleTarget };
+                          updateFilters({ name_rules: next });
+                        }}
+                        class="bg-theme-input border border-theme-border rounded px-1"
+                      >
+                        <option value="file">file</option>
+                        <option value="folder">folder</option>
+                      </select>
+                    </td>
+                    <td class="p-1">
+                      <input
+                        type="text"
+                        value={rule.pattern}
+                        placeholder={
+                          rule.type === "glob" ? "*_bad.fits" :
+                          rule.type === "regex" ? "^M\\d+$" : "rejected"
+                        }
+                        onInput={(e) => {
+                          const next = [...filters().name_rules];
+                          next[i()] = { ...rule, pattern: e.currentTarget.value };
+                          updateFilters({ name_rules: next });
+                        }}
+                        class="w-full px-1 py-0.5 bg-theme-input border border-theme-border rounded font-mono"
+                      />
+                    </td>
+                    <td class="p-1">
+                      <button
+                        class="text-red-400"
+                        onClick={() => {
+                          const next = filters().name_rules.filter((_, idx) => idx !== i());
+                          updateFilters({ name_rules: next });
+                        }}
+                        aria-label="Remove rule"
+                      >
+                        ×
+                      </button>
+                    </td>
+                  </tr>
+                )}</For>
+              </tbody>
+            </table>
+          </div>
+          <button
+            class="px-2 py-1 text-xs rounded border border-theme-border"
+            onClick={() => {
+              const newRule: NameRule = {
+                id: crypto.randomUUID(),
+                action: "exclude",
+                type: "glob",
+                pattern: "",
+                target: "file",
+                enabled: true,
+              };
+              updateFilters({ name_rules: [...filters().name_rules, newRule] });
+            }}
+          >
+            Add rule
+          </button>
+        </div>
+
+        <div class="space-y-2">
+          <h4 class="text-sm font-medium text-theme-text-primary">Test a path</h4>
+          <p class="text-xs text-theme-text-secondary">
+            Paste a file or folder path to see how the current rules would treat it.
+            The path does not need to exist on disk. Unsaved changes are not used;
+            save first to test them.
+          </p>
+          <div class="space-y-1">
+            <div class="flex gap-2">
+              <input
+                type="text"
+                value={testPath()}
+                onInput={(e) => setTestPath(e.currentTarget.value)}
+                placeholder={`${fitsRoot() || "/data/fits"}/2025/M31/frame_bad.fits`}
+                class="flex-1 px-2 py-1 text-xs bg-theme-input border border-theme-border rounded font-mono"
+              />
+              <button
+                class="px-2 py-1 text-xs rounded border border-theme-border"
+                onClick={runTest}
+              >
+                Test
+              </button>
+            </div>
+            <Show when={testResult()}>
+              <div class="text-xs">
+                Verdict:{" "}
+                <strong
+                  class={
+                    testResult()!.verdict === "included"
+                      ? "text-green-400"
+                      : "text-red-400"
+                  }
+                >
+                  {VERDICT_LABEL[testResult()!.verdict]}
+                </strong>
+                <Show when={testResult()!.matched.length > 0}>
+                  {" "}
+                  — matched rules: {testResult()!.matched.join(", ")}
+                </Show>
+              </div>
+            </Show>
+          </div>
+        </div>
+
+        <div class="flex flex-wrap gap-2">
+          <button
+            class="px-3 py-1.5 text-sm rounded bg-theme-accent text-white disabled:opacity-50"
+            disabled={!dirty() || saving()}
+            onClick={save}
+          >
+            {saving() ? "Saving…" : "Save filters"}
+          </button>
+          <button
+            class="px-3 py-1.5 text-sm rounded border border-theme-border disabled:opacity-50"
+            disabled={!dirty()}
+            onClick={revert}
+          >
+            Revert
+          </button>
+          <button
+            class="px-3 py-1.5 text-sm rounded border border-amber-500 text-amber-400"
+            onClick={applyNow}
+          >
+            Apply now
+          </button>
+        </div>
+      </div>
+
+      <FolderBrowserModal
+        open={browsing() !== null}
+        fitsRoot={fitsRoot()}
+        title={
+          browsing() === "include" ? "Add include paths" : "Add exclude paths"
+        }
+        onCancel={() => setBrowsing(null)}
+        onConfirm={(paths) => {
+          const key =
+            browsing() === "include" ? "include_paths" : "exclude_paths";
+          const current = filters()[key];
+          const merged = Array.from(new Set([...current, ...paths]));
+          updateFilters({ [key]: merged } as Partial<ScanFilters>);
+          setBrowsing(null);
+        }}
+      />
+    </details>
+  );
+};
+
+export default ScanFiltersPanel;

--- a/frontend/src/components/ScanFiltersPanel.tsx
+++ b/frontend/src/components/ScanFiltersPanel.tsx
@@ -412,21 +412,21 @@ const ScanFiltersPanel: Component<Props> = (props) => {
 
         <div class="flex flex-wrap gap-2">
           <button
-            class="px-3 py-1.5 text-sm rounded bg-theme-accent text-white disabled:opacity-50"
+            class="px-4 py-1.5 bg-theme-accent/15 text-theme-accent border border-theme-accent/30 rounded text-sm font-medium disabled:opacity-50 hover:bg-theme-accent/25 transition-colors"
             disabled={!dirty() || saving()}
             onClick={save}
           >
             {saving() ? "Saving…" : "Save filters"}
           </button>
           <button
-            class="px-3 py-1.5 text-sm rounded border border-theme-border disabled:opacity-50"
+            class="px-4 py-1.5 bg-theme-surface text-theme-text-primary border border-theme-border rounded text-sm font-medium disabled:opacity-50 hover:bg-theme-hover transition-colors"
             disabled={!dirty()}
             onClick={revert}
           >
             Revert
           </button>
           <button
-            class="px-3 py-1.5 text-sm rounded border border-amber-500 text-amber-400"
+            class="px-4 py-1.5 bg-theme-warning/15 text-theme-warning border border-theme-warning/30 rounded text-sm font-medium hover:bg-theme-warning/25 transition-colors"
             onClick={applyNow}
           >
             Apply now

--- a/frontend/src/components/ScanFiltersPanel.tsx
+++ b/frontend/src/components/ScanFiltersPanel.tsx
@@ -9,6 +9,7 @@ import type {
   Verdict,
 } from "../api/scanFilters";
 import FolderBrowserModal from "./FolderBrowserModal";
+import SettingsHelpSection from "./settings/SettingsHelpSection";
 import { showToast } from "./Toast";
 
 const EMPTY: ScanFilters = { include_paths: [], exclude_paths: [], name_rules: [] };
@@ -216,13 +217,25 @@ const ScanFiltersPanel: Component<Props> = (props) => {
     );
   };
 
+  const firstVisit = (() => {
+    try {
+      const key = "galactilog.scanFiltersPanel.visited";
+      if (localStorage.getItem(key)) return false;
+      localStorage.setItem(key, "1");
+      return true;
+    } catch {
+      return false;
+    }
+  })();
+
   return (
     <details
       id="scan-filters-panel"
-      class="rounded-[var(--radius-md)] bg-theme-surface border border-theme-border"
+      open={firstVisit}
+      class="rounded-[var(--radius-sm)] border border-theme-border"
     >
-      <summary class="p-4 cursor-pointer text-sm font-medium text-theme-text-primary">
-        Scan filters — {filters().include_paths.length} include path(s),{" "}
+      <summary class="p-3 cursor-pointer text-sm font-medium text-theme-text-primary">
+        Path & name rules — {filters().include_paths.length} include path(s),{" "}
         {filters().exclude_paths.length} exclude path(s),{" "}
         {filters().name_rules.length} name rule(s)
         <Show when={dirty()}>
@@ -231,34 +244,59 @@ const ScanFiltersPanel: Component<Props> = (props) => {
       </summary>
 
       <div class="p-4 border-t border-theme-border space-y-6">
-        <div class="text-xs text-theme-text-secondary space-y-2">
-          <p>
-            Scan filters control what the scanner walks and ingests. There are two
-            kinds of rules working together:
-          </p>
-          <ul class="list-disc pl-4 space-y-1">
-            <li>
-              <strong>Paths</strong>: <em>include paths</em> narrow the scan to a
-              subset of the data root (empty means scan everything).{" "}
-              <em>Exclude paths</em> prune subtrees that should never be walked.
-            </li>
-            <li>
-              <strong>Name rules</strong>: wildcard, substring, or regex patterns
-              that match on file names or folder names. Exclude rules win over
-              includes. When at least one include rule exists for a target (file
-              or folder), that target must match one of them.
-            </li>
-          </ul>
-          <p>
-            Example: include path <code>{fitsRoot() || "/data/fits"}/2025</code>,
-            exclude path <code>{fitsRoot() || "/data/fits"}/2025/rejected</code>,
-            plus a file exclude rule <code>*_bad.fits</code> and a folder include
-            regex <code>^M\d+$</code>. The scanner walks only 2025, skips{" "}
-            <code>rejected</code>, drops any file ending in <code>_bad.fits</code>,
-            and only keeps files whose parent folder name matches an{" "}
-            <code>M</code>-catalog designation.
-          </p>
-        </div>
+        <SettingsHelpSection tabId="scan_path_name_rules">
+          <div class="space-y-3 text-xs text-theme-text-secondary">
+            <p>
+              Filtering happens in <strong class="text-theme-text-primary">two layers</strong>, applied in order.
+            </p>
+
+            <div class="space-y-1">
+              <p class="text-theme-text-primary font-medium">1. Paths, which folders to walk</p>
+              <ul class="list-disc pl-5 space-y-0.5">
+                <li>
+                  <strong>Include paths</strong> limit the scan to specific subtrees.
+                  <em> Empty means scan everything under the data root.</em>
+                </li>
+                <li>
+                  <strong>Exclude paths</strong> skip subtrees entirely.
+                  <em> Exclude always wins over include.</em>
+                </li>
+              </ul>
+            </div>
+
+            <div class="space-y-1">
+              <p class="text-theme-text-primary font-medium">2. Name rules, which files and folders to keep</p>
+              <ul class="list-disc pl-5 space-y-0.5">
+                <li>
+                  Patterns match against <strong>file names</strong> or <strong>folder names</strong>, using
+                  <strong> wildcard</strong>, <strong>substring</strong>, or <strong>regex</strong>.
+                </li>
+                <li>
+                  <strong>Exclude rules</strong> are checked first, then <strong>include rules</strong> narrow the result.
+                </li>
+                <li>
+                  If any include rule exists for a target kind (file or folder), that target
+                  <strong> must</strong> match at least one.
+                </li>
+              </ul>
+            </div>
+
+            <div class="space-y-1">
+              <p class="text-theme-text-primary font-medium">Example</p>
+              <pre class="bg-theme-input border border-theme-border rounded p-2 font-mono text-[11px] leading-relaxed whitespace-pre-wrap break-all">
+{`include path   ${fitsRoot() || "/data/fits"}/2025
+exclude path   ${fitsRoot() || "/data/fits"}/2025/rejected
+exclude rule   *_bad.fits      (wildcard, file)
+include rule   ^M\\d+$          (regex, folder)`}
+              </pre>
+              <p>
+                Result: scans only <code>2025</code>, skips <code>rejected/</code>, drops any file ending in
+                {" "}<code>_bad.fits</code>, and only keeps files whose parent folder name is an M-catalog
+                designation like <code>M31</code> or <code>M42</code>.
+              </p>
+            </div>
+          </div>
+        </SettingsHelpSection>
 
         <PathList
           label="Include paths"
@@ -286,17 +324,17 @@ const ScanFiltersPanel: Component<Props> = (props) => {
 
         <div class="space-y-2">
           <h4 class="text-sm font-medium text-theme-text-primary">Name rules</h4>
-          <p class="text-xs text-theme-text-secondary">
-            Rules are evaluated in order: excludes first, then include-narrowing.
-            Three pattern types: <strong>wildcard</strong> uses <code>*</code> for
-            any characters and <code>?</code> for a single character — examples{" "}
-            <code>*_bad.fits</code>, <code>*_calibration</code>.{" "}
-            <strong>Substring</strong> matches if the pattern appears anywhere
-            inside the name (case-insensitive) — examples <code>rejected</code>,{" "}
-            <code>test_</code>. <strong>Regex</strong> is a full regular
-            expression — examples <code>^M\d+$</code>,{" "}
-            <code>.*_v[0-9]+\.fits</code>.
-          </p>
+          <SettingsHelpSection tabId="scan_name_rules_syntax">
+            <p class="text-xs text-theme-text-secondary">
+              Pattern syntax: <strong>wildcard</strong> uses <code>*</code> for any
+              characters and <code>?</code> for a single character (e.g.{" "}
+              <code>*_bad.fits</code>, <code>*_calibration</code>).{" "}
+              <strong>Substring</strong> matches anywhere inside the name,
+              case-insensitive (e.g. <code>rejected</code>, <code>test_</code>).{" "}
+              <strong>Regex</strong> is a full regular expression (e.g.{" "}
+              <code>^M\d+$</code>, <code>.*_v[0-9]+\.fits</code>).
+            </p>
+          </SettingsHelpSection>
           <div class="overflow-x-auto">
             <table class="w-full text-xs">
               <thead>
@@ -490,7 +528,7 @@ const ScanFiltersPanel: Component<Props> = (props) => {
                 : "Store the current filters. Future scans will use them. Does not touch the existing catalog."
             }
           >
-            {saving() ? "Saving…" : "Save filters"}
+            {saving() ? "Saving…" : "Save rules"}
           </button>
           <button
             class="px-4 py-1.5 bg-theme-surface text-theme-text-primary border border-theme-border rounded text-sm font-medium disabled:opacity-50 hover:bg-theme-hover transition-colors"

--- a/frontend/src/components/ScanFiltersPanel.tsx
+++ b/frontend/src/components/ScanFiltersPanel.tsx
@@ -122,7 +122,7 @@ const ScanFiltersPanel: Component<Props> = (props) => {
         <div class="flex items-center justify-between">
           <h4 class="text-sm font-medium text-theme-text-primary">{p.label}</h4>
           <button
-            class="px-2 py-1 text-xs rounded border border-theme-border"
+            class="px-4 py-1.5 bg-theme-accent/15 text-theme-accent border border-theme-accent/30 rounded text-sm font-medium hover:bg-theme-accent/25 transition-colors"
             onClick={p.onBrowse}
           >
             Browse…

--- a/frontend/src/components/ScanFiltersPanel.tsx
+++ b/frontend/src/components/ScanFiltersPanel.tsx
@@ -107,16 +107,21 @@ const ScanFiltersPanel: Component<Props> = (props) => {
     try {
       const dry = await scanFilters.applyNow(true);
       if (dry.matched === 0) {
-        showToast("No image rows match the current exclude rules");
+        showToast(
+          "Nothing to clean up. The saved filters do not exclude any " +
+          "existing image rows in the catalog."
+        );
         return;
       }
       const ok = window.confirm(
-        `This will remove ${dry.matched} image row(s) matching the current ` +
-        `exclude rules. Rows will return on next scan if rules change. Continue?`
+        `This will permanently remove ${dry.matched} image row(s) from the ` +
+        `catalog because they are excluded by the saved filters. The files ` +
+        `on disk are not touched, and rows will return on the next scan if ` +
+        `the filters are relaxed. Continue?`
       );
       if (!ok) return;
       const res = await scanFilters.applyNow(false);
-      showToast(`Removed ${res.matched} image row(s)`);
+      showToast(`Removed ${res.matched} image row(s) from the catalog`);
     } catch (e: any) {
       showToast(e?.message ?? "Apply now failed", "error");
     }

--- a/frontend/src/components/ScanFiltersPanel.tsx
+++ b/frontend/src/components/ScanFiltersPanel.tsx
@@ -32,9 +32,23 @@ const ScanFiltersPanel: Component<Props> = (props) => {
   const [browsing, setBrowsing] = createSignal<null | "include" | "exclude">(null);
   const [saving, setSaving] = createSignal(false);
   const [testPath, setTestPath] = createSignal("");
+  const [testKind, setTestKind] = createSignal<"auto" | "file" | "folder">("auto");
   const [testResult, setTestResult] = createSignal<
     null | { verdict: Verdict; matched: string[] }
   >(null);
+
+  const ruleIsInvalid = (r: NameRule): string | null => {
+    if (!r.pattern.trim()) return "empty pattern";
+    if (r.type === "regex") {
+      try { new RegExp(r.pattern); } catch { return "invalid regex"; }
+    }
+    return null;
+  };
+  const anyRuleInvalid = () => filters().name_rules.some((r) => ruleIsInvalid(r) !== null);
+  const anyPathInvalid = () =>
+    filters().include_paths.some((p) => !pathIsInsideRoot(p)) ||
+    filters().exclude_paths.some((p) => !pathIsInsideRoot(p));
+  const canSave = () => dirty() && !saving() && !anyRuleInvalid() && !anyPathInvalid();
 
   const load = async () => {
     try {
@@ -82,7 +96,7 @@ const ScanFiltersPanel: Component<Props> = (props) => {
   const runTest = async () => {
     if (!testPath().trim()) return;
     try {
-      const r = await scanFilters.test(testPath().trim());
+      const r = await scanFilters.test(testPath().trim(), testKind());
       setTestResult({ verdict: r.verdict, matched: r.matched_rule_ids });
     } catch (e: any) {
       showToast(e?.message ?? "Test failed", "error");
@@ -108,6 +122,14 @@ const ScanFiltersPanel: Component<Props> = (props) => {
     }
   };
 
+  const pathIsInsideRoot = (p: string): boolean => {
+    const root = fitsRoot();
+    if (!root) return true; // can't validate yet, defer to server
+    const trimmed = p.trim().replace(/[\\/]+$/, "");
+    const rootTrimmed = root.replace(/[\\/]+$/, "");
+    return trimmed === rootTrimmed || trimmed.startsWith(rootTrimmed + "/");
+  };
+
   const PathList: Component<{
     label: string;
     help: string;
@@ -117,6 +139,12 @@ const ScanFiltersPanel: Component<Props> = (props) => {
     onBrowse: () => void;
   }> = (p) => {
     const [draft, setDraft] = createSignal("");
+    const draftError = () => {
+      const d = draft().trim();
+      if (!d) return null;
+      if (!pathIsInsideRoot(d)) return `Path must be inside ${fitsRoot()}`;
+      return null;
+    };
     return (
       <div class="space-y-2">
         <div class="flex items-center justify-between">
@@ -136,9 +164,11 @@ const ScanFiltersPanel: Component<Props> = (props) => {
           <ul class="space-y-1">
             <For each={p.values}>{(v, i) => (
               <li class="flex items-center gap-2 text-sm">
-                <code class="flex-1 truncate">{v}</code>
+                <code class={`flex-1 truncate ${pathIsInsideRoot(v) ? "" : "text-theme-error"}`}>
+                  {v}
+                </code>
                 <button
-                  class="text-xs text-red-400"
+                  class="text-xs text-theme-error hover:underline"
                   onClick={() => p.onRemove(i())}
                 >
                   Remove
@@ -150,15 +180,23 @@ const ScanFiltersPanel: Component<Props> = (props) => {
         <div class="flex gap-2">
           <input
             type="text"
-            placeholder={`${fitsRoot()}/subfolder`}
+            placeholder={`${fitsRoot() || "/data/fits"}/subfolder`}
             value={draft()}
             onInput={(e) => setDraft(e.currentTarget.value)}
-            class="flex-1 px-2 py-1 text-xs bg-theme-input border border-theme-border rounded"
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !draftError() && draft().trim()) {
+                p.onAdd(draft().trim());
+                setDraft("");
+              }
+            }}
+            class={`flex-1 px-2 py-1 text-xs bg-theme-input border rounded ${
+              draftError() ? "border-theme-error" : "border-theme-border"
+            }`}
           />
           <button
-            class="px-2 py-1 text-xs rounded border border-theme-border"
+            class="px-4 py-1.5 bg-theme-surface text-theme-text-primary border border-theme-border rounded text-sm font-medium disabled:opacity-50 hover:bg-theme-hover transition-colors"
+            disabled={!draft().trim() || !!draftError()}
             onClick={() => {
-              if (!draft().trim()) return;
               p.onAdd(draft().trim());
               setDraft("");
             }}
@@ -166,6 +204,9 @@ const ScanFiltersPanel: Component<Props> = (props) => {
             Add
           </button>
         </div>
+        <Show when={draftError()}>
+          <p class="text-xs text-theme-error">{draftError()}</p>
+        </Show>
       </div>
     );
   };
@@ -328,7 +369,10 @@ const ScanFiltersPanel: Component<Props> = (props) => {
                           next[i()] = { ...rule, pattern: e.currentTarget.value };
                           updateFilters({ name_rules: next });
                         }}
-                        class="w-full px-1 py-0.5 bg-theme-input border border-theme-border rounded font-mono"
+                        class={`w-full px-1 py-0.5 bg-theme-input border rounded font-mono ${
+                          ruleIsInvalid(rule) ? "border-theme-error" : "border-theme-border"
+                        }`}
+                        title={ruleIsInvalid(rule) ?? ""}
                       />
                     </td>
                     <td class="p-1">
@@ -374,16 +418,29 @@ const ScanFiltersPanel: Component<Props> = (props) => {
             save first to test them.
           </p>
           <div class="space-y-1">
-            <div class="flex gap-2">
+            <div class="flex gap-2 flex-wrap">
               <input
                 type="text"
                 value={testPath()}
                 onInput={(e) => setTestPath(e.currentTarget.value)}
+                onKeyDown={(e) => { if (e.key === "Enter") runTest(); }}
                 placeholder={`${fitsRoot() || "/data/fits"}/2025/M31/frame_bad.fits`}
-                class="flex-1 px-2 py-1 text-xs bg-theme-input border border-theme-border rounded font-mono"
+                class="flex-1 min-w-0 px-2 py-1 text-xs bg-theme-input border border-theme-border rounded font-mono"
               />
+              <select
+                value={testKind()}
+                onChange={(e) =>
+                  setTestKind(e.currentTarget.value as "auto" | "file" | "folder")
+                }
+                class="px-2 py-1 text-xs bg-theme-input border border-theme-border rounded"
+                title="Treat the path as a file, a folder, or auto-detect"
+              >
+                <option value="auto">auto</option>
+                <option value="file">file</option>
+                <option value="folder">folder</option>
+              </select>
               <button
-                class="px-2 py-1 text-xs rounded border border-theme-border"
+                class="px-4 py-1.5 bg-theme-surface text-theme-text-primary border border-theme-border rounded text-sm font-medium hover:bg-theme-hover transition-colors"
                 onClick={runTest}
               >
                 Test
@@ -413,8 +470,9 @@ const ScanFiltersPanel: Component<Props> = (props) => {
         <div class="flex flex-wrap gap-2">
           <button
             class="px-4 py-1.5 bg-theme-accent/15 text-theme-accent border border-theme-accent/30 rounded text-sm font-medium disabled:opacity-50 hover:bg-theme-accent/25 transition-colors"
-            disabled={!dirty() || saving()}
+            disabled={!canSave()}
             onClick={save}
+            title={anyRuleInvalid() ? "One or more rules have empty or invalid patterns" : anyPathInvalid() ? "One or more paths are outside the data root" : ""}
           >
             {saving() ? "Saving…" : "Save filters"}
           </button>

--- a/frontend/src/components/ScanManager.tsx
+++ b/frontend/src/components/ScanManager.tsx
@@ -8,6 +8,8 @@ import DatabaseOverview from "./DatabaseOverview";
 import ScanControls from "./ScanControls";
 import ActivityFeed from "./ActivityFeed";
 import MaintenanceActions from "./MaintenanceActions";
+import ScanFiltersPanel from "./ScanFiltersPanel";
+import ScanFiltersOnboarding from "./ScanFiltersOnboarding";
 import { showToast } from "./Toast";
 
 type FrameFilter = "all" | "light_only";
@@ -129,7 +131,13 @@ const ScanManager: Component = () => {
       <div class="grid grid-cols-1 lg:grid-cols-[minmax(0,3fr)_minmax(0,2fr)] gap-4 items-start">
         {/* Left column: controls */}
         <div class="space-y-4 min-w-0">
-          {/* scan-filters-onboarding-slot */}
+          <ScanFiltersOnboarding
+            onReview={() => {
+              const el = document.getElementById("scan-filters-panel");
+              if (el instanceof HTMLDetailsElement) el.open = true;
+              el?.scrollIntoView({ behavior: "smooth", block: "start" });
+            }}
+          />
           <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
             <Show when={isAdmin()}>
               <div class="rounded-[var(--radius-md)] bg-theme-surface border border-theme-border p-4 space-y-4">
@@ -176,7 +184,7 @@ const ScanManager: Component = () => {
             />
           </div>
 
-          {/* scan-filters-panel-slot */}
+          <ScanFiltersPanel />
 
           <Show when={isAdmin()}>
             <MaintenanceActions

--- a/frontend/src/components/ScanManager.tsx
+++ b/frontend/src/components/ScanManager.tsx
@@ -126,71 +126,83 @@ const ScanManager: Component = () => {
     <div class="space-y-4">
       <DatabaseOverview summary={dbSummary()} />
 
-      {/* Auto-scan + Scan Controls side by side */}
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <Show when={isAdmin()}>
-          <div class="rounded-[var(--radius-md)] bg-theme-surface border border-theme-border p-4 space-y-4">
-            <h3 class="text-sm font-medium text-theme-text-primary">Auto-scan</h3>
-            <div class="flex items-center justify-between">
-              <label class="text-sm text-theme-text-secondary">Enable automatic scanning</label>
-              <button
-                onClick={handleAutoScanToggle}
-                class={`relative w-10 h-5 rounded-full transition-colors ${
-                  autoScanEnabled() ? "bg-theme-accent" : "bg-theme-text-tertiary"
-                }`}
-              >
-                <span
-                  class={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform ${
-                    autoScanEnabled() ? "translate-x-5" : ""
-                  }`}
-                />
-              </button>
-            </div>
-            <Show when={autoScanEnabled()}>
-              <div class="flex items-center justify-between">
-                <label class="text-sm text-theme-text-secondary">Scan interval</label>
-                <select
-                  value={autoScanInterval()}
-                  onChange={(e) => handleIntervalChange(parseInt(e.currentTarget.value))}
-                  class="px-3 py-1.5 bg-theme-input border border-theme-border rounded-[var(--radius-sm)] text-sm text-theme-text-primary focus:ring-1 focus:ring-theme-accent focus:border-theme-accent outline-none"
-                >
-                  {INTERVALS.map((opt) => (
-                    <option value={opt.value}>{opt.label}</option>
-                  ))}
-                </select>
+      <div class="grid grid-cols-1 lg:grid-cols-[minmax(0,3fr)_minmax(0,2fr)] gap-4 items-start">
+        {/* Left column: controls */}
+        <div class="space-y-4 min-w-0">
+          {/* scan-filters-onboarding-slot */}
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <Show when={isAdmin()}>
+              <div class="rounded-[var(--radius-md)] bg-theme-surface border border-theme-border p-4 space-y-4">
+                <h3 class="text-sm font-medium text-theme-text-primary">Auto-scan</h3>
+                <div class="flex items-center justify-between">
+                  <label class="text-sm text-theme-text-secondary">Enable automatic scanning</label>
+                  <button
+                    onClick={handleAutoScanToggle}
+                    class={`relative w-10 h-5 rounded-full transition-colors ${
+                      autoScanEnabled() ? "bg-theme-accent" : "bg-theme-text-tertiary"
+                    }`}
+                  >
+                    <span
+                      class={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform ${
+                        autoScanEnabled() ? "translate-x-5" : ""
+                      }`}
+                    />
+                  </button>
+                </div>
+                <Show when={autoScanEnabled()}>
+                  <div class="flex items-center justify-between">
+                    <label class="text-sm text-theme-text-secondary">Scan interval</label>
+                    <select
+                      value={autoScanInterval()}
+                      onChange={(e) => handleIntervalChange(parseInt(e.currentTarget.value))}
+                      class="px-3 py-1.5 bg-theme-input border border-theme-border rounded-[var(--radius-sm)] text-sm text-theme-text-primary focus:ring-1 focus:ring-theme-accent focus:border-theme-accent outline-none"
+                    >
+                      {INTERVALS.map((opt) => (
+                        <option value={opt.value}>{opt.label}</option>
+                      ))}
+                    </select>
+                  </div>
+                </Show>
               </div>
             </Show>
+
+            <ScanControls
+              isActive={isActive()}
+              stopping={stopping()}
+              frameFilter={frameFilter()}
+              onFrameFilterChange={setFrameFilter}
+              onStartScan={() => startScan({ includeCalibration: frameFilter() === "all" })}
+              onStopScan={stopScan}
+            />
           </div>
-        </Show>
 
-        <ScanControls
-          isActive={isActive()}
-          stopping={stopping()}
-          frameFilter={frameFilter()}
-          onFrameFilterChange={setFrameFilter}
-          onStartScan={() => startScan({ includeCalibration: frameFilter() === "all" })}
-          onStopScan={stopScan}
-        />
+          {/* scan-filters-panel-slot */}
+
+          <Show when={isAdmin()}>
+            <MaintenanceActions
+              disabled={isActive()}
+              rebuildRunning={rebuildState().state === "running"}
+              rebuildMode={rebuildState().mode}
+              onRegenThumbnails={startRegeneration}
+              onStartedAction={startRebuildPolling}
+            />
+          </Show>
+        </div>
+
+        {/* Right column: sticky activity feed */}
+        <div class="lg:sticky lg:top-4 lg:self-start min-w-0">
+          <div class="lg:max-h-[calc(100vh-2rem)] lg:overflow-hidden lg:flex lg:flex-col">
+            <ActivityFeed
+              scanStatus={scanStatus()}
+              rebuildStatus={rebuildState()}
+              stopping={stopping()}
+              scanError={scanError()}
+              onResetAndRescan={handleResetAndRescan}
+              onDismissStalled={resetScan}
+            />
+          </div>
+        </div>
       </div>
-
-      <ActivityFeed
-        scanStatus={scanStatus()}
-        rebuildStatus={rebuildState()}
-        stopping={stopping()}
-        scanError={scanError()}
-        onResetAndRescan={handleResetAndRescan}
-        onDismissStalled={resetScan}
-      />
-
-      <Show when={isAdmin()}>
-        <MaintenanceActions
-          disabled={isActive()}
-          rebuildRunning={rebuildState().state === "running"}
-          rebuildMode={rebuildState().mode}
-          onRegenThumbnails={startRegeneration}
-          onStartedAction={startRebuildPolling}
-        />
-      </Show>
     </div>
   );
 };

--- a/frontend/src/components/ScanManager.tsx
+++ b/frontend/src/components/ScanManager.tsx
@@ -138,10 +138,12 @@ const ScanManager: Component = () => {
               el?.scrollIntoView({ behavior: "smooth", block: "start" });
             }}
           />
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div class="rounded-[var(--radius-md)] bg-theme-surface border border-theme-border p-4 space-y-6">
+            <h3 class="text-sm font-medium text-theme-text-primary">Library Scanning</h3>
+
             <Show when={isAdmin()}>
-              <div class="rounded-[var(--radius-md)] bg-theme-surface border border-theme-border p-4 space-y-4">
-                <h3 class="text-sm font-medium text-theme-text-primary">Auto-scan</h3>
+              <div class="space-y-4">
+                <h4 class="text-sm font-medium text-theme-text-primary">Auto-scan</h4>
                 <div class="flex items-center justify-between">
                   <label class="text-sm text-theme-text-secondary">Enable automatic scanning</label>
                   <button
@@ -174,17 +176,19 @@ const ScanManager: Component = () => {
               </div>
             </Show>
 
-            <ScanControls
-              isActive={isActive()}
-              stopping={stopping()}
-              frameFilter={frameFilter()}
-              onFrameFilterChange={setFrameFilter}
-              onStartScan={() => startScan({ includeCalibration: frameFilter() === "all" })}
-              onStopScan={stopScan}
-            />
-          </div>
+            <ScanFiltersPanel />
 
-          <ScanFiltersPanel />
+            <div class="flex flex-wrap items-center gap-4 justify-end pt-2 border-t border-theme-border">
+              <ScanControls
+                isActive={isActive()}
+                stopping={stopping()}
+                frameFilter={frameFilter()}
+                onFrameFilterChange={setFrameFilter}
+                onStartScan={() => startScan({ includeCalibration: frameFilter() === "all" })}
+                onStopScan={stopScan}
+              />
+            </div>
+          </div>
 
           <Show when={isAdmin()}>
             <MaintenanceActions

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -2,6 +2,7 @@ import { Component, onMount, onCleanup, createSignal } from "solid-js";
 import { useSearchParams } from "@solidjs/router";
 import Sidebar from "../components/Sidebar";
 import TargetFeed from "../components/TargetFeed";
+import ScanFiltersOnboarding from "../components/ScanFiltersOnboarding";
 import DashboardFilterProvider, { hasFilterParams, ALL_PARAM_KEYS } from "../components/DashboardFilterProvider";
 
 const SESSION_KEY = "dashboard_params";
@@ -71,6 +72,9 @@ const DashboardPage: Component = () => {
         </div>
 
         <main class="flex-1 min-h-[calc(100vh-57px)]">
+          <div class="px-4 pt-4">
+            <ScanFiltersOnboarding variant="global" />
+          </div>
           <TargetFeed />
         </main>
       </div>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -16,7 +16,7 @@ import { contentWidthClass } from "../utils/format";
 import SettingsHelpSection from "../components/settings/SettingsHelpSection";
 
 const ALL_TABS = [
-  { id: "scan", label: "Scan & Ingest" },
+  { id: "scan", label: "Library" },
   { id: "filters", label: "Filters" },
   { id: "equipment", label: "Equipment" },
   { id: "display", label: "Display" },
@@ -66,10 +66,11 @@ export const SettingsPage: Component = () => {
         <SettingsHelpSection tabId="scan">
           <p class="text-sm text-theme-text-secondary">GalactiLog builds its catalog by scanning a directory of FITS files. Each scan reads FITS headers to extract target names, filters, timestamps, and equipment metadata.</p>
           <ul class="text-sm text-theme-text-secondary list-disc list-inside space-y-1">
-            <li><strong class="text-theme-text-primary">Auto-scan</strong> runs on a timer so new files are cataloged automatically. <strong class="text-theme-text-primary">Scan Directory</strong> triggers a one-time scan.</li>
-            <li>Choose <strong class="text-theme-text-primary">Light frames only</strong> to skip calibration frames (darks, flats, bias) or <strong class="text-theme-text-primary">All frames</strong> to catalog everything.</li>
-            <li>The <strong class="text-theme-text-primary">Database Overview</strong> shows current catalog totals and name-resolution cache status (SIMBAD, SESAME, VizieR).</li>
-            <li><strong class="text-theme-text-primary">Maintenance</strong> actions: <strong class="text-theme-text-primary">Re-match</strong> re-resolves all target names against SIMBAD. <strong class="text-theme-text-primary">Retry Unresolved</strong> retries only failed lookups. <strong class="text-theme-text-primary">Regenerate</strong> rebuilds thumbnails. <strong class="text-theme-text-primary">Full Rebuild</strong> re-scans all files from scratch - use sparingly.</li>
+            <li><strong class="text-theme-text-primary">Library Scanning</strong> holds everything that controls what gets cataloged. <strong class="text-theme-text-primary">Auto-scan</strong> runs periodically on a configurable interval; <strong class="text-theme-text-primary">Scan Directory</strong> triggers a one-time scan.</li>
+            <li><strong class="text-theme-text-primary">Path & name rules</strong> restrict which folders are walked and which file or folder names are included or excluded. Rules accept wildcard, substring, or regex patterns, and a test-a-path tool previews matches before saving.</li>
+            <li>The action bar exposes <strong class="text-theme-text-primary">Save rules</strong>, <strong class="text-theme-text-primary">Revert</strong>, and <strong class="text-theme-text-primary">Apply now</strong>, plus a frame-filter selector: pick <strong class="text-theme-text-primary">Light frames only</strong> to skip calibration frames (darks, flats, bias) or <strong class="text-theme-text-primary">All frames</strong> to catalog everything.</li>
+            <li>The <strong class="text-theme-text-primary">Database Overview</strong> card shows current catalog totals and name-resolution cache status (SIMBAD, SESAME, VizieR).</li>
+            <li><strong class="text-theme-text-primary">Maintenance</strong> actions: <strong class="text-theme-text-primary">Re-match</strong> re-resolves all target names against SIMBAD. <strong class="text-theme-text-primary">Retry Unresolved</strong> retries only failed lookups. <strong class="text-theme-text-primary">Regenerate</strong> rebuilds thumbnails. <strong class="text-theme-text-primary">Full Rebuild</strong> re-scans all files from scratch, use sparingly.</li>
           </ul>
         </SettingsHelpSection>
         <ScanManager />

--- a/guides/CONFIGURATION.md
+++ b/guides/CONFIGURATION.md
@@ -63,7 +63,7 @@ Configure from **Settings > General**:
 - **Scan Interval** -- 1 to 24 hours
 - **Include Calibration Frames** -- Whether to ingest DARK, FLAT, and BIAS frames
 
-Manual scans can be triggered from **Settings > Scan & Ingest**.
+Manual scans can be triggered from **Settings > Library**.
 
 ## Filter Aliases
 

--- a/guides/INSTALL.md
+++ b/guides/INSTALL.md
@@ -87,7 +87,7 @@ curl http://localhost:8080/api/scan/status
 
 ### 5. First Scan
 
-Log in and go to **Settings > Scan & Ingest > Start Scan**. GalactiLog discovers FITS files, extracts metadata, generates thumbnails, resolves targets via SIMBAD, and backfills metrics from any N.I.N.A. CSV files. Progress is shown in real-time.
+Log in and go to **Settings > Library > Scan Directory**. GalactiLog discovers FITS files, extracts metadata, generates thumbnails, resolves targets via SIMBAD, and backfills metrics from any N.I.N.A. CSV files. Progress is shown in real-time.
 
 ## Architecture
 
@@ -170,7 +170,7 @@ ports:
 
 ### SIMBAD resolution timeouts
 
-SIMBAD may be slow or temporarily unavailable. Failed lookups are retried on subsequent scans, and resolved targets are cached locally. You can trigger a backfill from Settings > Scan & Ingest > Backfill Targets.
+SIMBAD may be slow or temporarily unavailable. Failed lookups are retried on subsequent scans, and resolved targets are cached locally. You can trigger a backfill from Settings > Library > Backfill Targets.
 
 ### Database connection errors
 


### PR DESCRIPTION
**Summary**
This pull request introduces a comprehensive scan filtering system, including a new frontend panel, API endpoints for filter management, and core integration into the scanner and worker processes. It enables users to define and apply rules to control which files and directories are included in a scan.

**Changes**
*   Implements the scan filters frontend panel, folder browser, and a global onboarding banner.
*   Adds API endpoints for scan filter CRUD operations, applying filters, and folder browsing.
*   Integrates scan filter loading and effective root iteration into the worker's `run_scan` process.
*   Modifies the scanner to accept `ScanFilterConfig` for pruning directories and filtering files during file system walks.
*   Introduces `ScanFilterConfig` construction with path validation and supports `NameRule` with wildcard, substring, and regex matching.
*   Adds `should_walk_dir`, `should_include_file` predicates, and a `test_path` verdict helper for filter logic.
*   Corrects filter application logic by gating `should_include_file` and `test_path` on `include_paths` and gating auto-scan on `scan_filters_configured`.
*   Improves UI elements: clarifies `apply-now` empty-state and confirmation wording, renames 'glob' to 'wildcard', adds tooltips, and ensures theme-consistent buttons.
*   Refactors the scan page to a two-column layout with a sticky activity feed, allowing inner scroll.
*   Renames scan settings sections and improves filter panel discoverability with auto-expand on first visit.
*   Adds `apply-now` activity feed entry and implements loading/error states for the folder browser.
*   Expands test coverage for scan filter API endpoints and scanner integration.
*   Updates CI to include image size in build summaries and adds `.gitattributes` for LF enforcement on shell scripts and source files.

**Impact**
*   **Backend**: Introduces new API endpoints for scan filters, modifies scanner logic, and updates worker tasks.
*   **Frontend**: Adds new components for scan filter management, updates existing scan-related pages and components, and refactors layout.
*   **Tests**: Adds extensive unit and integration tests for scan filter API and core logic.
*   **Build/CI**: Updates CI workflows and adds `.gitattributes` for code consistency.
*   **Documentation**: Updates configuration and installation guides.