### PR TITLE
Rename "Target Metrics Across Sessions" header to "Graphs"

### DIFF
--- a/frontend/src/pages/TargetDetailPage.tsx
+++ b/frontend/src/pages/TargetDetailPage.tsx
@@ -352,7 +352,7 @@ const TargetDetailPage: Component = () => {
                   onClick={toggleTargetChart}
                 >
                   <h3 class="text-xs font-semibold uppercase tracking-wider text-theme-text-secondary border-l-2 border-theme-accent pl-2 group-hover:text-theme-text-primary transition-colors">
-                    Target Metrics Across Sessions
+                    Graphs
                   </h3>
                   <svg
                     class={`w-3.5 h-3.5 transition-transform duration-200 text-theme-text-tertiary ${targetChartExpanded() ? "rotate-180" : ""}`}


### PR DESCRIPTION
**Summary**
This PR renames the "Target Metrics Across Sessions" section header to "Graphs" within the Target Detail Page.

**Changes**
*   The section header "Target Metrics Across Sessions" is renamed to "Graphs".

**Impact**
*   Affects the `TargetDetailPage.tsx` component in the frontend.