### PR TITLE
Update Scan Filter Testing and Python Regex Validation

### DIFF
--- a/backend/app/api/scan.py
+++ b/backend/app/api/scan.py
@@ -13,8 +13,11 @@ from app.api.deps import get_current_user, require_admin
 from app.models.user import User
 from app.models import Image, Target
 from app.models.user_settings import UserSettings, SETTINGS_ROW_ID
+import re as _re
+
 from app.schemas.scan_filters import (
     ScanFiltersIn, ScanFiltersOut, TestPathIn, TestPathOut, BrowseEntry, ApplyNowOut,
+    ValidateRegexIn, ValidateRegexOut,
 )
 from app.services.scan_filters import ScanFilterConfig
 from app.services.scan_state import (
@@ -512,6 +515,25 @@ async def test_scan_filter_path(
         verdict=test_result.verdict,
         matched_rule_ids=test_result.matched_rule_ids,
     )
+
+
+@router.post("/filters/validate-regex", response_model=ValidateRegexOut)
+async def validate_scan_filter_regex(
+    payload: ValidateRegexIn,
+    user: User = Depends(get_current_user),
+):
+    """Validate a regex pattern against Python's `re` engine.
+
+    The scanner evaluates name rules with `re.compile(...).search(...)`, so
+    this is the single source of truth for pattern validity. The frontend
+    calls this instead of `new RegExp(...)` to avoid JS/Python dialect
+    mismatches (e.g. `(?i)` inline flags, `(?P<name>)` named groups).
+    """
+    try:
+        _re.compile(payload.pattern)
+    except _re.error as exc:
+        return ValidateRegexOut(ok=False, error=str(exc))
+    return ValidateRegexOut(ok=True)
 
 
 @router.post("/filters/apply-now", response_model=ApplyNowOut)

--- a/backend/app/schemas/scan_filters.py
+++ b/backend/app/schemas/scan_filters.py
@@ -88,3 +88,17 @@ class BrowseEntry(BaseModel):
 class ApplyNowOut(BaseModel):
     dry_run: bool
     matched: int
+
+
+class ValidateRegexIn(BaseModel):
+    pattern: str = Field(min_length=1, max_length=512)
+
+    @field_validator("pattern")
+    @classmethod
+    def _pattern_clean(cls, v: str) -> str:
+        return _no_control_chars(v, "pattern")
+
+
+class ValidateRegexOut(BaseModel):
+    ok: bool
+    error: str | None = None

--- a/frontend/src/api/scanFilters.ts
+++ b/frontend/src/api/scanFilters.ts
@@ -47,6 +47,11 @@ export interface ApplyNowResult {
   matched: number;
 }
 
+export interface ValidateRegexResult {
+  ok: boolean;
+  error: string | null;
+}
+
 export const scanFilters = {
   get: (): Promise<ScanFiltersResponse> =>
     fetchJson<ScanFiltersResponse>("/scan/filters"),
@@ -64,6 +69,12 @@ export const scanFilters = {
     fetchJson<TestResult>("/scan/filters/test", {
       method: "POST",
       body: JSON.stringify({ path, target_kind: targetKind }),
+    }),
+
+  validateRegex: (pattern: string): Promise<ValidateRegexResult> =>
+    fetchJson<ValidateRegexResult>("/scan/filters/validate-regex", {
+      method: "POST",
+      body: JSON.stringify({ pattern }),
     }),
 
   applyNow: (dryRun: boolean): Promise<ApplyNowResult> =>

--- a/frontend/src/components/ScanFiltersPanel.tsx
+++ b/frontend/src/components/ScanFiltersPanel.tsx
@@ -38,10 +38,43 @@ const ScanFiltersPanel: Component<Props> = (props) => {
     null | { verdict: Verdict; matched: string[] }
   >(null);
 
+  // Regex validation runs on the backend (Python `re`) because the scanner
+  // uses that engine. Validating with `new RegExp(...)` here would reject
+  // Python-only syntax like `(?i)foo` or `(?P<name>)` even though the
+  // scanner accepts them. We cache results by pattern string so rendering
+  // stays synchronous.
+  const [regexCache, setRegexCache] = createSignal<Record<string, string | null>>({});
+  const regexPending = new Set<string>();
+
+  const validatePattern = (pattern: string) => {
+    if (regexPending.has(pattern) || pattern in regexCache()) return;
+    regexPending.add(pattern);
+    scanFilters.validateRegex(pattern).then(
+      (r) => {
+        regexPending.delete(pattern);
+        setRegexCache({ ...regexCache(), [pattern]: r.ok ? null : (r.error ?? "invalid regex") });
+      },
+      () => {
+        regexPending.delete(pattern);
+        // Network failure: don't block the user. Treat as valid for now;
+        // the backend will reject on save if it's truly broken.
+        setRegexCache({ ...regexCache(), [pattern]: null });
+      },
+    );
+  };
+
+  createEffect(() => {
+    for (const r of filters().name_rules) {
+      if (r.type === "regex" && r.pattern.trim()) validatePattern(r.pattern);
+    }
+  });
+
   const ruleIsInvalid = (r: NameRule): string | null => {
     if (!r.pattern.trim()) return "empty pattern";
     if (r.type === "regex") {
-      try { new RegExp(r.pattern); } catch { return "invalid regex"; }
+      const cached = regexCache()[r.pattern];
+      if (cached === undefined) return null; // optimistic while validating
+      return cached;
     }
     return null;
   };

--- a/frontend/src/components/ScanFiltersPanel.tsx
+++ b/frontend/src/components/ScanFiltersPanel.tsx
@@ -15,10 +15,18 @@ import { showToast } from "./Toast";
 const EMPTY: ScanFilters = { include_paths: [], exclude_paths: [], name_rules: [] };
 
 const VERDICT_LABEL: Record<Verdict, string> = {
-  included: "Included",
-  excluded_by_path: "Excluded by path",
-  excluded_by_rule: "Excluded by rule",
-  excluded_by_missing_include: "Excluded (no include rule matched)",
+  included: "Will be scanned",
+  excluded_by_path: "Skipped: excluded by path",
+  excluded_by_rule: "Skipped: matched an exclude rule",
+  excluded_by_missing_include: "Skipped: no include rule matched",
+};
+
+const VERDICT_HINT: Record<Verdict, string> = {
+  included: "No rule caused this path to be skipped.",
+  excluded_by_path: "A parent folder is listed under Exclude paths.",
+  excluded_by_rule: "A name rule with action=exclude matched.",
+  excluded_by_missing_include:
+    "Include rules are set, but none of them matched this path.",
 };
 
 interface Props {
@@ -528,21 +536,36 @@ include rule   ^M\\d+$          (regex, folder)`}
               </button>
             </div>
             <Show when={testResult()}>
-              <div class="text-xs">
-                Verdict:{" "}
-                <strong
-                  class={
-                    testResult()!.verdict === "included"
-                      ? "text-green-400"
-                      : "text-red-400"
-                  }
-                >
-                  {VERDICT_LABEL[testResult()!.verdict]}
-                </strong>
-                <Show when={testResult()!.matched.length > 0}>
-                  {" "}
-                  — matched rules: {testResult()!.matched.join(", ")}
-                </Show>
+              <div class="text-xs space-y-0.5">
+                <div>
+                  Verdict:{" "}
+                  <strong
+                    class={
+                      testResult()!.verdict === "included"
+                        ? "text-green-400"
+                        : "text-red-400"
+                    }
+                  >
+                    {VERDICT_LABEL[testResult()!.verdict]}
+                  </strong>
+                  <Show when={testResult()!.matched.length > 0}>
+                    {" "}
+                    — matched rules: {testResult()!.matched.join(", ")}
+                  </Show>
+                </div>
+                <div class="text-theme-text-secondary">
+                  {VERDICT_HINT[testResult()!.verdict]}
+                  <Show
+                    when={
+                      testResult()!.verdict === "included" &&
+                      filters().name_rules.some((r) => r.action === "exclude")
+                    }
+                  >
+                    {" "}None of your exclude rules matched this path. If you
+                    expected one to match, double-check the pattern against
+                    the exact filename.
+                  </Show>
+                </div>
               </div>
             </Show>
           </div>

--- a/frontend/src/components/ScanFiltersPanel.tsx
+++ b/frontend/src/components/ScanFiltersPanel.tsx
@@ -45,6 +45,13 @@ const ScanFiltersPanel: Component<Props> = (props) => {
   const [testResult, setTestResult] = createSignal<
     null | { verdict: Verdict; matched: string[] }
   >(null);
+  const [testing, setTesting] = createSignal(false);
+
+  const describeRule = (id: string): string => {
+    const r = filters().name_rules.find((x) => x.id === id);
+    if (!r) return id.slice(0, 8);
+    return `${r.action} ${r.type} on ${r.target}: ${r.pattern}`;
+  };
 
   // Regex validation runs on the backend (Python `re`) because the scanner
   // uses that engine. Validating with `new RegExp(...)` here would reject
@@ -136,12 +143,16 @@ const ScanFiltersPanel: Component<Props> = (props) => {
   };
 
   const runTest = async () => {
-    if (!testPath().trim()) return;
+    if (!testPath().trim() || testing()) return;
+    setTesting(true);
+    setTestResult(null);
     try {
       const r = await scanFilters.test(testPath().trim(), testKind());
       setTestResult({ verdict: r.verdict, matched: r.matched_rule_ids });
     } catch (e: any) {
       showToast(e?.message ?? "Test failed", "error");
+    } finally {
+      setTesting(false);
     }
   };
 
@@ -529,10 +540,11 @@ include rule   ^M\\d+$          (regex, folder)`}
                 <option value="folder">folder</option>
               </select>
               <button
-                class="px-4 py-1.5 bg-theme-surface text-theme-text-primary border border-theme-border rounded text-sm font-medium hover:bg-theme-hover transition-colors"
+                class="px-4 py-1.5 bg-theme-surface text-theme-text-primary border border-theme-border rounded text-sm font-medium hover:bg-theme-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 onClick={runTest}
+                disabled={testing() || !testPath().trim()}
               >
-                Test
+                {testing() ? "Testing…" : "Test"}
               </button>
             </div>
             <Show when={testResult()}>
@@ -548,11 +560,16 @@ include rule   ^M\\d+$          (regex, folder)`}
                   >
                     {VERDICT_LABEL[testResult()!.verdict]}
                   </strong>
-                  <Show when={testResult()!.matched.length > 0}>
-                    {" "}
-                    — matched rules: {testResult()!.matched.join(", ")}
-                  </Show>
                 </div>
+                <Show when={testResult()!.matched.length > 0}>
+                  <ul class="list-disc list-inside text-theme-text-secondary">
+                    <For each={testResult()!.matched}>
+                      {(id) => (
+                        <li class="font-mono">{describeRule(id)}</li>
+                      )}
+                    </For>
+                  </ul>
+                </Show>
                 <div class="text-theme-text-secondary">
                   {VERDICT_HINT[testResult()!.verdict]}
                   <Show


### PR DESCRIPTION
**Summary**:
This pull request updates the scan filter testing interface and switches regex pattern validation to use Python's `re` engine.

**Changes**:
*   Switched regex pattern validation from JavaScript's `RegExp` to Python's `re` engine.
*   Added a loading state to the scan filter test user interface.
*   Improved readability of rule descriptions within the scan filter test interface.
*   Clarified verdict labels in scan filter test results.
*   Added contextual hints to scan filter test results.

**Impact**:
*   **Backend**: Regex pattern validation logic in `backend/app/api/scan.py` and `backend/app/schemas/scan_filters.py` now uses Python's `re` engine. This changes how regex patterns are interpreted and validated.
*   **Frontend**: The scan filter testing panel (`frontend/src/components/ScanFiltersPanel.tsx`) displays an improved user experience with loading indicators, clearer rule descriptions, and more informative test results. Frontend API calls (`frontend/src/api/scanFilters.ts`) reflect backend validation changes.