### PR TITLE
Add 'Remember me' login option

### DIFF
--- a/backend/alembic/versions/0003_refresh_token_persistent.py
+++ b/backend/alembic/versions/0003_refresh_token_persistent.py
@@ -1,0 +1,38 @@
+"""Add persistent column to refresh_tokens for 'remember me' sessions.
+
+When a user logs in with 'Remember me' checked, the refresh token is marked
+persistent so that cookie max_age is set on subsequent refreshes too.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0003"
+down_revision = "0002"
+branch_labels = None
+depends_on = None
+
+
+def _column_exists(table: str, column: str) -> bool:
+    bind = op.get_bind()
+    result = bind.execute(
+        sa.text(
+            "SELECT 1 FROM information_schema.columns "
+            "WHERE table_name = :t AND column_name = :c"
+        ),
+        {"t": table, "c": column},
+    ).scalar()
+    return result is not None
+
+
+def upgrade() -> None:
+    if not _column_exists("refresh_tokens", "persistent"):
+        op.add_column(
+            "refresh_tokens",
+            sa.Column("persistent", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        )
+
+
+def downgrade() -> None:
+    if _column_exists("refresh_tokens", "persistent"):
+        op.drop_column("refresh_tokens", "persistent")

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -39,7 +39,17 @@ router = APIRouter(prefix="/auth", tags=["auth"])
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _set_auth_cookies(response: Response, access_token: str, refresh_token: str) -> None:
+def _set_auth_cookies(
+    response: Response,
+    access_token: str,
+    refresh_token: str,
+    persistent: bool = False,
+) -> None:
+    # persistent=True  → cookies survive browser restart (max_age set)
+    # persistent=False → session cookies (no max_age, cleared on browser close)
+    access_max_age = settings.access_token_expiry if persistent else None
+    refresh_max_age = settings.refresh_token_expiry if persistent else None
+
     response.set_cookie(
         key="access_token",
         value=access_token,
@@ -47,6 +57,7 @@ def _set_auth_cookies(response: Response, access_token: str, refresh_token: str)
         secure=settings.https,
         samesite="strict",
         path="/",
+        max_age=access_max_age,
     )
     response.set_cookie(
         key="refresh_token",
@@ -55,6 +66,7 @@ def _set_auth_cookies(response: Response, access_token: str, refresh_token: str)
         secure=settings.https,
         samesite="strict",
         path="/api/auth",
+        max_age=refresh_max_age,
     )
 
 
@@ -122,10 +134,10 @@ async def login(
 
     access = create_access_token(user.id, user.role.value)
     refresh = generate_refresh_token()
-    await store_refresh_token(session, user.id, refresh)
+    await store_refresh_token(session, user.id, refresh, persistent=body.remember)
     await session.commit()
 
-    _set_auth_cookies(response, access, refresh)
+    _set_auth_cookies(response, access, refresh, persistent=body.remember)
     audit_log("login", user_id=user.id, username=user.username, source_ip=ip, success=True)
 
     return LoginResponse(username=user.username, role=user.role.value)
@@ -162,10 +174,14 @@ async def refresh(
 
     access = create_access_token(user.id, user.role.value)
     new_refresh = generate_refresh_token()
-    await store_refresh_token(session, user.id, new_refresh, family_id=old_rt.family_id)
+    await store_refresh_token(
+        session, user.id, new_refresh,
+        family_id=old_rt.family_id,
+        persistent=old_rt.persistent,
+    )
     await session.commit()
 
-    _set_auth_cookies(response, access, new_refresh)
+    _set_auth_cookies(response, access, new_refresh, persistent=old_rt.persistent)
     audit_log("refresh", user_id=user.id, source_ip=ip)
     return {"status": "ok"}
 

--- a/backend/app/models/refresh_token.py
+++ b/backend/app/models/refresh_token.py
@@ -17,6 +17,7 @@ class RefreshToken(Base):
     family_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), default=uuid.uuid4, nullable=False)
     expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     revoked: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    persistent: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False, doc="True when user checked 'Remember me'")
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
 
     __table_args__ = (

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 class LoginRequest(BaseModel):
     username: str
     password: str
+    remember: bool = False
 
 
 class LoginResponse(BaseModel):

--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -82,6 +82,7 @@ async def store_refresh_token(
     user_id: uuid.UUID,
     token: str,
     family_id: uuid.UUID | None = None,
+    persistent: bool = False,
 ) -> RefreshToken:
     token_hash = hash_token(token)
     if family_id is None:
@@ -91,6 +92,7 @@ async def store_refresh_token(
         token_hash=token_hash,
         family_id=family_id,
         expires_at=datetime.now(timezone.utc) + timedelta(seconds=settings.refresh_token_expiry),
+        persistent=persistent,
     )
     session.add(rt)
     await session.flush()

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -220,10 +220,10 @@ function buildTargetQuery(filters: ActiveFilters, page?: number, pageSize?: numb
 
 export const api = {
   // Auth
-  login: (username: string, password: string) =>
+  login: (username: string, password: string, remember: boolean = false) =>
     fetchJson<LoginResponse>("/auth/login", {
       method: "POST",
-      body: JSON.stringify({ username, password }),
+      body: JSON.stringify({ username, password, remember }),
     }),
 
   logout: () =>

--- a/frontend/src/components/AuthProvider.tsx
+++ b/frontend/src/components/AuthProvider.tsx
@@ -5,7 +5,7 @@ import type { AuthUser } from "../types";
 interface AuthContextValue {
   user: () => AuthUser | null;
   loading: () => boolean;
-  login: (username: string, password: string) => Promise<void>;
+  login: (username: string, password: string, remember?: boolean) => Promise<void>;
   logout: () => Promise<void>;
   refreshUser: () => Promise<void>;
   isAdmin: () => boolean;
@@ -26,8 +26,8 @@ export const AuthProvider: Component<ParentProps> = (props) => {
     }
   };
 
-  const login = async (username: string, password: string) => {
-    await api.login(username, password);
+  const login = async (username: string, password: string, remember?: boolean) => {
+    await api.login(username, password, remember ?? false);
     await refreshUser();
   };
 

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -6,6 +6,7 @@ const LoginPage: Component = () => {
   const { login } = useAuth();
   const [username, setUsername] = createSignal("");
   const [password, setPassword] = createSignal("");
+  const [remember, setRemember] = createSignal(false);
   const [error, setError] = createSignal("");
   const [submitting, setSubmitting] = createSignal(false);
 
@@ -14,7 +15,7 @@ const LoginPage: Component = () => {
     setError("");
     setSubmitting(true);
     try {
-      await login(username(), password());
+      await login(username(), password(), remember());
       showToast(`Welcome, ${username()}`);
       window.location.href = "/";
     } catch (err: any) {
@@ -62,6 +63,15 @@ const LoginPage: Component = () => {
               required
             />
           </div>
+          <label class="flex items-center gap-2 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={remember()}
+              onChange={(e) => setRemember(e.currentTarget.checked)}
+              class="accent-theme-accent w-3.5 h-3.5"
+            />
+            <span class="text-sm text-theme-text-secondary">Remember me</span>
+          </label>
           <button
             type="submit"
             disabled={submitting()}


### PR DESCRIPTION
**Summary**:
This pull request adds a "Remember me" option to the login page, allowing user sessions to persist across browser restarts through the use of persistent refresh tokens.

**Changes**:
*   Added a "Remember me" checkbox to the login page.
*   Modified the authentication API to support persistent refresh tokens.
*   Implemented a database migration to store refresh tokens persistently.
*   Updated the frontend authentication provider and API client to manage persistent sessions.
*   Adjusted backend authentication services to handle persistent token generation and validation.

**Impact**:
*   Affects user authentication flow.
*   Modifies the `refresh_token` database schema.
*   Changes backend authentication API endpoints and services.
*   Updates frontend login page, authentication context, and API client.