### PR TITLE
Implement Prometheus Monitoring and Grafana Dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ CLAUDE.md
 
 # Claude Code / Superpowers tooling
 .claude/
+.mcp.json
 .superpowers/
 .playwright-mcp/
 docs/

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ See the [Install Guide](guides/INSTALL.md) for platform-specific paths, version 
 - [N.I.N.A. Setup Guide](guides/NINA-SETUP.md) -- Configuring N.I.N.A. for use with GalactiLog
 - [Configuration Guide](guides/CONFIGURATION.md) -- Environment variables, themes, filter/equipment aliases, and display settings
 - [Security Guide](guides/security.md) -- Authentication, HTTPS, cookie security, and user management
+- [Monitoring Guide](guides/MONITORING.md) -- Prometheus metrics endpoint, Grafana dashboards, and performance tracking
 
 ## Tech Stack
 

--- a/backend/app/api/metrics_endpoint.py
+++ b/backend/app/api/metrics_endpoint.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter
 from fastapi.responses import Response
 from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
 
-router = APIRouter()
+router = APIRouter(prefix="/api")
 
 
 @router.get("/metrics", include_in_schema=False)

--- a/backend/app/api/metrics_endpoint.py
+++ b/backend/app/api/metrics_endpoint.py
@@ -1,0 +1,13 @@
+from fastapi import APIRouter
+from fastapi.responses import Response
+from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
+
+router = APIRouter()
+
+
+@router.get("/metrics", include_in_schema=False)
+async def metrics():
+    return Response(
+        content=generate_latest(),
+        media_type=CONTENT_TYPE_LATEST,
+    )

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -5,6 +5,9 @@ from .config import settings
 engine = create_async_engine(settings.database_url, echo=False, pool_pre_ping=True)
 async_session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
+from app.metrics import register_db_listeners
+register_db_listeners(engine.sync_engine)
+
 
 async def get_session() -> AsyncSession:  # type: ignore[misc]
     async with async_session() as session:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,6 +11,8 @@ from starlette.responses import JSONResponse
 
 from app.config import settings, limiter
 from app.api.router import api_router
+from app.api.metrics_endpoint import router as metrics_router
+from app.metrics import PrometheusMiddleware
 
 logger = logging.getLogger(__name__)
 
@@ -94,6 +96,9 @@ def create_app() -> FastAPI:
 
     # API routes
     application.include_router(api_router)
+    application.include_router(metrics_router)
+
+    application.add_middleware(PrometheusMiddleware)
 
     # Serve generated thumbnails as static files
     thumbnails_dir = Path(settings.thumbnails_path)

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -1,13 +1,12 @@
 import time
 import threading
 import logging
-from contextvars import ContextVar
 
 from prometheus_client import Counter, Histogram, Gauge
 
 logger = logging.getLogger(__name__)
 
-_db_query_count: ContextVar[int] = ContextVar("_db_query_count", default=0)
+_request_local = threading.local()
 
 HTTP_REQUEST_DURATION = Histogram(
     "galactilog_http_request_duration_seconds",
@@ -62,10 +61,10 @@ from starlette.requests import Request
 
 class PrometheusMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
-        if request.url.path == "/metrics":
+        if request.url.path == "/api/metrics":
             return await call_next(request)
 
-        _db_query_count.set(0)
+        _request_local.query_count = 0
 
         start = time.perf_counter()
         response = await call_next(request)
@@ -80,7 +79,7 @@ class PrometheusMiddleware(BaseHTTPMiddleware):
         HTTP_REQUEST_DURATION.labels(method=method, endpoint=endpoint, status_code=status).observe(duration)
         HTTP_REQUESTS_TOTAL.labels(method=method, endpoint=endpoint, status_code=status).inc()
 
-        query_count = _db_query_count.get()
+        query_count = getattr(_request_local, 'query_count', 0)
         if query_count > 0:
             DB_QUERIES_PER_REQUEST.labels(endpoint=endpoint).observe(query_count)
 
@@ -104,7 +103,7 @@ def register_db_listeners(sync_engine):
         start = conn.info.pop("query_start", None)
         if start is not None:
             DB_QUERY_DURATION.observe(time.perf_counter() - start)
-        _db_query_count.set(_db_query_count.get() + 1)
+        _request_local.query_count = getattr(_request_local, 'query_count', 0) + 1
 
     pool = sync_engine.pool
 

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -1,0 +1,184 @@
+import time
+import threading
+import logging
+from contextvars import ContextVar
+
+from prometheus_client import Counter, Histogram, Gauge
+
+logger = logging.getLogger(__name__)
+
+_db_query_count: ContextVar[int] = ContextVar("_db_query_count", default=0)
+
+HTTP_REQUEST_DURATION = Histogram(
+    "galactilog_http_request_duration_seconds",
+    "HTTP request latency end-to-end",
+    ["method", "endpoint", "status_code"],
+    buckets=[0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0],
+)
+
+HTTP_REQUESTS_TOTAL = Counter(
+    "galactilog_http_requests_total",
+    "Total HTTP request count",
+    ["method", "endpoint", "status_code"],
+)
+
+DB_QUERY_DURATION = Histogram(
+    "galactilog_db_query_duration_seconds",
+    "Individual DB query execution time",
+    buckets=[0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0],
+)
+
+DB_QUERIES_PER_REQUEST = Histogram(
+    "galactilog_db_queries_per_request",
+    "Number of DB queries issued per HTTP request",
+    ["endpoint"],
+    buckets=[1, 2, 5, 10, 25, 50, 100, 250],
+)
+
+DB_POOL_SIZE = Gauge("galactilog_db_pool_size", "Current DB connection pool size")
+DB_POOL_CHECKED_OUT = Gauge("galactilog_db_pool_checked_out", "DB connections currently in use")
+DB_POOL_OVERFLOW = Gauge("galactilog_db_pool_overflow", "DB overflow connections active")
+
+CELERY_TASK_DURATION = Histogram(
+    "galactilog_celery_task_duration_seconds",
+    "Celery task execution duration",
+    ["task_name"],
+    buckets=[0.1, 0.5, 1.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0, 600.0],
+)
+
+CELERY_TASK_FAILURES = Counter(
+    "galactilog_celery_task_failures_total",
+    "Celery task failure count",
+    ["task_name"],
+)
+
+CELERY_QUEUE_DEPTH = Gauge("galactilog_celery_queue_depth", "Tasks waiting in Redis queue")
+CELERY_WORKERS_ACTIVE = Gauge("galactilog_celery_workers_active", "Worker slots currently processing tasks")
+CELERY_WORKERS_TOTAL = Gauge("galactilog_celery_workers_total", "Total worker slots available")
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+
+
+class PrometheusMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        if request.url.path == "/metrics":
+            return await call_next(request)
+
+        _db_query_count.set(0)
+
+        start = time.perf_counter()
+        response = await call_next(request)
+        duration = time.perf_counter() - start
+
+        route = request.scope.get("route")
+        endpoint = route.path if route is not None else request.url.path
+
+        method = request.method
+        status = str(response.status_code)
+
+        HTTP_REQUEST_DURATION.labels(method=method, endpoint=endpoint, status_code=status).observe(duration)
+        HTTP_REQUESTS_TOTAL.labels(method=method, endpoint=endpoint, status_code=status).inc()
+
+        query_count = _db_query_count.get()
+        if query_count > 0:
+            DB_QUERIES_PER_REQUEST.labels(endpoint=endpoint).observe(query_count)
+
+        return response
+
+
+def register_db_listeners(sync_engine):
+    """Attach query timing and pool instrumentation to a SQLAlchemy sync engine.
+
+    Pass engine.sync_engine when working with an AsyncEngine.
+    Call once after engine construction.
+    """
+    from sqlalchemy import event
+
+    @event.listens_for(sync_engine, "before_cursor_execute")
+    def before_cursor_execute(conn, cursor, statement, parameters, context, executemany):
+        conn.info["query_start"] = time.perf_counter()
+
+    @event.listens_for(sync_engine, "after_cursor_execute")
+    def after_cursor_execute(conn, cursor, statement, parameters, context, executemany):
+        start = conn.info.pop("query_start", None)
+        if start is not None:
+            DB_QUERY_DURATION.observe(time.perf_counter() - start)
+        _db_query_count.set(_db_query_count.get() + 1)
+
+    pool = sync_engine.pool
+
+    @event.listens_for(pool, "checkout")
+    def on_checkout(dbapi_conn, conn_record, conn_proxy):
+        DB_POOL_CHECKED_OUT.inc()
+        DB_POOL_SIZE.set(pool.size())
+        DB_POOL_OVERFLOW.set(pool.overflow())
+
+    @event.listens_for(pool, "checkin")
+    def on_checkin(dbapi_conn, conn_record):
+        DB_POOL_CHECKED_OUT.dec()
+        DB_POOL_SIZE.set(pool.size())
+        DB_POOL_OVERFLOW.set(pool.overflow())
+
+
+def register_celery_signals():
+    """Connect Celery signals for task timing and failure counting.
+
+    Call once at worker startup. dispatch_uid prevents duplicate connections
+    if this function is called more than once in the same process.
+    """
+    from celery.signals import task_prerun, task_postrun, task_failure
+
+    @task_prerun.connect(dispatch_uid="galactilog_task_prerun")
+    def on_task_prerun(task_id, task, *args, **kwargs):
+        task.request._metrics_start = time.perf_counter()
+
+    @task_postrun.connect(dispatch_uid="galactilog_task_postrun")
+    def on_task_postrun(task_id, task, *args, **kwargs):
+        start = getattr(task.request, "_metrics_start", None)
+        if start is not None:
+            CELERY_TASK_DURATION.labels(task_name=task.name).observe(
+                time.perf_counter() - start
+            )
+
+    @task_failure.connect(dispatch_uid="galactilog_task_failure")
+    def on_task_failure(task_id, exception, traceback, sender, *args, **kwargs):
+        CELERY_TASK_FAILURES.labels(task_name=sender.name).inc()
+
+
+def start_queue_depth_probe(celery_app, redis_url: str, interval: int = 15):
+    """Start a daemon thread that polls Redis and Celery inspect every `interval` seconds.
+
+    Call from the worker_ready signal in tasks.py. Runs only in the worker process.
+    """
+    import redis as sync_redis
+
+    def _probe():
+        r = sync_redis.from_url(redis_url, decode_responses=True)
+        while True:
+            try:
+                depth = r.llen("celery")
+                CELERY_QUEUE_DEPTH.set(depth if depth is not None else 0)
+            except Exception:
+                logger.debug("Queue depth probe: Redis query failed", exc_info=True)
+
+            try:
+                inspector = celery_app.control.inspect(timeout=2)
+                active = inspector.active() or {}
+                stats = inspector.stats() or {}
+
+                active_count = sum(len(tasks) for tasks in active.values())
+                total_slots = sum(
+                    s.get("pool", {}).get("max-concurrency", 0)
+                    for s in stats.values()
+                )
+                CELERY_WORKERS_ACTIVE.set(active_count)
+                CELERY_WORKERS_TOTAL.set(total_slots)
+            except Exception:
+                logger.debug("Queue depth probe: Celery inspect failed", exc_info=True)
+
+            time.sleep(interval)
+
+    t = threading.Thread(target=_probe, daemon=True, name="metrics-queue-probe")
+    t.start()
+    logger.info("Prometheus queue depth probe started (interval=%ds)", interval)

--- a/backend/app/worker/celery_app.py
+++ b/backend/app/worker/celery_app.py
@@ -25,3 +25,6 @@ celery_app.conf.update(
 )
 
 celery_app.autodiscover_tasks(["app.worker"])
+
+from app.metrics import register_celery_signals
+register_celery_signals()

--- a/backend/app/worker/tasks.py
+++ b/backend/app/worker/tasks.py
@@ -41,6 +41,14 @@ from app.services.scan_state import (
 
 _redis = get_sync_redis()
 
+from celery.signals import worker_ready as _worker_ready
+
+@_worker_ready.connect
+def _start_metrics_probe(sender, **kwargs):
+    from app.metrics import start_queue_depth_probe
+    from app.worker.celery_app import celery_app as _app
+    start_queue_depth_probe(_app, settings.redis_url)
+
 
 @celery_app.task(bind=True)
 def run_scan(self, include_calibration: bool = True) -> dict:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "pwdlib[argon2]>=0.2.0",
     "PyJWT>=2.9.0",
     "slowapi>=0.1.9",
+    "prometheus-client>=0.21.0",
     "python-multipart>=0.0.9",
     "astropy>=6.0.0",
 ]

--- a/guides/MONITORING.md
+++ b/guides/MONITORING.md
@@ -31,28 +31,6 @@ GalactiLog exposes a Prometheus-compatible metrics endpoint at `/api/metrics`. T
 | `galactilog_celery_workers_active` | Gauge | (none) | Worker slots processing |
 | `galactilog_celery_workers_total` | Gauge | (none) | Total worker slots |
 
-## Scraping with Telegraf
-
-Add a config file to `/etc/telegraf/telegraf.d/`:
-
-```ini
-# /etc/telegraf/telegraf.d/galactilog.conf
-[[inputs.prometheus]]
-  urls = ["http://astrodb.lan:8080/api/metrics"]
-  interval = "30s"
-  namepass = ["galactilog_*"]
-  [inputs.prometheus.tags]
-    source = "galactilog"
-```
-
-Reload telegraf:
-
-```bash
-sudo systemctl reload telegraf
-```
-
-Metrics flow into InfluxDB under the `telegraf` database with measurement names matching the metric names above.
-
 ## Scraping with Prometheus
 
 Add a scrape target to `prometheus.yml`:
@@ -79,26 +57,28 @@ A pre-built dashboard is available in the GalactiLog folder on Grafana. It inclu
 
 ### Example: Queries Per Request
 
-The `galactilog_db_queries_per_request` metric tracks how many database queries each HTTP request issues. High values indicate N+1 query patterns. Sample InfluxDB query:
+The `galactilog_db_queries_per_request` metric tracks how many database queries each HTTP request issues. High values indicate N+1 query patterns. Sample PromQL:
 
-```sql
-SELECT non_negative_derivative(last("sum"), 1s)
-     / non_negative_derivative(last("count"), 1s)
-FROM "galactilog_db_queries_per_request"
-WHERE ("source" = 'galactilog') AND $timeFilter
-GROUP BY time($__interval), "endpoint"
-fill(null)
+```promql
+# Average queries per request by endpoint (over 5m windows)
+rate(galactilog_db_queries_per_request_sum[5m])
+  / rate(galactilog_db_queries_per_request_count[5m])
 ```
 
 ### Example: Request Latency
 
-```sql
-SELECT non_negative_derivative(last("sum"), 1s)
-     / non_negative_derivative(last("count"), 1s)
-FROM "galactilog_http_request_duration_seconds"
-WHERE ("source" = 'galactilog') AND $timeFilter
-GROUP BY time($__interval), "endpoint"
-fill(null)
+```promql
+# Average request latency by endpoint (over 5m windows)
+rate(galactilog_http_request_duration_seconds_sum[5m])
+  / rate(galactilog_http_request_duration_seconds_count[5m])
+```
+
+### Example: P95 Latency
+
+```promql
+histogram_quantile(0.95,
+  rate(galactilog_http_request_duration_seconds_bucket[5m])
+)
 ```
 
 ## Endpoint Labels

--- a/guides/MONITORING.md
+++ b/guides/MONITORING.md
@@ -1,0 +1,106 @@
+# Application Monitoring
+
+GalactiLog exposes a Prometheus-compatible metrics endpoint at `/api/metrics`. The endpoint requires no authentication and returns standard Prometheus text format.
+
+## Metrics Exposed
+
+### HTTP
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `galactilog_http_request_duration_seconds` | Histogram | method, endpoint, status_code | Request latency |
+| `galactilog_http_requests_total` | Counter | method, endpoint, status_code | Request count |
+
+### Database
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `galactilog_db_query_duration_seconds` | Histogram | (none) | Individual query execution time |
+| `galactilog_db_queries_per_request` | Histogram | endpoint | Queries issued per HTTP request |
+| `galactilog_db_pool_size` | Gauge | (none) | Connection pool size |
+| `galactilog_db_pool_checked_out` | Gauge | (none) | Connections in use |
+| `galactilog_db_pool_overflow` | Gauge | (none) | Overflow connections active |
+
+### Celery
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `galactilog_celery_task_duration_seconds` | Histogram | task_name | Task execution time |
+| `galactilog_celery_task_failures_total` | Counter | task_name | Task failure count |
+| `galactilog_celery_queue_depth` | Gauge | (none) | Tasks waiting in Redis |
+| `galactilog_celery_workers_active` | Gauge | (none) | Worker slots processing |
+| `galactilog_celery_workers_total` | Gauge | (none) | Total worker slots |
+
+## Scraping with Telegraf
+
+Add a config file to `/etc/telegraf/telegraf.d/`:
+
+```ini
+# /etc/telegraf/telegraf.d/galactilog.conf
+[[inputs.prometheus]]
+  urls = ["http://astrodb.lan:8080/api/metrics"]
+  interval = "30s"
+  namepass = ["galactilog_*"]
+  [inputs.prometheus.tags]
+    source = "galactilog"
+```
+
+Reload telegraf:
+
+```bash
+sudo systemctl reload telegraf
+```
+
+Metrics flow into InfluxDB under the `telegraf` database with measurement names matching the metric names above.
+
+## Scraping with Prometheus
+
+Add a scrape target to `prometheus.yml`:
+
+```yaml
+scrape_configs:
+  - job_name: galactilog
+    scrape_interval: 30s
+    metrics_path: /api/metrics
+    static_configs:
+      - targets: ["astrodb.lan:8080"]
+```
+
+## Grafana Dashboard
+
+A pre-built dashboard is available in the GalactiLog folder on Grafana. It includes:
+
+* Request rate and latency by endpoint (time series)
+* Stat panels for total requests, average latency, pool utilization, queue depth, and worker count
+* Queries per request by endpoint (bar chart, useful for detecting N+1 patterns)
+* Average query duration over time
+* Connection pool utilization (pool size vs checked out vs overflow)
+* Celery queue depth and worker utilization
+
+### Example: Queries Per Request
+
+The `galactilog_db_queries_per_request` metric tracks how many database queries each HTTP request issues. High values indicate N+1 query patterns. Sample InfluxDB query:
+
+```sql
+SELECT non_negative_derivative(last("sum"), 1s)
+     / non_negative_derivative(last("count"), 1s)
+FROM "galactilog_db_queries_per_request"
+WHERE ("source" = 'galactilog') AND $timeFilter
+GROUP BY time($__interval), "endpoint"
+fill(null)
+```
+
+### Example: Request Latency
+
+```sql
+SELECT non_negative_derivative(last("sum"), 1s)
+     / non_negative_derivative(last("count"), 1s)
+FROM "galactilog_http_request_duration_seconds"
+WHERE ("source" = 'galactilog') AND $timeFilter
+GROUP BY time($__interval), "endpoint"
+fill(null)
+```
+
+## Endpoint Labels
+
+The `endpoint` label uses route templates (e.g., `/api/targets/{target_id}`), not resolved paths. This keeps label cardinality bounded regardless of how many targets or mosaics exist in the database.

--- a/guides/grafana-dashboard.json
+++ b/guides/grafana-dashboard.json
@@ -1,0 +1,617 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "datasource": { "type": "influxdb", "uid": "_vqb8EkGz" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "fixedColor": "blue", "mode": "fixed" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": 0 }] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 0 },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "_vqb8EkGz" },
+          "query": "SELECT last(\"counter\") FROM \"galactilog_http_requests_total\" WHERE (\"source\" = 'galactilog') AND $timeFilter GROUP BY time($__interval) fill(null)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "Total Requests",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "influxdb", "uid": "_vqb8EkGz" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": 0 },
+              { "color": "yellow", "value": 0.1 },
+              { "color": "orange", "value": 0.5 },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 0 },
+      "id": 5,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "_vqb8EkGz" },
+          "query": "SELECT last(\"sum\") / last(\"count\") FROM \"galactilog_http_request_duration_seconds\" WHERE (\"source\" = 'galactilog') AND $timeFilter",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "Avg Latency",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "influxdb", "uid": "_vqb8EkGz" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": 0 },
+              { "color": "yellow", "value": 5 },
+              { "color": "red", "value": 10 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 0 },
+      "id": 6,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "_vqb8EkGz" },
+          "query": "SELECT last(\"gauge\") FROM \"galactilog_db_pool_checked_out\" WHERE (\"source\" = 'galactilog') AND $timeFilter GROUP BY time($__interval) fill(null)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "DB Pool Active",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "influxdb", "uid": "_vqb8EkGz" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": 0 },
+              { "color": "yellow", "value": 10 },
+              { "color": "orange", "value": 50 },
+              { "color": "red", "value": 100 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 0 },
+      "id": 7,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "_vqb8EkGz" },
+          "query": "SELECT last(\"gauge\") FROM \"galactilog_celery_queue_depth\" WHERE (\"source\" = 'galactilog') AND $timeFilter GROUP BY time($__interval) fill(null)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "Queue Depth",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "influxdb", "uid": "_vqb8EkGz" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "fixedColor": "purple", "mode": "fixed" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "purple", "value": 0 }] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 0 },
+      "id": 8,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "_vqb8EkGz" },
+          "query": "SELECT last(\"gauge\") FROM \"galactilog_celery_workers_active\" WHERE (\"source\" = 'galactilog') AND $timeFilter GROUP BY time($__interval) fill(null)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "Workers Active",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "influxdb", "uid": "_vqb8EkGz" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "fixedColor": "semi-dark-blue", "mode": "fixed" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "semi-dark-blue", "value": 0 }] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 0 },
+      "id": 9,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "_vqb8EkGz" },
+          "query": "SELECT last(\"gauge\") FROM \"galactilog_db_pool_size\" WHERE (\"source\" = 'galactilog') AND $timeFilter GROUP BY time($__interval) fill(null)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "DB Pool Size",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 4 },
+      "id": 1,
+      "panels": [],
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "influxdb", "uid": "_vqb8EkGz" },
+      "description": "HTTP requests per second by endpoint",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisSoftMin": 0,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "opacity",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 5 },
+      "id": 2,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "alias": "$tag_endpoint",
+          "datasource": { "type": "influxdb", "uid": "_vqb8EkGz" },
+          "query": "SELECT non_negative_derivative(last(\"counter\"), 1s) FROM \"galactilog_http_requests_total\" WHERE (\"source\" = 'galactilog') AND $timeFilter GROUP BY time($__interval), \"endpoint\" fill(null)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "Request Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "influxdb", "uid": "_vqb8EkGz" },
+      "description": "Average request duration by endpoint",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisSoftMin": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 5 },
+      "id": 3,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "alias": "$tag_endpoint",
+          "datasource": { "type": "influxdb", "uid": "_vqb8EkGz" },
+          "query": "SELECT non_negative_derivative(last(\"sum\"), 1s) / non_negative_derivative(last(\"count\"), 1s) FROM \"galactilog_http_request_duration_seconds\" WHERE (\"source\" = 'galactilog') AND $timeFilter GROUP BY time($__interval), \"endpoint\" fill(null)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "Request Latency (avg)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 13 },
+      "id": 20,
+      "panels": [],
+      "title": "Database",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "influxdb", "uid": "_vqb8EkGz" },
+      "description": "Number of database queries issued per HTTP request, by endpoint. This is the key metric for detecting N+1 query problems.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisSoftMin": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 60,
+            "gradientMode": "scheme",
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "decimals": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 },
+      "id": 10,
+      "options": {
+        "legend": { "calcs": ["mean", "max", "lastNotNull"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "alias": "$tag_endpoint",
+          "datasource": { "type": "influxdb", "uid": "_vqb8EkGz" },
+          "query": "SELECT non_negative_derivative(last(\"sum\"), 1s) / non_negative_derivative(last(\"count\"), 1s) FROM \"galactilog_db_queries_per_request\" WHERE (\"source\" = 'galactilog') AND $timeFilter GROUP BY time($__interval), \"endpoint\" fill(null)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "DB Queries per Request",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "influxdb", "uid": "_vqb8EkGz" },
+      "description": "Average time per database query",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "continuous-GrYlRd" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisSoftMin": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "scheme",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 14 },
+      "id": 11,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "alias": "avg query time",
+          "datasource": { "type": "influxdb", "uid": "_vqb8EkGz" },
+          "query": "SELECT non_negative_derivative(last(\"sum\"), 1s) / non_negative_derivative(last(\"count\"), 1s) FROM \"galactilog_db_query_duration_seconds\" WHERE (\"source\" = 'galactilog') AND $timeFilter GROUP BY time($__interval) fill(null)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "DB Query Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "influxdb", "uid": "_vqb8EkGz" },
+      "description": "Database connection pool utilization over time",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisSoftMin": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "pool size" },
+            "properties": [
+              { "id": "custom.lineStyle", "value": { "dash": [10, 10], "fill": "dash" } },
+              { "id": "color", "value": { "fixedColor": "white", "mode": "fixed" } }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "checked out" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } },
+              { "id": "custom.fillOpacity", "value": 30 }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "overflow" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 22 },
+      "id": 12,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "alias": "pool size",
+          "datasource": { "type": "influxdb", "uid": "_vqb8EkGz" },
+          "query": "SELECT last(\"gauge\") FROM \"galactilog_db_pool_size\" WHERE (\"source\" = 'galactilog') AND $timeFilter GROUP BY time($__interval) fill(previous)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        },
+        {
+          "alias": "checked out",
+          "datasource": { "type": "influxdb", "uid": "_vqb8EkGz" },
+          "query": "SELECT last(\"gauge\") FROM \"galactilog_db_pool_checked_out\" WHERE (\"source\" = 'galactilog') AND $timeFilter GROUP BY time($__interval) fill(previous)",
+          "rawQuery": true,
+          "refId": "B",
+          "resultFormat": "time_series"
+        },
+        {
+          "alias": "overflow",
+          "datasource": { "type": "influxdb", "uid": "_vqb8EkGz" },
+          "query": "SELECT last(\"gauge\") FROM \"galactilog_db_pool_overflow\" WHERE (\"source\" = 'galactilog') AND $timeFilter GROUP BY time($__interval) fill(previous)",
+          "rawQuery": true,
+          "refId": "C",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "Connection Pool",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 30 },
+      "id": 30,
+      "panels": [],
+      "title": "Celery Workers",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "influxdb", "uid": "_vqb8EkGz" },
+      "description": "Tasks waiting in the Redis queue to be processed",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "fixedColor": "orange", "mode": "fixed" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisSoftMin": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "opacity",
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "decimals": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 31 },
+      "id": 13,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "alias": "queue depth",
+          "datasource": { "type": "influxdb", "uid": "_vqb8EkGz" },
+          "query": "SELECT last(\"gauge\") FROM \"galactilog_celery_queue_depth\" WHERE (\"source\" = 'galactilog') AND $timeFilter GROUP BY time($__interval) fill(previous)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "Celery Queue Depth",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "influxdb", "uid": "_vqb8EkGz" },
+      "description": "Active vs total Celery worker slots",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisSoftMin": 0,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "opacity",
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "decimals": 0,
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "total slots" },
+            "properties": [
+              { "id": "custom.lineStyle", "value": { "dash": [10, 10], "fill": "dash" } },
+              { "id": "color", "value": { "fixedColor": "white", "mode": "fixed" } }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "active" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } },
+              { "id": "custom.fillOpacity", "value": 40 }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 31 },
+      "id": 14,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "alias": "active",
+          "datasource": { "type": "influxdb", "uid": "_vqb8EkGz" },
+          "query": "SELECT last(\"gauge\") FROM \"galactilog_celery_workers_active\" WHERE (\"source\" = 'galactilog') AND $timeFilter GROUP BY time($__interval) fill(previous)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        },
+        {
+          "alias": "total slots",
+          "datasource": { "type": "influxdb", "uid": "_vqb8EkGz" },
+          "query": "SELECT last(\"gauge\") FROM \"galactilog_celery_workers_total\" WHERE (\"source\" = 'galactilog') AND $timeFilter GROUP BY time($__interval) fill(previous)",
+          "rawQuery": true,
+          "refId": "B",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "Worker Utilization",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 42,
+  "tags": ["galactilog", "performance", "prometheus"],
+  "templating": {
+    "list": [
+      {
+        "current": { "text": ["All"], "value": ["$__all"] },
+        "datasource": { "type": "influxdb", "uid": "_vqb8EkGz" },
+        "includeAll": true,
+        "multi": true,
+        "name": "endpoint",
+        "query": "SHOW TAG VALUES FROM \"galactilog_http_requests_total\" WITH KEY = \"endpoint\"",
+        "refresh": 1,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timezone": "browser",
+  "title": "GalactiLog Performance",
+  "uid": "galactilog-perf"
+}


### PR DESCRIPTION
**Summary**
This PR introduces Prometheus metrics for performance monitoring, including a dedicated endpoint and per-request query counting. It also adds a comprehensive monitoring guide and a Grafana dashboard export for visualization.

**Changes**
*   Adds a Prometheus metrics endpoint for performance monitoring.
*   Corrects metrics endpoint routing and implements per-request query counting.
*   Introduces a new `MONITORING.md` guide and adds `.mcp.json` to `.gitignore`.
*   Updates the monitoring guide to focus exclusively on Prometheus and adds a link to it in `README.md`.
*   Includes a `grafana-dashboard.json` file for importing a pre-configured Grafana dashboard.

**Impact**
This PR introduces new files and modifies existing ones across several key areas:
*   **Backend API**: Adds a new `/metrics` endpoint and its routing.
*   **Metrics System**: Implements core Prometheus metrics collection logic.
*   **Database Interactions**: Integrates per-request query counting into the database layer.
*   **Asynchronous Workers**: Extends metrics collection to Celery worker processes and tasks.
*   **Documentation**: Adds a dedicated monitoring guide and updates the main README.
*   **Configuration**: Includes a Grafana dashboard export and updates `.gitignore`.