### PR TITLE
Simplify Merge Confirmation and Inline Mosaic Actions

### DIFF
--- a/frontend/src/components/settings/MergesTab.tsx
+++ b/frontend/src/components/settings/MergesTab.tsx
@@ -13,7 +13,6 @@ export const MergesTab: Component = () => {
   const [detecting, setDetecting] = createSignal(false);
   const [view, setView] = createSignal<"suggestions" | "merged" | "unresolved">("suggestions");
   const [unresolvedCount, setUnresolvedCount] = createSignal(0);
-  const [confirmMergeId, setConfirmMergeId] = createSignal<string | null>(null);
   const [confirmRevertId, setConfirmRevertId] = createSignal<string | null>(null);
 
   const refresh = async () => {
@@ -35,7 +34,6 @@ export const MergesTab: Component = () => {
   });
 
   const handleMerge = async (candidate: MergeCandidateResponse) => {
-    setConfirmMergeId(null);
     try {
       await api.mergeTargets(
         candidate.suggested_target_id,
@@ -163,7 +161,7 @@ export const MergesTab: Component = () => {
                     <Show when={isAdmin()}>
                       <div class="flex gap-2">
                         <button
-                          onClick={() => setConfirmMergeId(c.id)}
+                          onClick={() => handleMerge(c)}
                           class="px-2 py-1 text-xs border border-theme-accent/50 text-theme-accent rounded-[var(--radius-sm)] hover:bg-theme-accent/10 transition-colors"
                         >
                           Merge
@@ -174,26 +172,6 @@ export const MergesTab: Component = () => {
                         >
                           Dismiss
                         </button>
-                      </div>
-                    </Show>
-                    <Show when={confirmMergeId() === c.id}>
-                      <div class="w-full mt-2 bg-theme-accent/10 border border-theme-accent/30 rounded-[var(--radius-md)] p-3 space-y-2">
-                        <p class="text-sm text-theme-accent font-medium">Merge "{c.source_name}" into "{c.suggested_target_name}"?</p>
-                        <p class="text-xs text-theme-text-secondary">All images from "{c.source_name}" will be reassigned. This can be reverted later.</p>
-                        <div class="flex gap-2 pt-1">
-                          <button
-                            onClick={() => handleMerge(c)}
-                            class="px-3 py-1.5 bg-theme-accent/15 text-theme-accent border border-theme-accent/30 rounded text-xs font-medium hover:bg-theme-accent/25 transition-colors"
-                          >
-                            Yes, merge
-                          </button>
-                          <button
-                            onClick={() => setConfirmMergeId(null)}
-                            class="px-3 py-1.5 border border-theme-border-em text-theme-text-secondary rounded text-xs hover:text-theme-text-primary transition-colors"
-                          >
-                            Cancel
-                          </button>
-                        </div>
                       </div>
                     </Show>
                   </div>

--- a/frontend/src/components/settings/MosaicsTab.tsx
+++ b/frontend/src/components/settings/MosaicsTab.tsx
@@ -447,30 +447,52 @@ export const MosaicsTab: Component = () => {
 
                 return (
                   <div class="border border-theme-border rounded-[var(--radius-sm)] overflow-hidden">
-                    <button
-                      onClick={() => {
-                        const next = expandedSuggestion() === s.id ? null : s.id;
-                        setExpandedSuggestion(next);
-                        if (next) initSelection(s);
-                      }}
-                      class="w-full flex items-center justify-between p-3 bg-theme-base/50 text-left hover:bg-theme-base/80 transition-colors"
-                    >
-                      <div class="flex-1">
-                        <span class="text-theme-text-primary text-sm font-medium">
-                          {s.suggested_name}
-                        </span>
-                        <div class="text-xs text-theme-text-secondary mt-0.5">
-                          {s.panel_labels.length} panels
-                          {" \u00b7 "}
-                          {totalFrames()} frames
-                          {" \u00b7 "}
-                          {formatIntegration(totalInt())}
+                    <div class="flex items-center p-3 bg-theme-base/50">
+                      <button
+                        onClick={() => {
+                          const next = expandedSuggestion() === s.id ? null : s.id;
+                          setExpandedSuggestion(next);
+                          if (next) initSelection(s);
+                        }}
+                        class="flex-1 flex items-center justify-between text-left hover:bg-theme-base/80 transition-colors"
+                      >
+                        <div class="flex-1">
+                          <span class="text-theme-text-primary text-sm font-medium">
+                            {s.suggested_name}
+                          </span>
+                          <div class="text-xs text-theme-text-secondary mt-0.5">
+                            {s.panel_labels.length} panels
+                            {" \u00b7 "}
+                            {totalFrames()} frames
+                            {" \u00b7 "}
+                            {formatIntegration(totalInt())}
+                          </div>
                         </div>
-                      </div>
-                      <span class="text-theme-text-secondary text-xs ml-2">
-                        {expandedSuggestion() === s.id ? "\u25B2" : "\u25BC"}
-                      </span>
-                    </button>
+                        <span class="text-theme-text-secondary text-xs ml-2">
+                          {expandedSuggestion() === s.id ? "\u25B2" : "\u25BC"}
+                        </span>
+                      </button>
+                      <Show when={isAdmin()}>
+                        <div class="flex gap-2 ml-3 shrink-0">
+                          <button
+                            onClick={(e) => { e.stopPropagation(); handleAccept(s); }}
+                            class="px-4 py-1.5 bg-theme-accent/15 text-theme-accent border border-theme-accent/30 rounded text-sm font-medium hover:bg-theme-accent/25 transition-colors"
+                          >
+                            Accept{(() => {
+                              const sel = selectedPanels()[s.id];
+                              const count = sel?.size ?? s.panel_labels.length;
+                              return count < s.panel_labels.length ? ` (${count}/${s.panel_labels.length})` : "";
+                            })()}
+                          </button>
+                          <button
+                            onClick={(e) => { e.stopPropagation(); handleDismiss(s); }}
+                            class="px-2.5 py-1.5 text-sm border border-theme-border text-theme-text-secondary rounded-[var(--radius-sm)] hover:text-theme-text-primary transition-colors"
+                          >
+                            Dismiss
+                          </button>
+                        </div>
+                      </Show>
+                    </div>
 
                     <Show when={expandedSuggestion() === s.id}>
                       <div class="border-t border-theme-border">
@@ -539,26 +561,6 @@ export const MosaicsTab: Component = () => {
                           </table>
                         </Show>
 
-                        <Show when={isAdmin()}>
-                          <div class="flex gap-2 px-3 py-2">
-                            <button
-                              onClick={() => handleAccept(s)}
-                              class="px-4 py-1.5 bg-theme-accent/15 text-theme-accent border border-theme-accent/30 rounded text-sm font-medium hover:bg-theme-accent/25 transition-colors"
-                            >
-                              Accept{(() => {
-                                const sel = selectedPanels()[s.id];
-                                const count = sel?.size ?? s.panel_labels.length;
-                                return count < s.panel_labels.length ? ` (${count}/${s.panel_labels.length})` : "";
-                              })()}
-                            </button>
-                            <button
-                              onClick={() => handleDismiss(s)}
-                              class="px-2.5 py-1 text-xs border border-theme-border text-theme-text-secondary rounded-[var(--radius-sm)] hover:text-theme-text-primary transition-colors"
-                            >
-                              Dismiss
-                            </button>
-                          </div>
-                        </Show>
                       </div>
                     </Show>
                   </div>
@@ -639,12 +641,43 @@ export const MosaicsTab: Component = () => {
                         {expandedId() === m.id ? "\u25B2" : "\u25BC"}
                       </span>
                     </button>
-                    <a
-                      href={`/mosaics/${m.id}`}
-                      class="ml-3 px-4 py-1.5 bg-theme-accent/15 text-theme-accent border border-theme-accent/30 rounded text-sm font-medium hover:bg-theme-accent/25 transition-colors shrink-0"
-                    >
-                      Detail
-                    </a>
+                    <div class="flex items-center gap-2 ml-3 shrink-0">
+                      <Show when={isAdmin()}>
+                        <Show
+                          when={confirmDeleteId() === m.id}
+                          fallback={
+                            <button
+                              onClick={() => setConfirmDeleteId(m.id)}
+                              class="px-2 py-1.5 text-sm border border-theme-border text-theme-text-secondary rounded hover:text-theme-danger hover:border-theme-danger transition-colors"
+                            >
+                              Delete
+                            </button>
+                          }
+                        >
+                          <div class="flex items-center gap-2">
+                            <span class="text-xs text-theme-danger">Delete?</span>
+                            <button
+                              onClick={() => handleDeleteMosaic(m.id)}
+                              class="px-2 py-1.5 text-sm border border-theme-error/50 text-theme-error rounded-[var(--radius-sm)] hover:bg-theme-error/10 transition-colors"
+                            >
+                              Confirm
+                            </button>
+                            <button
+                              onClick={() => setConfirmDeleteId(null)}
+                              class="px-2 py-1.5 text-sm border border-theme-border text-theme-text-secondary rounded hover:text-theme-text-primary transition-colors"
+                            >
+                              Cancel
+                            </button>
+                          </div>
+                        </Show>
+                      </Show>
+                      <a
+                        href={`/mosaics/${m.id}`}
+                        class="px-4 py-1.5 bg-theme-accent/15 text-theme-accent border border-theme-accent/30 rounded text-sm font-medium hover:bg-theme-accent/25 transition-colors"
+                      >
+                        Detail
+                      </a>
+                    </div>
                   </div>
 
                   {/* Expanded detail */}
@@ -796,38 +829,6 @@ export const MosaicsTab: Component = () => {
                         </Show>
                       </Show>
 
-                      {/* Footer actions */}
-                      <div class="flex items-center justify-end pt-2 border-t border-theme-border/50">
-                        <Show when={isAdmin()}>
-                          <Show
-                            when={confirmDeleteId() === m.id}
-                            fallback={
-                              <button
-                                onClick={() => setConfirmDeleteId(m.id)}
-                                class="px-2 py-1 text-xs border border-theme-border text-theme-text-secondary rounded hover:text-theme-danger hover:border-theme-danger transition-colors"
-                              >
-                                Delete
-                              </button>
-                            }
-                          >
-                            <div class="flex items-center gap-2">
-                              <span class="text-xs text-theme-danger">Delete this mosaic?</span>
-                              <button
-                                onClick={() => handleDeleteMosaic(m.id)}
-                                class="px-2 py-1 text-xs border border-theme-error/50 text-theme-error rounded-[var(--radius-sm)] hover:bg-theme-error/10 transition-colors"
-                              >
-                                Confirm
-                              </button>
-                              <button
-                                onClick={() => setConfirmDeleteId(null)}
-                                class="px-2 py-1 text-xs border border-theme-border text-theme-text-secondary rounded hover:text-theme-text-primary transition-colors"
-                              >
-                                Cancel
-                              </button>
-                            </div>
-                          </Show>
-                        </Show>
-                      </div>
                     </div>
                   </Show>
                 </div>


### PR DESCRIPTION
**Summary**
This pull request simplifies the merge confirmation flow and displays mosaic action buttons directly inline within the UI.

**Changes**
*   Simplified the merge confirmation flow.
*   Surfaced mosaic action buttons inline.

**Impact**
*   `frontend/src/components/settings/MergesTab.tsx`: Adjustments to the merge confirmation user interface.
*   `frontend/src/components/settings/MosaicsTab.tsx`: Changes to the rendering and placement of mosaic action buttons.