### PR TITLE
Target Chart Rig Selection, Scan UX, and Filter Fixes

### DIFF
--- a/backend/app/api/scan.py
+++ b/backend/app/api/scan.py
@@ -556,11 +556,15 @@ async def apply_filters_now(
     # Pull file paths and evaluate in Python (keeps rule logic in one place)
     paths_result = await session.execute(select(Image.id, Image.file_path))
     matched_ids: list = []
+    sample_paths: list[str] = []
+    _SAMPLE_LIMIT = 20
     for image_id, file_path in paths_result.all():
         if not file_path:
             continue
         if not cfg.should_include_file(FsPath(file_path), fits_root):
             matched_ids.append(image_id)
+            if len(sample_paths) < _SAMPLE_LIMIT:
+                sample_paths.append(file_path)
 
     if not dry_run and matched_ids:
         await session.execute(
@@ -589,7 +593,11 @@ async def apply_filters_now(
             len(matched_ids), user.username,
         )
 
-    return ApplyNowOut(dry_run=dry_run, matched=len(matched_ids))
+    return ApplyNowOut(
+        dry_run=dry_run,
+        matched=len(matched_ids),
+        sample_paths=sample_paths,
+    )
 
 
 @router.get("/browse", response_model=list[BrowseEntry])

--- a/backend/app/api/targets.py
+++ b/backend/app/api/targets.py
@@ -2,7 +2,7 @@ import re
 import uuid
 import statistics
 from collections import defaultdict
-from datetime import date as date_type, datetime, timedelta
+from datetime import date as date_type, datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 import sqlalchemy as sa
@@ -1361,7 +1361,18 @@ async def get_session_detail(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(get_current_user),
 ):
-    """Return detailed session data for a target on a specific date."""
+    """Return detailed session data for a target on a specific date.
+
+    The date string is interpreted as a UTC calendar day to match the
+    listing endpoint, which groups by `capture_date.strftime("%Y-%m-%d")`
+    against the tz-aware (UTC) column value. Passing a naive datetime to
+    a `timestamptz` comparison would make Postgres coerce it via the
+    session TimeZone, which shifts the window at the midnight boundary
+    and returns zero rows for sessions the listing placed on the other
+    side of UTC midnight.
+    """
+    day_start = datetime.fromisoformat(date).replace(tzinfo=timezone.utc)
+    day_end = day_start + timedelta(days=1)
     if target_id == "obj:__uncategorized__":
         target_name = "Uncategorized"
         target_obj = None
@@ -1375,8 +1386,8 @@ async def get_session_detail(
             .where(
                 Image.resolved_target_id.is_(None),
                 _no_object,
-                Image.capture_date >= datetime.fromisoformat(date),
-                Image.capture_date < datetime.fromisoformat(date) + timedelta(days=1),
+                Image.capture_date >= day_start,
+                Image.capture_date < day_end,
             )
             .order_by(Image.capture_date)
         )
@@ -1395,8 +1406,8 @@ async def get_session_detail(
             select(Image)
             .where(
                 Image.raw_headers["OBJECT"].astext == object_name,
-                Image.capture_date >= datetime.fromisoformat(date),
-                Image.capture_date < datetime.fromisoformat(date) + timedelta(days=1),
+                Image.capture_date >= day_start,
+                Image.capture_date < day_end,
                 Image.image_type == "LIGHT",
             )
             .order_by(Image.capture_date)
@@ -1421,8 +1432,8 @@ async def get_session_detail(
             select(Image)
             .where(
                 Image.resolved_target_id == tid,
-                Image.capture_date >= datetime.fromisoformat(date),
-                Image.capture_date < datetime.fromisoformat(date) + timedelta(days=1),
+                Image.capture_date >= day_start,
+                Image.capture_date < day_end,
                 Image.image_type == "LIGHT",
             )
             .order_by(Image.capture_date)

--- a/backend/app/schemas/scan_filters.py
+++ b/backend/app/schemas/scan_filters.py
@@ -88,6 +88,7 @@ class BrowseEntry(BaseModel):
 class ApplyNowOut(BaseModel):
     dry_run: bool
     matched: int
+    sample_paths: list[str] = Field(default_factory=list)
 
 
 class ValidateRegexIn(BaseModel):

--- a/frontend/src/api/scanFilters.ts
+++ b/frontend/src/api/scanFilters.ts
@@ -45,6 +45,7 @@ export interface BrowseEntry {
 export interface ApplyNowResult {
   dry_run: boolean;
   matched: number;
+  sample_paths?: string[];
 }
 
 export interface ValidateRegexResult {

--- a/frontend/src/components/ScanFiltersPanel.tsx
+++ b/frontend/src/components/ScanFiltersPanel.tsx
@@ -40,6 +40,7 @@ const ScanFiltersPanel: Component<Props> = (props) => {
   const [dirty, setDirty] = createSignal(false);
   const [browsing, setBrowsing] = createSignal<null | "include" | "exclude">(null);
   const [saving, setSaving] = createSignal(false);
+  const [applying, setApplying] = createSignal(false);
   const [testPath, setTestPath] = createSignal("");
   const [testKind, setTestKind] = createSignal<"auto" | "file" | "folder">("auto");
   const [testResult, setTestResult] = createSignal<
@@ -165,6 +166,7 @@ const ScanFiltersPanel: Component<Props> = (props) => {
       );
       return;
     }
+    setApplying(true);
     try {
       const dry = await scanFilters.applyNow(true);
       if (dry.matched === 0) {
@@ -190,6 +192,8 @@ const ScanFiltersPanel: Component<Props> = (props) => {
       showToast(`Removed ${res.matched} image row(s) from the catalog`);
     } catch (e: any) {
       showToast(e?.message ?? "Apply now failed", "error");
+    } finally {
+      setApplying(false);
     }
   };
 
@@ -626,7 +630,7 @@ include rule   ^M\\d+$          (regex, folder)`}
           </button>
           <button
             class="px-4 py-1.5 bg-theme-warning/15 text-theme-warning border border-theme-warning/30 rounded text-sm font-medium disabled:opacity-50 hover:bg-theme-warning/25 transition-colors"
-            disabled={dirty()}
+            disabled={dirty() || applying()}
             onClick={applyNow}
             title={
               dirty()
@@ -634,7 +638,7 @@ include rule   ^M\\d+$          (regex, folder)`}
                 : "Remove already-ingested image rows that match the current exclude rules. Destructive. You will see a confirmation with the row count and example paths before anything is deleted."
             }
           >
-            Apply now
+            {applying() ? "Checking\u2026" : "Apply now"}
           </button>
         </div>
       </div>

--- a/frontend/src/components/ScanFiltersPanel.tsx
+++ b/frontend/src/components/ScanFiltersPanel.tsx
@@ -157,6 +157,14 @@ const ScanFiltersPanel: Component<Props> = (props) => {
   };
 
   const applyNow = async () => {
+    if (dirty()) {
+      showToast(
+        "Save your filter changes before running Apply now. It operates on " +
+        "the last saved filters, not unsaved edits.",
+        "error",
+      );
+      return;
+    }
     try {
       const dry = await scanFilters.applyNow(true);
       if (dry.matched === 0) {
@@ -166,11 +174,16 @@ const ScanFiltersPanel: Component<Props> = (props) => {
         );
         return;
       }
+      const sample = (dry.sample_paths ?? []).slice(0, 10);
+      const preview = sample.length > 0
+        ? "\n\nExamples:\n" + sample.join("\n") +
+          (dry.matched > sample.length ? `\n... and ${dry.matched - sample.length} more` : "")
+        : "";
       const ok = window.confirm(
         `This will permanently remove ${dry.matched} image row(s) from the ` +
         `catalog because they are excluded by the saved filters. The files ` +
         `on disk are not touched, and rows will return on the next scan if ` +
-        `the filters are relaxed. Continue?`
+        `the filters are relaxed.${preview}\n\nContinue?`
       );
       if (!ok) return;
       const res = await scanFilters.applyNow(false);
@@ -612,9 +625,14 @@ include rule   ^M\\d+$          (regex, folder)`}
             Revert
           </button>
           <button
-            class="px-4 py-1.5 bg-theme-warning/15 text-theme-warning border border-theme-warning/30 rounded text-sm font-medium hover:bg-theme-warning/25 transition-colors"
+            class="px-4 py-1.5 bg-theme-warning/15 text-theme-warning border border-theme-warning/30 rounded text-sm font-medium disabled:opacity-50 hover:bg-theme-warning/25 transition-colors"
+            disabled={dirty()}
             onClick={applyNow}
-            title="Remove already-ingested image rows that match the current exclude rules. Destructive. Uses the last SAVED filters, not unsaved edits. You will see a confirmation with the row count before anything is deleted."
+            title={
+              dirty()
+                ? "Save your filter changes first. Apply now operates on the last saved filters."
+                : "Remove already-ingested image rows that match the current exclude rules. Destructive. You will see a confirmation with the row count and example paths before anything is deleted."
+            }
           >
             Apply now
           </button>

--- a/frontend/src/components/TargetMetricsChart.tsx
+++ b/frontend/src/components/TargetMetricsChart.tsx
@@ -6,7 +6,20 @@ import { formatTime } from "../utils/dateTime";
 import { METRIC_DEFINITIONS, getMetricColor, getMetricDef, chartFontSize } from "../utils/chartConfig";
 import MetricTogglePills from "./MetricTogglePills";
 import FilterTogglePills from "./FilterTogglePills";
-import { rigColor } from "./RigTogglePills";
+
+/** Dash patterns used to distinguish rigs on the same color-coded line. */
+const RIG_DASH_PATTERNS: number[][] = [
+  [],            // rig 0: solid
+  [6, 3],        // rig 1: long dash
+  [2, 2],        // rig 2: dotted
+  [8, 3, 2, 3],  // rig 3: dash-dot
+  [1, 2],        // rig 4: fine dots
+  [10, 4, 2, 4], // rig 5: long-short
+];
+
+function rigDash(index: number): number[] {
+  return RIG_DASH_PATTERNS[index % RIG_DASH_PATTERNS.length];
+}
 
 Chart.register(LineController, CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Filler);
 
@@ -142,61 +155,29 @@ export default function TargetMetricsChart(props: Props) {
     const { labels, framesByIndex, sessionBoundaries } = chartFrameData();
     const datasets: any[] = [];
 
+    const multiRig = isMultiRig();
+    const rigs = multiRig ? allRigs() : [null];
+
     for (const metricKey of enabledMetrics) {
       const def = getMetricDef(metricKey);
       if (!def) continue;
       const field = def.frameField as keyof FrameRecord;
       const metricColor = getMetricColor(def.colorVar);
 
-      if (isMultiRig()) {
-        const rigs = allRigs();
-        for (let ri = 0; ri < rigs.length; ri++) {
-          const rig = rigs[ri];
-          const color = rigColor(ri);
+      for (let ri = 0; ri < rigs.length; ri++) {
+        const rig = rigs[ri];
+        const dash = multiRig ? rigDash(ri) : undefined;
+        const rigLabel = rig ? ` [${rig}]` : "";
 
-          if (enabledFilters.includes("overall")) {
-            datasets.push({
-              label: `${def.label} (${rig})`,
-              data: framesByIndex.map((f) =>
-                f && f.rig === rig ? ((f[field] as number | null) ?? null) : null
-              ),
-              borderColor: color,
-              backgroundColor: `${color}33`,
-              borderWidth: 1.5,
-              pointRadius: 0,
-              pointHitRadius: 8,
-              tension: 0.3,
-              spanGaps: false,
-              yAxisID: def.yAxisId,
-            });
-          }
+        const matchesRig = (f: FrameRecord | null): f is FrameRecord =>
+          !!f && (rig === null || f.rig === rig);
 
-          for (const filterName of enabledFilters) {
-            if (filterName === "overall") continue;
-            datasets.push({
-              label: `${def.label} (${rig} / ${filterName})`,
-              data: framesByIndex.map((f) =>
-                f && f.rig === rig && f.filter_used === filterName
-                  ? ((f[field] as number | null) ?? null)
-                  : null
-              ),
-              borderColor: color,
-              backgroundColor: `${color}33`,
-              borderWidth: 1.5,
-              pointRadius: 0,
-              pointHitRadius: 8,
-              tension: 0.3,
-              spanGaps: false,
-              yAxisID: def.yAxisId,
-              borderDash: [4, 2],
-            });
-          }
-        }
-      } else {
         if (enabledFilters.includes("overall")) {
           datasets.push({
-            label: def.label,
-            data: framesByIndex.map((f) => f ? ((f[field] as number | null) ?? null) : null),
+            label: `${def.label}${rigLabel}`,
+            data: framesByIndex.map((f) =>
+              matchesRig(f) ? ((f[field] as number | null) ?? null) : null
+            ),
             borderColor: metricColor,
             backgroundColor: `${metricColor}33`,
             borderWidth: 1.5,
@@ -205,6 +186,7 @@ export default function TargetMetricsChart(props: Props) {
             tension: 0.3,
             spanGaps: false,
             yAxisID: def.yAxisId,
+            borderDash: dash,
           });
         }
 
@@ -212,9 +194,11 @@ export default function TargetMetricsChart(props: Props) {
           if (filterName === "overall") continue;
           const fColor = filterColorMap()[filterName] ?? metricColor;
           datasets.push({
-            label: `${def.label} (${filterName})`,
+            label: `${def.label} (${filterName})${rigLabel}`,
             data: framesByIndex.map((f) =>
-              f && f.filter_used === filterName ? ((f[field] as number | null) ?? null) : null
+              matchesRig(f) && f.filter_used === filterName
+                ? ((f[field] as number | null) ?? null)
+                : null
             ),
             borderColor: fColor,
             backgroundColor: `${fColor}33`,
@@ -224,7 +208,7 @@ export default function TargetMetricsChart(props: Props) {
             tension: 0.3,
             spanGaps: false,
             yAxisID: def.yAxisId,
-            borderDash: [4, 2],
+            borderDash: dash ?? [4, 2],
           });
         }
       }

--- a/frontend/src/components/TargetMetricsChart.tsx
+++ b/frontend/src/components/TargetMetricsChart.tsx
@@ -1,4 +1,4 @@
-import { createMemo, createEffect, createSignal, onCleanup, Show } from "solid-js";
+import { createMemo, createEffect, createSignal, onCleanup, Show, untrack } from "solid-js";
 import { Chart, LineController, CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Filler } from "chart.js";
 import type { SessionDetail, FrameRecord } from "../types";
 import { useSettingsContext } from "./SettingsProvider";
@@ -29,6 +29,8 @@ interface Props {
   sessionDetails: Record<string, SessionDetail>;
   expanded: boolean;
   onLoadSession: (date: string) => void;
+  /** Full list of filters available across all sessions for this target. */
+  availableFilters: string[];
 }
 
 /** Sentinel value inserted between sessions to create a visual gap */
@@ -50,25 +52,18 @@ export default function TargetMetricsChart(props: Props) {
     }
   });
 
-  const allFilters = createMemo(() => {
-    const filterSet = new Set<string>();
-    for (const date of props.selectedDates) {
-      const detail = props.sessionDetails[date];
-      if (detail) {
-        for (const fd of detail.filter_details) filterSet.add(fd.filter_name);
-      }
-    }
-    return [...filterSet].sort();
-  });
+  // Target-wide filters (from targetDetail.filters_used). Always shows the
+  // full set for the target regardless of which sessions are currently selected.
+  const allFilters = createMemo(() => [...props.availableFilters].sort());
 
+  // Rigs from every loaded session detail (not just selected), so rig pills
+  // grow as the user expands or selects additional sessions.
   const allRigs = createMemo(() => {
     const rigSet = new Set<string>();
-    for (const date of props.selectedDates) {
-      const detail = props.sessionDetails[date];
-      if (detail) {
-        for (const frame of detail.frames) {
-          if (frame.rig) rigSet.add(frame.rig);
-        }
+    for (const detail of Object.values(props.sessionDetails)) {
+      if (!detail) continue;
+      for (const frame of detail.frames) {
+        if (frame.rig) rigSet.add(frame.rig);
       }
     }
     return [...rigSet].sort();
@@ -77,19 +72,26 @@ export default function TargetMetricsChart(props: Props) {
   const isMultiRig = () => allRigs().length > 1;
 
   const [enabledRigs, setEnabledRigs] = createSignal<string[]>([]);
+  // Tracks rigs previously observed in allRigs() so we can distinguish a newly
+  // discovered rig (default it on) from a rig the user explicitly toggled off.
+  let seenRigs = new Set<string>();
 
-  // Keep enabled rigs in sync with rigs present in loaded sessions: drop
-  // missing ones and default newly-seen rigs to enabled.
   createEffect(() => {
     const current = allRigs();
-    const prev = enabledRigs();
-    const prevSet = new Set(prev);
-    const kept = prev.filter((r) => current.includes(r));
-    const added = current.filter((r) => !prevSet.has(r));
-    const next = [...kept, ...added];
-    if (next.length !== prev.length || next.some((r, i) => r !== prev[i])) {
-      setEnabledRigs(next);
-    }
+    untrack(() => {
+      const added = current.filter((r) => !seenRigs.has(r));
+      const stillPresent = (r: string) => current.includes(r);
+      if (added.length > 0) {
+        setEnabledRigs((prev) => [...prev.filter(stillPresent), ...added]);
+      } else {
+        // Drop any enabled rigs that are no longer present.
+        setEnabledRigs((prev) => {
+          const next = prev.filter(stillPresent);
+          return next.length === prev.length ? prev : next;
+        });
+      }
+      seenRigs = new Set(current);
+    });
   });
 
   const toggleRig = (rig: string) => {
@@ -186,6 +188,22 @@ export default function TargetMetricsChart(props: Props) {
     // even when some rigs are toggled off.
     const allRigList = allRigs();
 
+    // Segment callback that hides line segments crossing a session boundary,
+    // so spanGaps:true connects points within a session (across interleaved
+    // frames from other rigs/filters) but never draws across sessions.
+    const crossesBoundary = (p0Idx: number, p1Idx: number): boolean => {
+      for (const b of sessionBoundaries) {
+        if (b > 0 && p0Idx < b && p1Idx >= b) return true;
+      }
+      return false;
+    };
+    const segmentBreak = {
+      borderColor: (ctx: any) =>
+        crossesBoundary(ctx.p0DataIndex, ctx.p1DataIndex)
+          ? "rgba(0,0,0,0)"
+          : undefined,
+    };
+
     for (const metricKey of enabledMetrics) {
       const def = getMetricDef(metricKey);
       if (!def) continue;
@@ -212,7 +230,8 @@ export default function TargetMetricsChart(props: Props) {
             pointRadius: 0,
             pointHitRadius: 8,
             tension: 0.3,
-            spanGaps: false,
+            spanGaps: true,
+            segment: segmentBreak,
             yAxisID: def.yAxisId,
             borderDash: dash,
           });
@@ -234,7 +253,8 @@ export default function TargetMetricsChart(props: Props) {
             pointRadius: 0,
             pointHitRadius: 8,
             tension: 0.3,
-            spanGaps: false,
+            spanGaps: true,
+            segment: segmentBreak,
             yAxisID: def.yAxisId,
             borderDash: dash ?? [4, 2],
           });

--- a/frontend/src/components/TargetMetricsChart.tsx
+++ b/frontend/src/components/TargetMetricsChart.tsx
@@ -1,4 +1,4 @@
-import { createMemo, createEffect, onCleanup, Show } from "solid-js";
+import { createMemo, createEffect, createSignal, onCleanup, Show } from "solid-js";
 import { Chart, LineController, CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Filler } from "chart.js";
 import type { SessionDetail, FrameRecord } from "../types";
 import { useSettingsContext } from "./SettingsProvider";
@@ -6,6 +6,7 @@ import { formatTime } from "../utils/dateTime";
 import { METRIC_DEFINITIONS, getMetricColor, getMetricDef, chartFontSize } from "../utils/chartConfig";
 import MetricTogglePills from "./MetricTogglePills";
 import FilterTogglePills from "./FilterTogglePills";
+import RigTogglePills from "./RigTogglePills";
 
 /** Dash patterns used to distinguish rigs on the same color-coded line. */
 const RIG_DASH_PATTERNS: number[][] = [
@@ -74,6 +75,28 @@ export default function TargetMetricsChart(props: Props) {
   });
 
   const isMultiRig = () => allRigs().length > 1;
+
+  const [enabledRigs, setEnabledRigs] = createSignal<string[]>([]);
+
+  // Keep enabled rigs in sync with rigs present in loaded sessions: drop
+  // missing ones and default newly-seen rigs to enabled.
+  createEffect(() => {
+    const current = allRigs();
+    const prev = enabledRigs();
+    const prevSet = new Set(prev);
+    const kept = prev.filter((r) => current.includes(r));
+    const added = current.filter((r) => !prevSet.has(r));
+    const next = [...kept, ...added];
+    if (next.length !== prev.length || next.some((r, i) => r !== prev[i])) {
+      setEnabledRigs(next);
+    }
+  });
+
+  const toggleRig = (rig: string) => {
+    setEnabledRigs((prev) =>
+      prev.includes(rig) ? prev.filter((r) => r !== rig) : [...prev, rig]
+    );
+  };
 
   /** Build arrays of labels + per-metric data, with gaps between sessions */
   const chartFrameData = createMemo(() => {
@@ -156,7 +179,12 @@ export default function TargetMetricsChart(props: Props) {
     const datasets: any[] = [];
 
     const multiRig = isMultiRig();
-    const rigs = multiRig ? allRigs() : [null];
+    const activeRigs = multiRig
+      ? allRigs().filter((r) => enabledRigs().includes(r))
+      : [null];
+    // Preserve rig index from the full rig list so dash patterns remain stable
+    // even when some rigs are toggled off.
+    const allRigList = allRigs();
 
     for (const metricKey of enabledMetrics) {
       const def = getMetricDef(metricKey);
@@ -164,8 +192,8 @@ export default function TargetMetricsChart(props: Props) {
       const field = def.frameField as keyof FrameRecord;
       const metricColor = getMetricColor(def.colorVar);
 
-      for (let ri = 0; ri < rigs.length; ri++) {
-        const rig = rigs[ri];
+      for (const rig of activeRigs) {
+        const ri = rig === null ? 0 : allRigList.indexOf(rig);
         const dash = multiRig ? rigDash(ri) : undefined;
         const rigLabel = rig ? ` [${rig}]` : "";
 
@@ -304,6 +332,7 @@ export default function TargetMetricsChart(props: Props) {
     // Track all reactive dependencies
     chartFrameData();
     graphSettings();
+    enabledRigs();
     if (pendingRAF !== null) cancelAnimationFrame(pendingRAF);
     if (props.expanded) {
       pendingRAF = requestAnimationFrame(() => {
@@ -342,8 +371,15 @@ export default function TargetMetricsChart(props: Props) {
         </div>
         <MetricTogglePills availableMetrics={availableMetricKeys()} />
       </div>
-      <div class="mb-3">
+      <div class="mb-3 flex flex-wrap items-center gap-3">
         <FilterTogglePills filters={allFilters()} />
+        <Show when={isMultiRig()}>
+          <RigTogglePills
+            rigs={allRigs()}
+            enabledRigs={enabledRigs()}
+            onToggle={toggleRig}
+          />
+        </Show>
       </div>
       <div style={{ height: "220px" }}>
         <canvas ref={canvasRef} />

--- a/frontend/src/pages/TargetDetailPage.tsx
+++ b/frontend/src/pages/TargetDetailPage.tsx
@@ -74,7 +74,7 @@ const TargetDetailPage: Component = () => {
     const detail = targetDetail();
     if (detail && !chartDatesInitialized) {
       chartDatesInitialized = true;
-      setSelectedChartDates(detail.sessions.map((s) => s.session_date));
+      setSelectedChartDates(detail.sessions.slice(0, 1).map((s) => s.session_date));
     }
   });
 

--- a/frontend/src/pages/TargetDetailPage.tsx
+++ b/frontend/src/pages/TargetDetailPage.tsx
@@ -3,6 +3,7 @@ import { A, useParams, useSearchParams } from "@solidjs/router";
 import { api } from "../api/client";
 import type { TargetDetailResponse, SessionDetail } from "../types";
 import SessionAccordionCard from "../components/SessionAccordionCard";
+import { showToast } from "../components/Toast";
 import FilterBadges from "../components/FilterBadges";
 import TargetMetricsChart from "../components/TargetMetricsChart";
 import ExportModal from "../components/ExportModal";
@@ -98,8 +99,20 @@ const TargetDetailPage: Component = () => {
 
   const loadSessionDetail = async (date: string) => {
     if (sessionCache()[date]) return;
-    const detail = await api.getSessionDetail(params.targetId, date);
-    setSessionCache((prev) => ({ ...prev, [date]: detail }));
+    try {
+      const detail = await api.getSessionDetail(params.targetId, date);
+      setSessionCache((prev) => ({ ...prev, [date]: detail }));
+    } catch (e: any) {
+      showToast(
+        e?.message ?? `Failed to load session ${date}`,
+        "error",
+      );
+      setExpandedSessions((prev) => {
+        const next = new Set(prev);
+        next.delete(date);
+        return next;
+      });
+    }
   };
 
   // Auto-expand first session or session from query param, and load its data

--- a/frontend/src/pages/TargetDetailPage.tsx
+++ b/frontend/src/pages/TargetDetailPage.tsx
@@ -369,6 +369,7 @@ const TargetDetailPage: Component = () => {
                     sessionDetails={sessionCache()}
                     expanded={targetChartExpanded()}
                     onLoadSession={loadSessionDetail}
+                    availableFilters={detail().filters_used ?? []}
                   />
                 </Show>
               </div>


### PR DESCRIPTION
**Summary**:
This PR introduces rig selection and display enhancements for the target metrics chart, alongside critical fixes for scan filter user experience, session loading, and dry-run previews.

**Changes**:
*   Adds a rig selector to the target metrics chart.
*   Encodes rig data using dash patterns on the target chart and defaults to the most recent session.
*   Fixes target chart rig toggles, filter pills, and data gaps.
*   Disables the "Apply Now" button and displays "Checking…" during scan progress.
*   Fixes session detail loading, improves filter cleanup UX, and corrects dry-run preview behavior.

**Impact**:
This PR affects backend API endpoints for scans and targets, backend scan filter schemas, and frontend components related to scan filters, target metrics charts, and target detail pages.