### PR TITLE
Target Chart Rig Display and Scan/Session Fixes

### DIFF
--- a/backend/app/api/scan.py
+++ b/backend/app/api/scan.py
@@ -556,11 +556,15 @@ async def apply_filters_now(
     # Pull file paths and evaluate in Python (keeps rule logic in one place)
     paths_result = await session.execute(select(Image.id, Image.file_path))
     matched_ids: list = []
+    sample_paths: list[str] = []
+    _SAMPLE_LIMIT = 20
     for image_id, file_path in paths_result.all():
         if not file_path:
             continue
         if not cfg.should_include_file(FsPath(file_path), fits_root):
             matched_ids.append(image_id)
+            if len(sample_paths) < _SAMPLE_LIMIT:
+                sample_paths.append(file_path)
 
     if not dry_run and matched_ids:
         await session.execute(
@@ -589,7 +593,11 @@ async def apply_filters_now(
             len(matched_ids), user.username,
         )
 
-    return ApplyNowOut(dry_run=dry_run, matched=len(matched_ids))
+    return ApplyNowOut(
+        dry_run=dry_run,
+        matched=len(matched_ids),
+        sample_paths=sample_paths,
+    )
 
 
 @router.get("/browse", response_model=list[BrowseEntry])

--- a/backend/app/api/targets.py
+++ b/backend/app/api/targets.py
@@ -2,7 +2,7 @@ import re
 import uuid
 import statistics
 from collections import defaultdict
-from datetime import date as date_type, datetime, timedelta
+from datetime import date as date_type, datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 import sqlalchemy as sa
@@ -1361,7 +1361,18 @@ async def get_session_detail(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(get_current_user),
 ):
-    """Return detailed session data for a target on a specific date."""
+    """Return detailed session data for a target on a specific date.
+
+    The date string is interpreted as a UTC calendar day to match the
+    listing endpoint, which groups by `capture_date.strftime("%Y-%m-%d")`
+    against the tz-aware (UTC) column value. Passing a naive datetime to
+    a `timestamptz` comparison would make Postgres coerce it via the
+    session TimeZone, which shifts the window at the midnight boundary
+    and returns zero rows for sessions the listing placed on the other
+    side of UTC midnight.
+    """
+    day_start = datetime.fromisoformat(date).replace(tzinfo=timezone.utc)
+    day_end = day_start + timedelta(days=1)
     if target_id == "obj:__uncategorized__":
         target_name = "Uncategorized"
         target_obj = None
@@ -1375,8 +1386,8 @@ async def get_session_detail(
             .where(
                 Image.resolved_target_id.is_(None),
                 _no_object,
-                Image.capture_date >= datetime.fromisoformat(date),
-                Image.capture_date < datetime.fromisoformat(date) + timedelta(days=1),
+                Image.capture_date >= day_start,
+                Image.capture_date < day_end,
             )
             .order_by(Image.capture_date)
         )
@@ -1395,8 +1406,8 @@ async def get_session_detail(
             select(Image)
             .where(
                 Image.raw_headers["OBJECT"].astext == object_name,
-                Image.capture_date >= datetime.fromisoformat(date),
-                Image.capture_date < datetime.fromisoformat(date) + timedelta(days=1),
+                Image.capture_date >= day_start,
+                Image.capture_date < day_end,
                 Image.image_type == "LIGHT",
             )
             .order_by(Image.capture_date)
@@ -1421,8 +1432,8 @@ async def get_session_detail(
             select(Image)
             .where(
                 Image.resolved_target_id == tid,
-                Image.capture_date >= datetime.fromisoformat(date),
-                Image.capture_date < datetime.fromisoformat(date) + timedelta(days=1),
+                Image.capture_date >= day_start,
+                Image.capture_date < day_end,
                 Image.image_type == "LIGHT",
             )
             .order_by(Image.capture_date)

--- a/backend/app/schemas/scan_filters.py
+++ b/backend/app/schemas/scan_filters.py
@@ -88,6 +88,7 @@ class BrowseEntry(BaseModel):
 class ApplyNowOut(BaseModel):
     dry_run: bool
     matched: int
+    sample_paths: list[str] = Field(default_factory=list)
 
 
 class ValidateRegexIn(BaseModel):

--- a/frontend/src/api/scanFilters.ts
+++ b/frontend/src/api/scanFilters.ts
@@ -45,6 +45,7 @@ export interface BrowseEntry {
 export interface ApplyNowResult {
   dry_run: boolean;
   matched: number;
+  sample_paths?: string[];
 }
 
 export interface ValidateRegexResult {

--- a/frontend/src/components/ScanFiltersPanel.tsx
+++ b/frontend/src/components/ScanFiltersPanel.tsx
@@ -157,6 +157,14 @@ const ScanFiltersPanel: Component<Props> = (props) => {
   };
 
   const applyNow = async () => {
+    if (dirty()) {
+      showToast(
+        "Save your filter changes before running Apply now. It operates on " +
+        "the last saved filters, not unsaved edits.",
+        "error",
+      );
+      return;
+    }
     try {
       const dry = await scanFilters.applyNow(true);
       if (dry.matched === 0) {
@@ -166,11 +174,16 @@ const ScanFiltersPanel: Component<Props> = (props) => {
         );
         return;
       }
+      const sample = (dry.sample_paths ?? []).slice(0, 10);
+      const preview = sample.length > 0
+        ? "\n\nExamples:\n" + sample.join("\n") +
+          (dry.matched > sample.length ? `\n... and ${dry.matched - sample.length} more` : "")
+        : "";
       const ok = window.confirm(
         `This will permanently remove ${dry.matched} image row(s) from the ` +
         `catalog because they are excluded by the saved filters. The files ` +
         `on disk are not touched, and rows will return on the next scan if ` +
-        `the filters are relaxed. Continue?`
+        `the filters are relaxed.${preview}\n\nContinue?`
       );
       if (!ok) return;
       const res = await scanFilters.applyNow(false);
@@ -612,9 +625,14 @@ include rule   ^M\\d+$          (regex, folder)`}
             Revert
           </button>
           <button
-            class="px-4 py-1.5 bg-theme-warning/15 text-theme-warning border border-theme-warning/30 rounded text-sm font-medium hover:bg-theme-warning/25 transition-colors"
+            class="px-4 py-1.5 bg-theme-warning/15 text-theme-warning border border-theme-warning/30 rounded text-sm font-medium disabled:opacity-50 hover:bg-theme-warning/25 transition-colors"
+            disabled={dirty()}
             onClick={applyNow}
-            title="Remove already-ingested image rows that match the current exclude rules. Destructive. Uses the last SAVED filters, not unsaved edits. You will see a confirmation with the row count before anything is deleted."
+            title={
+              dirty()
+                ? "Save your filter changes first. Apply now operates on the last saved filters."
+                : "Remove already-ingested image rows that match the current exclude rules. Destructive. You will see a confirmation with the row count and example paths before anything is deleted."
+            }
           >
             Apply now
           </button>

--- a/frontend/src/components/TargetMetricsChart.tsx
+++ b/frontend/src/components/TargetMetricsChart.tsx
@@ -6,7 +6,20 @@ import { formatTime } from "../utils/dateTime";
 import { METRIC_DEFINITIONS, getMetricColor, getMetricDef, chartFontSize } from "../utils/chartConfig";
 import MetricTogglePills from "./MetricTogglePills";
 import FilterTogglePills from "./FilterTogglePills";
-import { rigColor } from "./RigTogglePills";
+
+/** Dash patterns used to distinguish rigs on the same color-coded line. */
+const RIG_DASH_PATTERNS: number[][] = [
+  [],            // rig 0: solid
+  [6, 3],        // rig 1: long dash
+  [2, 2],        // rig 2: dotted
+  [8, 3, 2, 3],  // rig 3: dash-dot
+  [1, 2],        // rig 4: fine dots
+  [10, 4, 2, 4], // rig 5: long-short
+];
+
+function rigDash(index: number): number[] {
+  return RIG_DASH_PATTERNS[index % RIG_DASH_PATTERNS.length];
+}
 
 Chart.register(LineController, CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Filler);
 
@@ -142,61 +155,29 @@ export default function TargetMetricsChart(props: Props) {
     const { labels, framesByIndex, sessionBoundaries } = chartFrameData();
     const datasets: any[] = [];
 
+    const multiRig = isMultiRig();
+    const rigs = multiRig ? allRigs() : [null];
+
     for (const metricKey of enabledMetrics) {
       const def = getMetricDef(metricKey);
       if (!def) continue;
       const field = def.frameField as keyof FrameRecord;
       const metricColor = getMetricColor(def.colorVar);
 
-      if (isMultiRig()) {
-        const rigs = allRigs();
-        for (let ri = 0; ri < rigs.length; ri++) {
-          const rig = rigs[ri];
-          const color = rigColor(ri);
+      for (let ri = 0; ri < rigs.length; ri++) {
+        const rig = rigs[ri];
+        const dash = multiRig ? rigDash(ri) : undefined;
+        const rigLabel = rig ? ` [${rig}]` : "";
 
-          if (enabledFilters.includes("overall")) {
-            datasets.push({
-              label: `${def.label} (${rig})`,
-              data: framesByIndex.map((f) =>
-                f && f.rig === rig ? ((f[field] as number | null) ?? null) : null
-              ),
-              borderColor: color,
-              backgroundColor: `${color}33`,
-              borderWidth: 1.5,
-              pointRadius: 0,
-              pointHitRadius: 8,
-              tension: 0.3,
-              spanGaps: false,
-              yAxisID: def.yAxisId,
-            });
-          }
+        const matchesRig = (f: FrameRecord | null): f is FrameRecord =>
+          !!f && (rig === null || f.rig === rig);
 
-          for (const filterName of enabledFilters) {
-            if (filterName === "overall") continue;
-            datasets.push({
-              label: `${def.label} (${rig} / ${filterName})`,
-              data: framesByIndex.map((f) =>
-                f && f.rig === rig && f.filter_used === filterName
-                  ? ((f[field] as number | null) ?? null)
-                  : null
-              ),
-              borderColor: color,
-              backgroundColor: `${color}33`,
-              borderWidth: 1.5,
-              pointRadius: 0,
-              pointHitRadius: 8,
-              tension: 0.3,
-              spanGaps: false,
-              yAxisID: def.yAxisId,
-              borderDash: [4, 2],
-            });
-          }
-        }
-      } else {
         if (enabledFilters.includes("overall")) {
           datasets.push({
-            label: def.label,
-            data: framesByIndex.map((f) => f ? ((f[field] as number | null) ?? null) : null),
+            label: `${def.label}${rigLabel}`,
+            data: framesByIndex.map((f) =>
+              matchesRig(f) ? ((f[field] as number | null) ?? null) : null
+            ),
             borderColor: metricColor,
             backgroundColor: `${metricColor}33`,
             borderWidth: 1.5,
@@ -205,6 +186,7 @@ export default function TargetMetricsChart(props: Props) {
             tension: 0.3,
             spanGaps: false,
             yAxisID: def.yAxisId,
+            borderDash: dash,
           });
         }
 
@@ -212,9 +194,11 @@ export default function TargetMetricsChart(props: Props) {
           if (filterName === "overall") continue;
           const fColor = filterColorMap()[filterName] ?? metricColor;
           datasets.push({
-            label: `${def.label} (${filterName})`,
+            label: `${def.label} (${filterName})${rigLabel}`,
             data: framesByIndex.map((f) =>
-              f && f.filter_used === filterName ? ((f[field] as number | null) ?? null) : null
+              matchesRig(f) && f.filter_used === filterName
+                ? ((f[field] as number | null) ?? null)
+                : null
             ),
             borderColor: fColor,
             backgroundColor: `${fColor}33`,
@@ -224,7 +208,7 @@ export default function TargetMetricsChart(props: Props) {
             tension: 0.3,
             spanGaps: false,
             yAxisID: def.yAxisId,
-            borderDash: [4, 2],
+            borderDash: dash ?? [4, 2],
           });
         }
       }

--- a/frontend/src/pages/TargetDetailPage.tsx
+++ b/frontend/src/pages/TargetDetailPage.tsx
@@ -74,7 +74,7 @@ const TargetDetailPage: Component = () => {
     const detail = targetDetail();
     if (detail && !chartDatesInitialized) {
       chartDatesInitialized = true;
-      setSelectedChartDates(detail.sessions.map((s) => s.session_date));
+      setSelectedChartDates(detail.sessions.slice(0, 1).map((s) => s.session_date));
     }
   });
 

--- a/frontend/src/pages/TargetDetailPage.tsx
+++ b/frontend/src/pages/TargetDetailPage.tsx
@@ -3,6 +3,7 @@ import { A, useParams, useSearchParams } from "@solidjs/router";
 import { api } from "../api/client";
 import type { TargetDetailResponse, SessionDetail } from "../types";
 import SessionAccordionCard from "../components/SessionAccordionCard";
+import { showToast } from "../components/Toast";
 import FilterBadges from "../components/FilterBadges";
 import TargetMetricsChart from "../components/TargetMetricsChart";
 import ExportModal from "../components/ExportModal";
@@ -98,8 +99,20 @@ const TargetDetailPage: Component = () => {
 
   const loadSessionDetail = async (date: string) => {
     if (sessionCache()[date]) return;
-    const detail = await api.getSessionDetail(params.targetId, date);
-    setSessionCache((prev) => ({ ...prev, [date]: detail }));
+    try {
+      const detail = await api.getSessionDetail(params.targetId, date);
+      setSessionCache((prev) => ({ ...prev, [date]: detail }));
+    } catch (e: any) {
+      showToast(
+        e?.message ?? `Failed to load session ${date}`,
+        "error",
+      );
+      setExpandedSessions((prev) => {
+        const next = new Set(prev);
+        next.delete(date);
+        return next;
+      });
+    }
   };
 
   // Auto-expand first session or session from query param, and load its data


### PR DESCRIPTION
**Summary**:
This PR implements rig encoding via dash patterns on the target chart, defaulting to the most recent session, and addresses issues with session detail loading, scan filter cleanup UX, and dry-run preview functionality.

**Changes**:
*   Encodes rig data on the target chart using a dash pattern.
*   Sets the target chart to default to data from the most recent session.
*   Corrects an issue preventing session details from loading.
*   Resolves user experience issues related to scan filter cleanup.
*   Fixes dry-run preview functionality.

**Impact**:
*   Backend scan API
*   Backend targets API
*   Backend scan filter schemas
*   Frontend scan filter API
*   Frontend scan filters panel component
*   Frontend target metrics chart component
*   Frontend target detail page