### PR TITLE
Manual Mosaic Panel Arrangement and Responsive Grid

### DIFF
--- a/backend/alembic/versions/0002_mosaic_panel_layout.py
+++ b/backend/alembic/versions/0002_mosaic_panel_layout.py
@@ -1,0 +1,57 @@
+"""Add manual layout columns to mosaic_panels.
+
+Adds grid_row, grid_col, rotation, and flip_h so users can manually arrange
+mosaic panels in a grid and override per-panel orientation to reconcile
+meridian-flipped captures. Existing panels default to rotation=0, flip_h=false,
+and a NULL grid position (meaning "not placed in the manual grid", fall back
+to sort_order-based auto layout).
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0002"
+down_revision = "0001"
+branch_labels = None
+depends_on = None
+
+
+def _column_exists(table: str, column: str) -> bool:
+    bind = op.get_bind()
+    result = bind.execute(
+        sa.text(
+            "SELECT 1 FROM information_schema.columns "
+            "WHERE table_name = :t AND column_name = :c"
+        ),
+        {"t": table, "c": column},
+    ).scalar()
+    return result is not None
+
+
+def _add_column_if_not_exists(table: str, column: sa.Column) -> None:
+    if not _column_exists(table, column.name):
+        op.add_column(table, column)
+
+
+def upgrade() -> None:
+    _add_column_if_not_exists(
+        "mosaic_panels", sa.Column("grid_row", sa.Integer(), nullable=True)
+    )
+    _add_column_if_not_exists(
+        "mosaic_panels", sa.Column("grid_col", sa.Integer(), nullable=True)
+    )
+    _add_column_if_not_exists(
+        "mosaic_panels",
+        sa.Column("rotation", sa.Integer(), nullable=False, server_default="0"),
+    )
+    _add_column_if_not_exists(
+        "mosaic_panels",
+        sa.Column("flip_h", sa.Boolean(), nullable=False, server_default="false"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("mosaic_panels", "flip_h")
+    op.drop_column("mosaic_panels", "rotation")
+    op.drop_column("mosaic_panels", "grid_col")
+    op.drop_column("mosaic_panels", "grid_row")

--- a/backend/app/api/mosaics.py
+++ b/backend/app/api/mosaics.py
@@ -136,6 +136,10 @@ async def _panel_stats(panel: MosaicPanel, session: AsyncSession) -> PanelStats:
         thumbnail_url=thumb_url,
         thumbnail_pier_side=thumb_pier_side,
         object_pattern=panel.object_pattern,
+        grid_row=panel.grid_row,
+        grid_col=panel.grid_col,
+        rotation=panel.rotation,
+        flip_h=panel.flip_h,
     )
 
 
@@ -651,6 +655,16 @@ async def update_panel(
         panel.sort_order = body.sort_order
     if body.object_pattern is not None:
         panel.object_pattern = body.object_pattern
+    if body.grid_row is not None:
+        panel.grid_row = body.grid_row
+    if body.grid_col is not None:
+        panel.grid_col = body.grid_col
+    if body.rotation is not None:
+        if body.rotation not in (0, 90, 180, 270):
+            raise HTTPException(400, "rotation must be 0, 90, 180, or 270")
+        panel.rotation = body.rotation
+    if body.flip_h is not None:
+        panel.flip_h = body.flip_h
     await session.commit()
     return {"status": "ok"}
 

--- a/backend/app/models/mosaic_panel.py
+++ b/backend/app/models/mosaic_panel.py
@@ -1,6 +1,6 @@
 import uuid
 
-from sqlalchemy import String, Integer, ForeignKey, UniqueConstraint
+from sqlalchemy import String, Integer, Boolean, ForeignKey, UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -16,6 +16,13 @@ class MosaicPanel(Base):
     panel_label: Mapped[str] = mapped_column(String(100), nullable=False)
     sort_order: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     object_pattern: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    # Manual grid arrangement overrides. Null means "not placed in the manual grid"
+    # (fallback to sort_order-based auto layout). Rotation is 0/90/180/270 only.
+    grid_row: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    grid_col: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    rotation: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+    flip_h: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
 
     mosaic: Mapped["Mosaic"] = relationship(back_populates="panels")
     target: Mapped["Target"] = relationship()

--- a/backend/app/schemas/mosaic.py
+++ b/backend/app/schemas/mosaic.py
@@ -13,6 +13,10 @@ class MosaicPanelUpdate(BaseModel):
     panel_label: str | None = None
     sort_order: int | None = None
     object_pattern: str | None = None
+    grid_row: int | None = None
+    grid_col: int | None = None
+    rotation: int | None = None
+    flip_h: bool | None = None
 
 
 class MosaicCreate(BaseModel):
@@ -41,6 +45,10 @@ class PanelStats(BaseModel):
     thumbnail_url: str | None = None
     thumbnail_pier_side: str | None = None
     object_pattern: str | None = None
+    grid_row: int | None = None
+    grid_col: int | None = None
+    rotation: int = 0
+    flip_h: bool = False
 
 
 class MosaicSummary(BaseModel):

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@solidjs/router": "^0.16.1",
+        "@thisbeyond/solid-dnd": "^0.7.5",
         "chart.js": "^4.5.1",
         "chartjs-adapter-date-fns": "^3.0.0",
         "chartjs-plugin-annotation": "^3.1.0",
@@ -1434,6 +1435,19 @@
         "@tailwindcss/oxide": "4.2.2",
         "postcss": "^8.5.6",
         "tailwindcss": "4.2.2"
+      }
+    },
+    "node_modules/@thisbeyond/solid-dnd": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@thisbeyond/solid-dnd/-/solid-dnd-0.7.5.tgz",
+      "integrity": "sha512-DfI5ff+yYGpK9M21LhYwIPlbP2msKxN2ARwuu6GF8tT1GgNVDTI8VCQvH4TJFoVApP9d44izmAcTh/iTCH2UUw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0",
+        "pnpm": ">=8.6.0"
+      },
+      "peerDependencies": {
+        "solid-js": "^1.5"
       }
     },
     "node_modules/@types/babel__core": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@solidjs/router": "^0.16.1",
+    "@thisbeyond/solid-dnd": "^0.7.5",
     "chart.js": "^4.5.1",
     "chartjs-adapter-date-fns": "^3.0.0",
     "chartjs-plugin-annotation": "^3.1.0",

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -621,7 +621,18 @@ export const api = {
       body: JSON.stringify({ target_id: targetId, panel_label: label }),
     }),
 
-  updateMosaicPanel: (mosaicId: string, panelId: string, data: { panel_label?: string; sort_order?: number }) =>
+  updateMosaicPanel: (
+    mosaicId: string,
+    panelId: string,
+    data: {
+      panel_label?: string;
+      sort_order?: number;
+      grid_row?: number | null;
+      grid_col?: number | null;
+      rotation?: number;
+      flip_h?: boolean;
+    },
+  ) =>
     fetchJson<{ status: string }>(`/mosaics/${mosaicId}/panels/${panelId}`, {
       method: "PUT",
       body: JSON.stringify(data),

--- a/frontend/src/components/mosaics/MosaicPanelArranger.tsx
+++ b/frontend/src/components/mosaics/MosaicPanelArranger.tsx
@@ -75,8 +75,6 @@ const MosaicPanelArranger: Component<Props> = (props) => {
   // destroy and recreate PanelDraggable, which would leave solid-dnd with
   // stale draggable registrations.
   const [cells, setCells] = createStore<LocalPanel[]>([]);
-  const [rows, setRows] = createSignal(1);
-  const [cols, setCols] = createSignal(1);
   const [activeId, setActiveId] = createSignal<string | null>(null);
   const [saving, setSaving] = createSignal(false);
   const [initialized, setInitialized] = createSignal(false);
@@ -88,10 +86,8 @@ const MosaicPanelArranger: Component<Props> = (props) => {
   createEffect(() => {
     if (initialized()) return;
     if (props.panels.length === 0) return;
-    const { cells: c, rows: r, cols: co } = buildInitialLayout(props.panels);
+    const { cells: c } = buildInitialLayout(props.panels);
     setCells(c);
-    setRows(r);
-    setCols(co);
     setInitialized(true);
   });
 
@@ -101,6 +97,26 @@ const MosaicPanelArranger: Component<Props> = (props) => {
 
   const cellAt = (row: number, col: number) =>
     cells.find((c) => c._row === row && c._col === col);
+
+  // Tight bounding box over placed panels, then expanded by one cell in every
+  // direction to give the user drop targets for extending the grid.
+  const bbox = createMemo(() => {
+    if (cells.length === 0) return { minR: 0, maxR: 0, minC: 0, maxC: 0 };
+    let minR = Infinity, maxR = -Infinity, minC = Infinity, maxC = -Infinity;
+    for (const p of cells) {
+      if (p._row < minR) minR = p._row;
+      if (p._row > maxR) maxR = p._row;
+      if (p._col < minC) minC = p._col;
+      if (p._col > maxC) maxC = p._col;
+    }
+    return { minR, maxR, minC, maxC };
+  });
+  const extBox = createMemo(() => {
+    const b = bbox();
+    return { minR: b.minR - 1, maxR: b.maxR + 1, minC: b.minC - 1, maxC: b.maxC + 1 };
+  });
+  const renderRows = createMemo(() => extBox().maxR - extBox().minR + 1);
+  const renderCols = createMemo(() => extBox().maxC - extBox().minC + 1);
 
   const persist = async (panelId: string, patch: Partial<PanelStats>) => {
     setSaving(true);
@@ -122,7 +138,7 @@ const MosaicPanelArranger: Component<Props> = (props) => {
     if (!droppable) return;
     const panelId = String(draggable.id);
     const target = String(droppable.id);
-    const match = target.match(/^cell-(\d+)-(\d+)$/);
+    const match = target.match(/^cell-(-?\d+)-(-?\d+)$/);
     if (!match) return;
     const tRow = parseInt(match[1], 10);
     const tCol = parseInt(match[2], 10);
@@ -202,28 +218,13 @@ const MosaicPanelArranger: Component<Props> = (props) => {
     persist(panelId, { rotation: rot });
   };
 
-  const addRow = () => setRows(rows() + 1);
-  const addCol = () => setCols(cols() + 1);
-
   return (
     <div class="space-y-3">
       <div class="flex items-center gap-2 text-xs text-theme-text-secondary">
-        <span>Drag to rearrange. Use the buttons on each panel to rotate or flip.</span>
+        <span>Drag to rearrange. Drop into an edge cell to extend the grid in any direction.</span>
         <Show when={saving()}>
-          <span class="text-theme-text-secondary">Saving...</span>
+          <span class="ml-auto text-theme-text-secondary">Saving...</span>
         </Show>
-        <div class="ml-auto flex items-center gap-1">
-          <button
-            class="px-2 py-1 rounded border border-theme-border text-theme-text-secondary hover:text-theme-text-primary hover:border-theme-border-em transition-colors"
-            onClick={addRow}
-            title="Add row"
-          >+ row</button>
-          <button
-            class="px-2 py-1 rounded border border-theme-border text-theme-text-secondary hover:text-theme-text-primary hover:border-theme-border-em transition-colors"
-            onClick={addCol}
-            title="Add column"
-          >+ col</button>
-        </div>
       </div>
 
       <DragDropProvider
@@ -236,26 +237,26 @@ const MosaicPanelArranger: Component<Props> = (props) => {
           class="mx-auto"
           style={{
             display: "grid",
-            "grid-template-columns": `repeat(${cols()}, ${CELL_PX}px)`,
-            "grid-template-rows": `repeat(${rows()}, ${CELL_PX}px)`,
+            "grid-template-columns": `repeat(${renderCols()}, ${CELL_PX}px)`,
+            "grid-template-rows": `repeat(${renderRows()}, ${CELL_PX}px)`,
             gap: `${GAP_PX}px`,
-            width: `${cols() * CELL_PX + (cols() - 1) * GAP_PX}px`,
+            width: `${renderCols() * CELL_PX + (renderCols() - 1) * GAP_PX}px`,
           }}
         >
-          {/* Droppable background cells -- index-keyed since they never move */}
-          <For each={Array.from({ length: rows() * cols() }, (_, i) => i)}>
+          {/* Droppable background cells over the extended bounding box. */}
+          <For each={Array.from({ length: renderRows() * renderCols() }, (_, i) => i)}>
             {(i) => {
-              const r = Math.floor(i / cols());
-              const c = i % cols();
+              const r = Math.floor(i / renderCols()) + extBox().minR;
+              const c = (i % renderCols()) + extBox().minC;
+              const panel = cellAt(r, c);
               return (
                 <DropCell
                   row={r}
                   col={c}
-                  hasPanel={!!cellAt(r, c)}
-                  isSource={(() => {
-                    const p = cellAt(r, c);
-                    return !!p && p.panel_id === activeId();
-                  })()}
+                  cssRow={r - extBox().minR + 1}
+                  cssCol={c - extBox().minC + 1}
+                  hasPanel={!!panel}
+                  isSource={!!panel && panel.panel_id === activeId()}
                   isDragging={activeId() !== null}
                 />
               );
@@ -267,6 +268,8 @@ const MosaicPanelArranger: Component<Props> = (props) => {
             {(panel) => (
               <PanelDraggable
                 panel={panel}
+                extMinR={extBox().minR}
+                extMinC={extBox().minC}
                 maxIntegration={maxIntegration()}
                 isActive={activeId() === panel.panel_id}
                 onRotate={rotatePanel}
@@ -284,6 +287,8 @@ const MosaicPanelArranger: Component<Props> = (props) => {
 const DropCell: Component<{
   row: number;
   col: number;
+  cssRow: number;
+  cssCol: number;
   hasPanel: boolean;
   isSource: boolean;
   isDragging: boolean;
@@ -301,11 +306,11 @@ const DropCell: Component<{
         "ring-2 ring-theme-border border-dashed": props.isDragging && !isHovered() && !props.isSource,
       }}
       style={{
-        "grid-row": `${props.row + 1}`,
-        "grid-column": `${props.col + 1}`,
+        "grid-row": `${props.cssRow}`,
+        "grid-column": `${props.cssCol}`,
       }}
     >
-      <Show when={!props.hasPanel || props.isSource}>
+      <Show when={props.isDragging && (!props.hasPanel || props.isSource)}>
         <div
           class="w-full h-full flex items-center justify-center text-caption transition-colors"
           classList={{
@@ -322,6 +327,8 @@ const DropCell: Component<{
 
 const PanelDraggable: Component<{
   panel: LocalPanel;
+  extMinR: number;
+  extMinC: number;
   maxIntegration: number;
   isActive: boolean;
   onRotate: (id: string) => void;
@@ -338,8 +345,8 @@ const PanelDraggable: Component<{
         "ring-4 ring-theme-accent shadow-2xl scale-105": props.isActive,
       }}
       style={{
-        "grid-row": `${props.panel._row + 1}`,
-        "grid-column": `${props.panel._col + 1}`,
+        "grid-row": `${props.panel._row - props.extMinR + 1}`,
+        "grid-column": `${props.panel._col - props.extMinC + 1}`,
         "z-index": props.isActive ? 1000 : 2,
         "pointer-events": "auto",
       }}

--- a/frontend/src/components/mosaics/MosaicPanelArranger.tsx
+++ b/frontend/src/components/mosaics/MosaicPanelArranger.tsx
@@ -1,0 +1,446 @@
+import { Component, For, Show, createMemo, createSignal, createEffect } from "solid-js";
+import { createStore, produce } from "solid-js/store";
+import {
+  DragDropProvider,
+  DragDropSensors,
+  createDraggable,
+  createDroppable,
+  mostIntersecting,
+  type Draggable,
+  type Droppable,
+} from "@thisbeyond/solid-dnd";
+import { api } from "../../api/client";
+import type { PanelStats } from "../../types";
+import { formatIntegration } from "../../utils/format";
+
+interface Props {
+  mosaicId: string;
+  panels: PanelStats[];
+  onChange?: () => void;
+}
+
+type LocalPanel = PanelStats & { _row: number; _col: number };
+
+const CELL_PX = 200;
+const GAP_PX = 8;
+
+function buildInitialLayout(panels: PanelStats[]): { cells: LocalPanel[]; rows: number; cols: number } {
+  const n = panels.length;
+  if (n === 0) return { cells: [], rows: 0, cols: 0 };
+
+  const placed = panels.filter((p) => p.grid_row != null && p.grid_col != null);
+  const unplaced = panels.filter((p) => p.grid_row == null || p.grid_col == null);
+
+  const autoCols = Math.max(1, Math.ceil(Math.sqrt(n)));
+  let rows = 0;
+  let cols = autoCols;
+
+  // Start with placed panels at their stored position.
+  const used = new Set<string>();
+  const cells: LocalPanel[] = placed.map((p) => {
+    const r = p.grid_row as number;
+    const c = p.grid_col as number;
+    used.add(`${r},${c}`);
+    rows = Math.max(rows, r + 1);
+    cols = Math.max(cols, c + 1);
+    return { ...p, _row: r, _col: c };
+  });
+
+  // Fill unplaced panels into the next free cells in row-major order.
+  // Expand rows as needed; keep cols stable.
+  if (unplaced.length > 0) {
+    const sorted = [...unplaced].sort((a, b) => a.sort_order - b.sort_order);
+    let r = 0;
+    let c = 0;
+    for (const p of sorted) {
+      while (used.has(`${r},${c}`)) {
+        c += 1;
+        if (c >= cols) {
+          c = 0;
+          r += 1;
+        }
+      }
+      used.add(`${r},${c}`);
+      cells.push({ ...p, _row: r, _col: c });
+      rows = Math.max(rows, r + 1);
+    }
+  }
+
+  return { cells, rows: Math.max(1, rows), cols: Math.max(1, cols) };
+}
+
+const MosaicPanelArranger: Component<Props> = (props) => {
+  // Store gives us fine-grained reactivity: mutating panel._row in place keeps
+  // the panel's object identity stable, so <For> (keyed by reference) does not
+  // destroy and recreate PanelDraggable, which would leave solid-dnd with
+  // stale draggable registrations.
+  const [cells, setCells] = createStore<LocalPanel[]>([]);
+  const [rows, setRows] = createSignal(1);
+  const [cols, setCols] = createSignal(1);
+  const [activeId, setActiveId] = createSignal<string | null>(null);
+  const [saving, setSaving] = createSignal(false);
+  const [initialized, setInitialized] = createSignal(false);
+
+  // Seed local state from props once. Subsequent updates are driven by user
+  // interaction -- we do NOT re-derive from props.panels because the backend
+  // echoes the same state we just pushed, which would race with optimistic
+  // updates and wipe in-flight edits.
+  createEffect(() => {
+    if (initialized()) return;
+    if (props.panels.length === 0) return;
+    const { cells: c, rows: r, cols: co } = buildInitialLayout(props.panels);
+    setCells(c);
+    setRows(r);
+    setCols(co);
+    setInitialized(true);
+  });
+
+  const maxIntegration = createMemo(() =>
+    Math.max(1, ...props.panels.map((p) => p.total_integration_seconds)),
+  );
+
+  const cellAt = (row: number, col: number) =>
+    cells.find((c) => c._row === row && c._col === col);
+
+  const persist = async (panelId: string, patch: Partial<PanelStats>) => {
+    setSaving(true);
+    try {
+      await api.updateMosaicPanel(props.mosaicId, panelId, {
+        grid_row: patch.grid_row ?? undefined,
+        grid_col: patch.grid_col ?? undefined,
+        rotation: patch.rotation ?? undefined,
+        flip_h: patch.flip_h ?? undefined,
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDragEnd = (event: { draggable: Draggable; droppable?: Droppable | null }) => {
+    const { draggable, droppable } = event;
+    setActiveId(null);
+    if (!droppable) return;
+    const panelId = String(draggable.id);
+    const target = String(droppable.id);
+    const match = target.match(/^cell-(\d+)-(\d+)$/);
+    if (!match) return;
+    const tRow = parseInt(match[1], 10);
+    const tCol = parseInt(match[2], 10);
+
+    const src = cells.find((c) => c.panel_id === panelId);
+    if (!src) return;
+    if (src._row === tRow && src._col === tCol) return;
+
+    const dst = cellAt(tRow, tCol);
+    const srcRow = src._row;
+    const srcCol = src._col;
+
+    // Mutate in place via produce so panel object identity is preserved.
+    setCells(
+      produce((draft) => {
+        for (const c of draft) {
+          if (c.panel_id === panelId) {
+            c._row = tRow;
+            c._col = tCol;
+            c.grid_row = tRow;
+            c.grid_col = tCol;
+          } else if (dst && c.panel_id === dst.panel_id) {
+            c._row = srcRow;
+            c._col = srcCol;
+            c.grid_row = srcRow;
+            c.grid_col = srcCol;
+          }
+        }
+      }),
+    );
+
+    persist(panelId, { grid_row: tRow, grid_col: tCol });
+    if (dst) {
+      persist(dst.panel_id, { grid_row: srcRow, grid_col: srcCol });
+    }
+  };
+
+  const rotatePanel = (panelId: string) => {
+    let rot = 0;
+    setCells(
+      produce((draft) => {
+        const c = draft.find((c) => c.panel_id === panelId);
+        if (c) {
+          c.rotation = ((c.rotation ?? 0) + 90) % 360;
+          rot = c.rotation;
+        }
+      }),
+    );
+    persist(panelId, { rotation: rot });
+  };
+
+  const flipPanel = (panelId: string) => {
+    let flip = false;
+    setCells(
+      produce((draft) => {
+        const c = draft.find((c) => c.panel_id === panelId);
+        if (c) {
+          c.flip_h = !c.flip_h;
+          flip = c.flip_h;
+        }
+      }),
+    );
+    persist(panelId, { flip_h: flip });
+  };
+
+  const meridianFlip = (panelId: string) => {
+    let rot = 0;
+    setCells(
+      produce((draft) => {
+        const c = draft.find((c) => c.panel_id === panelId);
+        if (c) {
+          c.rotation = ((c.rotation ?? 0) + 180) % 360;
+          rot = c.rotation;
+        }
+      }),
+    );
+    persist(panelId, { rotation: rot });
+  };
+
+  const addRow = () => setRows(rows() + 1);
+  const addCol = () => setCols(cols() + 1);
+
+  return (
+    <div class="space-y-3">
+      <div class="flex items-center gap-2 text-xs text-theme-text-secondary">
+        <span>Drag to rearrange. Use the buttons on each panel to rotate or flip.</span>
+        <Show when={saving()}>
+          <span class="text-theme-text-secondary">Saving...</span>
+        </Show>
+        <div class="ml-auto flex items-center gap-1">
+          <button
+            class="px-2 py-1 rounded border border-theme-border text-theme-text-secondary hover:text-theme-text-primary hover:border-theme-border-em transition-colors"
+            onClick={addRow}
+            title="Add row"
+          >+ row</button>
+          <button
+            class="px-2 py-1 rounded border border-theme-border text-theme-text-secondary hover:text-theme-text-primary hover:border-theme-border-em transition-colors"
+            onClick={addCol}
+            title="Add column"
+          >+ col</button>
+        </div>
+      </div>
+
+      <DragDropProvider
+        onDragStart={({ draggable }: { draggable: Draggable }) => setActiveId(String(draggable.id))}
+        onDragEnd={handleDragEnd}
+        collisionDetector={mostIntersecting}
+      >
+        <DragDropSensors />
+        <div
+          class="mx-auto"
+          style={{
+            display: "grid",
+            "grid-template-columns": `repeat(${cols()}, ${CELL_PX}px)`,
+            "grid-template-rows": `repeat(${rows()}, ${CELL_PX}px)`,
+            gap: `${GAP_PX}px`,
+            width: `${cols() * CELL_PX + (cols() - 1) * GAP_PX}px`,
+          }}
+        >
+          {/* Droppable background cells -- index-keyed since they never move */}
+          <For each={Array.from({ length: rows() * cols() }, (_, i) => i)}>
+            {(i) => {
+              const r = Math.floor(i / cols());
+              const c = i % cols();
+              return (
+                <DropCell
+                  row={r}
+                  col={c}
+                  hasPanel={!!cellAt(r, c)}
+                  isSource={(() => {
+                    const p = cellAt(r, c);
+                    return !!p && p.panel_id === activeId();
+                  })()}
+                  isDragging={activeId() !== null}
+                />
+              );
+            }}
+          </For>
+
+          {/* Draggable panels -- keyed by panel_id, positioned via grid-area */}
+          <For each={cells}>
+            {(panel) => (
+              <PanelDraggable
+                panel={panel}
+                maxIntegration={maxIntegration()}
+                isActive={activeId() === panel.panel_id}
+                onRotate={rotatePanel}
+                onFlip={flipPanel}
+                onMeridianFlip={meridianFlip}
+              />
+            )}
+          </For>
+        </div>
+      </DragDropProvider>
+    </div>
+  );
+};
+
+const DropCell: Component<{
+  row: number;
+  col: number;
+  hasPanel: boolean;
+  isSource: boolean;
+  isDragging: boolean;
+}> = (props) => {
+  const droppable = createDroppable(`cell-${props.row}-${props.col}`);
+  const isHovered = () => droppable.isActiveDroppable;
+
+  return (
+    <div
+      ref={droppable.ref}
+      class="relative rounded transition-all duration-150"
+      classList={{
+        "ring-4 ring-theme-accent bg-theme-accent/15": isHovered() && !props.isSource,
+        "ring-2 ring-theme-accent/50 border-dashed bg-theme-accent/5": props.isSource,
+        "ring-2 ring-theme-border border-dashed": props.isDragging && !isHovered() && !props.isSource,
+      }}
+      style={{
+        "grid-row": `${props.row + 1}`,
+        "grid-column": `${props.col + 1}`,
+      }}
+    >
+      <Show when={!props.hasPanel || props.isSource}>
+        <div
+          class="w-full h-full flex items-center justify-center text-caption transition-colors"
+          classList={{
+            "text-theme-accent": isHovered(),
+            "text-theme-text-secondary/60": !isHovered(),
+          }}
+        >
+          {isHovered() ? "drop here" : props.isSource ? "" : "empty"}
+        </div>
+      </Show>
+    </div>
+  );
+};
+
+const PanelDraggable: Component<{
+  panel: LocalPanel;
+  maxIntegration: number;
+  isActive: boolean;
+  onRotate: (id: string) => void;
+  onFlip: (id: string) => void;
+  onMeridianFlip: (id: string) => void;
+}> = (props) => {
+  const draggable = createDraggable(props.panel.panel_id);
+
+  return (
+    <div
+      ref={draggable.ref}
+      class="rounded transition-[box-shadow,transform] duration-150"
+      classList={{
+        "ring-4 ring-theme-accent shadow-2xl scale-105": props.isActive,
+      }}
+      style={{
+        "grid-row": `${props.panel._row + 1}`,
+        "grid-column": `${props.panel._col + 1}`,
+        "z-index": props.isActive ? 1000 : 2,
+        "pointer-events": "auto",
+      }}
+    >
+      <div class="relative group w-full h-full">
+        <div
+          class={`absolute inset-0 ${props.isActive ? "cursor-grabbing" : "cursor-grab"}`}
+          {...draggable.dragActivators}
+        >
+          <PanelThumbnail panel={props.panel} maxIntegration={props.maxIntegration} />
+        </div>
+        <div class="absolute top-1 right-1 flex flex-col gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+          <IconButton
+            title="Rotate 90° CW"
+            onClick={() => props.onRotate(props.panel.panel_id)}
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="23 4 23 10 17 10" />
+              <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
+            </svg>
+          </IconButton>
+          <IconButton
+            title="Flip horizontal"
+            onClick={() => props.onFlip(props.panel.panel_id)}
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M12 3v18" />
+              <path d="M16 7l4 5-4 5" />
+              <path d="M8 7l-4 5 4 5" />
+            </svg>
+          </IconButton>
+          <IconButton
+            title="Meridian flip (rotate 180°)"
+            onClick={() => props.onMeridianFlip(props.panel.panel_id)}
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M12 2v20" />
+              <path d="M4 12h16" />
+              <circle cx="12" cy="12" r="9" />
+            </svg>
+          </IconButton>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const PanelThumbnail: Component<{ panel: LocalPanel; maxIntegration: number }> = (props) => {
+  const transform = () => {
+    const rot = props.panel.rotation ?? 0;
+    const flip = props.panel.flip_h ? " scaleX(-1)" : "";
+    return `rotate(${rot}deg)${flip}`;
+  };
+
+  const diff = () => props.panel.total_integration_seconds - props.maxIntegration;
+
+  return (
+    <div class="relative w-full h-full">
+      <Show
+        when={props.panel.thumbnail_url}
+        fallback={
+          <div class="w-full h-full bg-theme-elevated border border-theme-border rounded flex items-center justify-center text-theme-text-secondary text-xs">
+            {props.panel.panel_label}
+          </div>
+        }
+      >
+        <img
+          src={api.thumbnailUrl(props.panel.thumbnail_url!)}
+          alt={props.panel.panel_label}
+          class="w-full h-full object-cover rounded border border-theme-border"
+          style={{ transform: transform(), "transition": "transform 160ms ease" }}
+          draggable={false}
+        />
+      </Show>
+      <span class="absolute bottom-1 left-1 bg-black/60 text-white text-caption px-1.5 py-0.5 rounded pointer-events-none">
+        {props.panel.panel_label}
+      </span>
+      <span class="absolute bottom-1 right-1 bg-black/60 text-white text-caption px-1.5 py-0.5 rounded pointer-events-none">
+        {formatIntegration(props.panel.total_integration_seconds)}
+        <Show when={diff() < 0}>
+          <span class="ml-1 text-amber-300">-{formatIntegration(Math.abs(diff()))}</span>
+        </Show>
+      </span>
+      <Show when={props.panel.flip_h || (props.panel.rotation ?? 0) !== 0}>
+        <span class="absolute top-1 left-1 bg-theme-accent/80 text-white text-caption px-1.5 py-0.5 rounded pointer-events-none">
+          {props.panel.rotation ?? 0}°{props.panel.flip_h ? " ⇋" : ""}
+        </span>
+      </Show>
+    </div>
+  );
+};
+
+const IconButton: Component<{ title: string; onClick: () => void; children: any }> = (props) => (
+  <button
+    class="w-6 h-6 flex items-center justify-center rounded bg-black/60 text-white hover:bg-black/80 transition-colors"
+    title={props.title}
+    onClick={(e) => { e.stopPropagation(); props.onClick(); }}
+    onPointerDown={(e) => e.stopPropagation()}
+  >
+    {props.children}
+  </button>
+);
+
+export default MosaicPanelArranger;

--- a/frontend/src/components/mosaics/MosaicPanelArranger.tsx
+++ b/frontend/src/components/mosaics/MosaicPanelArranger.tsx
@@ -1,11 +1,11 @@
-import { Component, For, Show, createMemo, createSignal, createEffect } from "solid-js";
+import { Component, For, Show, createMemo, createSignal, createEffect, onCleanup } from "solid-js";
 import { createStore, produce } from "solid-js/store";
 import {
   DragDropProvider,
   DragDropSensors,
   createDraggable,
   createDroppable,
-  mostIntersecting,
+  type CollisionDetector,
   type Draggable,
   type Droppable,
 } from "@thisbeyond/solid-dnd";
@@ -78,6 +78,50 @@ const MosaicPanelArranger: Component<Props> = (props) => {
   const [activeId, setActiveId] = createSignal<string | null>(null);
   const [saving, setSaving] = createSignal(false);
   const [initialized, setInitialized] = createSignal(false);
+  const [pointerPos, setPointerPos] = createSignal<{ x: number; y: number } | null>(null);
+
+  // Track the real pointer position while a drag is active. The built-in
+  // collision detectors (mostIntersecting, closestCenter) use the draggable's
+  // translated bbox, which depends on where inside the tile the user grabbed
+  // -- grabbing near the bottom makes the tile sit above the pointer and the
+  // highlighted cell is one row off. A pointer-driven detector eliminates
+  // that asymmetry.
+  createEffect(() => {
+    if (activeId() === null) {
+      setPointerPos(null);
+      return;
+    }
+    const handler = (e: PointerEvent) => setPointerPos({ x: e.clientX, y: e.clientY });
+    window.addEventListener("pointermove", handler);
+    onCleanup(() => window.removeEventListener("pointermove", handler));
+  });
+
+  const pointerCollisionDetector: CollisionDetector = (_draggable, droppables) => {
+    const pos = pointerPos();
+    if (!pos) return null;
+    // Prefer a droppable whose bbox strictly contains the pointer.
+    for (const d of droppables) {
+      const l = d.layout;
+      if (pos.x >= l.left && pos.x <= l.right && pos.y >= l.top && pos.y <= l.bottom) {
+        return d;
+      }
+    }
+    // Fallback: closest droppable center to pointer (forgiving when the
+    // pointer slips into a gap between cells).
+    let best: Droppable | null = null;
+    let bestDist = Infinity;
+    for (const d of droppables) {
+      const c = d.layout.center;
+      const dx = c.x - pos.x;
+      const dy = c.y - pos.y;
+      const dist = dx * dx + dy * dy;
+      if (dist < bestDist) {
+        bestDist = dist;
+        best = d;
+      }
+    }
+    return best;
+  };
 
   // Seed local state from props once. Subsequent updates are driven by user
   // interaction -- we do NOT re-derive from props.panels because the backend
@@ -234,7 +278,7 @@ const MosaicPanelArranger: Component<Props> = (props) => {
       <DragDropProvider
         onDragStart={({ draggable }: { draggable: Draggable }) => setActiveId(String(draggable.id))}
         onDragEnd={handleDragEnd}
-        collisionDetector={mostIntersecting}
+        collisionDetector={pointerCollisionDetector}
       >
         <DragDropSensors />
         <div

--- a/frontend/src/components/mosaics/MosaicPanelArranger.tsx
+++ b/frontend/src/components/mosaics/MosaicPanelArranger.tsx
@@ -21,8 +21,8 @@ interface Props {
 
 type LocalPanel = PanelStats & { _row: number; _col: number };
 
-const CELL_PX = 200;
-const GAP_PX = 8;
+const CELL_MAX_PX = 360;
+const GAP_PX = 6;
 
 function buildInitialLayout(panels: PanelStats[]): { cells: LocalPanel[]; rows: number; cols: number } {
   const n = panels.length;
@@ -115,8 +115,12 @@ const MosaicPanelArranger: Component<Props> = (props) => {
     const b = bbox();
     return { minR: b.minR - 1, maxR: b.maxR + 1, minC: b.minC - 1, maxC: b.maxC + 1 };
   });
-  const renderRows = createMemo(() => extBox().maxR - extBox().minR + 1);
-  const renderCols = createMemo(() => extBox().maxC - extBox().minC + 1);
+  // Tight bbox at rest; extended (with 1-cell drop margin) during an active drag.
+  const displayBox = createMemo(() =>
+    activeId() !== null ? extBox() : bbox(),
+  );
+  const renderRows = createMemo(() => displayBox().maxR - displayBox().minR + 1);
+  const renderCols = createMemo(() => displayBox().maxC - displayBox().minC + 1);
 
   const persist = async (panelId: string, patch: Partial<PanelStats>) => {
     setSaving(true);
@@ -234,27 +238,27 @@ const MosaicPanelArranger: Component<Props> = (props) => {
       >
         <DragDropSensors />
         <div
-          class="mx-auto"
+          class="mx-auto w-full"
           style={{
             display: "grid",
-            "grid-template-columns": `repeat(${renderCols()}, ${CELL_PX}px)`,
-            "grid-template-rows": `repeat(${renderRows()}, ${CELL_PX}px)`,
+            "grid-template-columns": `repeat(${renderCols()}, minmax(0, 1fr))`,
+            "grid-auto-rows": "auto",
             gap: `${GAP_PX}px`,
-            width: `${renderCols() * CELL_PX + (renderCols() - 1) * GAP_PX}px`,
+            "max-width": `${renderCols() * CELL_MAX_PX + (renderCols() - 1) * GAP_PX}px`,
           }}
         >
-          {/* Droppable background cells over the extended bounding box. */}
+          {/* Droppable background cells over the display bounding box. */}
           <For each={Array.from({ length: renderRows() * renderCols() }, (_, i) => i)}>
             {(i) => {
-              const r = Math.floor(i / renderCols()) + extBox().minR;
-              const c = (i % renderCols()) + extBox().minC;
+              const r = Math.floor(i / renderCols()) + displayBox().minR;
+              const c = (i % renderCols()) + displayBox().minC;
               const panel = cellAt(r, c);
               return (
                 <DropCell
                   row={r}
                   col={c}
-                  cssRow={r - extBox().minR + 1}
-                  cssCol={c - extBox().minC + 1}
+                  cssRow={r - displayBox().minR + 1}
+                  cssCol={c - displayBox().minC + 1}
                   hasPanel={!!panel}
                   isSource={!!panel && panel.panel_id === activeId()}
                   isDragging={activeId() !== null}
@@ -268,8 +272,8 @@ const MosaicPanelArranger: Component<Props> = (props) => {
             {(panel) => (
               <PanelDraggable
                 panel={panel}
-                extMinR={extBox().minR}
-                extMinC={extBox().minC}
+                extMinR={displayBox().minR}
+                extMinC={displayBox().minC}
                 maxIntegration={maxIntegration()}
                 isActive={activeId() === panel.panel_id}
                 onRotate={rotatePanel}
@@ -308,6 +312,7 @@ const DropCell: Component<{
       style={{
         "grid-row": `${props.cssRow}`,
         "grid-column": `${props.cssCol}`,
+        "aspect-ratio": "1 / 1",
       }}
     >
       <Show when={props.isDragging && (!props.hasPanel || props.isSource)}>
@@ -347,6 +352,7 @@ const PanelDraggable: Component<{
       style={{
         "grid-row": `${props.panel._row - props.extMinR + 1}`,
         "grid-column": `${props.panel._col - props.extMinC + 1}`,
+        "aspect-ratio": "1 / 1",
         "z-index": props.isActive ? 1000 : 2,
         "pointer-events": "auto",
       }}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -7,6 +7,8 @@ import DashboardFilterProvider, { hasFilterParams, ALL_PARAM_KEYS } from "../com
 import SidebarRail from "../components/SidebarRail";
 import SidebarResizeHandle from "../components/SidebarResizeHandle";
 import { sidebarWidth, sidebarCollapsed, resizing, RAIL_WIDTH } from "../components/sidebarLayout";
+import { useSettingsContext } from "../components/SettingsProvider";
+import { contentWidthClass } from "../utils/format";
 
 const SESSION_KEY = "dashboard_params";
 
@@ -14,6 +16,7 @@ export const [sidebarOpen, setSidebarOpen] = createSignal(false);
 
 const DashboardPage: Component = () => {
   const [searchParams, setSearchParams] = useSearchParams();
+  const { contentWidth } = useSettingsContext();
 
   onMount(() => {
     if (!hasFilterParams(searchParams)) {
@@ -79,7 +82,7 @@ const DashboardPage: Component = () => {
           <Sidebar />
         </div>
 
-        <main class="flex-1 min-h-[calc(100vh-57px)]">
+        <main class={`flex-1 min-h-[calc(100vh-57px)] ${contentWidthClass(contentWidth())}`}>
           <ScanFiltersOnboarding variant="global" />
           <TargetFeed />
         </main>

--- a/frontend/src/pages/MosaicDetailPage.tsx
+++ b/frontend/src/pages/MosaicDetailPage.tsx
@@ -125,12 +125,13 @@ const MosaicDetailPage: Component = () => {
               <div class="rounded-[var(--radius-sm)] bg-theme-elevated border border-theme-border-em p-4 space-y-4">
                 <h2 class="text-sm font-semibold text-theme-text-primary">Panels</h2>
                 {(() => {
-                  const cols = Math.ceil(Math.sqrt(data().panels.length));
+                  const n = data().panels.length;
                   const maxIntegration = Math.max(...data().panels.map((p: PanelStats) => p.total_integration_seconds));
+                  const containerMax = Math.min(n * 280, 1680);
                   return (
                     <div
                       class="grid gap-2 mx-auto"
-                      style={{ "grid-template-columns": `repeat(${cols}, 1fr)`, "max-width": "800px" }}
+                      style={{ "grid-template-columns": `repeat(auto-fit, minmax(220px, 1fr))`, "max-width": `${containerMax}px` }}
                     >
                       <For each={[...data().panels].sort((a: PanelStats, b: PanelStats) => {
                         const na = parseInt(a.panel_label.replace(/\D/g, "")) || a.sort_order;

--- a/frontend/src/pages/MosaicDetailPage.tsx
+++ b/frontend/src/pages/MosaicDetailPage.tsx
@@ -5,6 +5,7 @@ import type { PanelStats } from "../types";
 import { formatIntegration, contentWidthClass } from "../utils/format";
 import { useSettingsContext } from "../components/SettingsProvider";
 import HelpPopover from "../components/HelpPopover";
+import MosaicPanelArranger from "../components/mosaics/MosaicPanelArranger";
 
 const MosaicDetailPage: Component = () => {
   const ctx = useSettingsContext();
@@ -124,61 +125,10 @@ const MosaicDetailPage: Component = () => {
             <Show when={data().panels.some((p: PanelStats) => p.thumbnail_url)}>
               <div class="rounded-[var(--radius-sm)] bg-theme-elevated border border-theme-border-em p-4 space-y-4">
                 <h2 class="text-sm font-semibold text-theme-text-primary">Panels</h2>
-                {(() => {
-                  const n = data().panels.length;
-                  const maxIntegration = Math.max(...data().panels.map((p: PanelStats) => p.total_integration_seconds));
-                  const containerMax = Math.min(n * 280, 1680);
-                  return (
-                    <div
-                      class="grid gap-2 mx-auto"
-                      style={{ "grid-template-columns": `repeat(auto-fit, minmax(220px, 1fr))`, "max-width": `${containerMax}px` }}
-                    >
-                      <For each={[...data().panels].sort((a: PanelStats, b: PanelStats) => {
-                        const na = parseInt(a.panel_label.replace(/\D/g, "")) || a.sort_order;
-                        const nb = parseInt(b.panel_label.replace(/\D/g, "")) || b.sort_order;
-                        return na - nb;
-                      })}>
-                        {(panel: PanelStats) => {
-                          const diff = panel.total_integration_seconds - maxIntegration;
-                          return (
-                            <div>
-                              <div class="relative">
-                                <Show
-                                  when={panel.thumbnail_url}
-                                  fallback={
-                                    <div class="aspect-square bg-theme-elevated border border-theme-border rounded flex items-center justify-center text-theme-text-secondary text-xs">
-                                      {panel.panel_label}
-                                    </div>
-                                  }
-                                >
-                                  <img
-                                    src={api.thumbnailUrl(panel.thumbnail_url!)}
-                                    alt={panel.panel_label}
-                                    class="w-full aspect-square object-cover rounded border border-theme-border"
-                                  />
-                                </Show>
-                                <span class="absolute bottom-1 left-1 bg-black/60 text-white text-caption px-1.5 py-0.5 rounded">
-                                  {panel.panel_label}
-                                </span>
-                              </div>
-                              <div
-                                class="text-center text-caption mt-1 text-theme-text-secondary"
-                                title={diff < 0
-                                  ? `${formatIntegration(Math.abs(diff))} less than the most-imaged panel`
-                                  : "Most integration time across all panels"}
-                              >
-                                {formatIntegration(panel.total_integration_seconds)}
-                                <Show when={diff < 0}>
-                                  <span class="ml-1 text-amber-400">(-{formatIntegration(Math.abs(diff))})</span>
-                                </Show>
-                              </div>
-                            </div>
-                          );
-                        }}
-                      </For>
-                    </div>
-                  );
-                })()}
+                <MosaicPanelArranger
+                  mosaicId={params.mosaicId}
+                  panels={data().panels}
+                />
               </div>
             </Show>
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -756,6 +756,11 @@ export interface PanelStats {
   last_session_date: string | null;
   thumbnail_url: string | null;
   thumbnail_pier_side: string | null;
+  object_pattern?: string | null;
+  grid_row: number | null;
+  grid_col: number | null;
+  rotation: number;
+  flip_h: boolean;
 }
 
 export interface MosaicSummary {


### PR DESCRIPTION
**Summary**:
This PR introduces a new manual arrangement system for mosaic panels, enabling users to drag, drop, rotate, and flip panels within a responsive grid. It also includes general layout improvements for mosaics and the dashboard.

**Changes**:
*   Implemented manual drag-and-drop panel arrangement, including controls for panel rotation and flipping.
*   The panel arranger grid is now fluid and responsive, automatically expanding rows and columns when panels are dragged to its edges.
*   Removed manual "add row/column" buttons; grid expansion is now automatic.
*   Corrected panel drop target behavior to track the pointer position, resolving off-by-one-row highlight issues.
*   Adjusted mosaic panel grid layout for improved responsiveness and sizing.
*   The dashboard content area now adheres to the user's configured content width setting.
*   Added database migration and backend API support for new panel layout properties.

**Impact**:
*   **Frontend:** The `MosaicPanelArranger.tsx` component is significantly updated to implement new arrangement logic and controls. `MosaicDetailPage.tsx` and `DashboardPage.tsx` are modified to integrate these features and layout adjustments.
*   **Backend:** `mosaics.py` API endpoints and the `mosaic_panel.py` model are updated to persist and retrieve panel rotation and flip states.
*   **Database:** A new migration (`0002_mosaic_panel_layout.py`) introduces schema changes to store additional mosaic panel properties.