### PR TITLE
Mobile Target List Sort and Settings Persistence

### DIFF
--- a/backend/app/api/settings.py
+++ b/backend/app/api/settings.py
@@ -1,9 +1,11 @@
+import copy
 import uuid
 from enum import Enum
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select, func as sa_func
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import attributes
 
 from app.config import async_redis
 from app.database import get_session
@@ -278,6 +280,7 @@ async def update_display(
     if "column_visibility_per_user" in existing:
         updated["column_visibility_per_user"] = existing["column_visibility_per_user"]
     row.display = updated
+    attributes.flag_modified(row, "display")
     await session.commit()
     return _row_to_response(row)
 
@@ -448,10 +451,11 @@ async def update_column_visibility(
     user: User = Depends(get_current_user),
 ):
     row = await _get_or_create_settings(session)
-    display = dict(row.display) if row.display else {}
+    display = copy.deepcopy(row.display) if row.display else {}
     per_user = display.get("column_visibility_per_user", {})
     per_user[str(user.id)] = payload.model_dump()
     display["column_visibility_per_user"] = per_user
     row.display = display
+    attributes.flag_modified(row, "display")
     await session.commit()
     return {"ok": True}

--- a/frontend/src/components/MaintenanceActions.tsx
+++ b/frontend/src/components/MaintenanceActions.tsx
@@ -44,14 +44,6 @@ const MaintenanceActions: Component<{
             {props.rebuildRunning && props.rebuildMode === "retry" ? "Running..." : "Re-resolve"}
           </button>
           <button
-            onClick={() => props.onRegenThumbnails()}
-            disabled={anyDisabled()}
-            title="Re-creates all thumbnails using current stretch settings. Does not affect database records."
-            class="px-3 py-1.5 border border-theme-border-em text-theme-text-secondary rounded text-sm disabled:opacity-50 hover:text-theme-text-primary hover:border-theme-accent transition-colors"
-          >
-            Regen Thumbs
-          </button>
-          <button
             onClick={() => runAction(api.triggerXmatchEnrichment)}
             disabled={anyDisabled()}
             title="Runs bulk cross-match enrichment against external catalogs (Caldwell, Herschel 400, Arp, Abell) for all targets."
@@ -66,6 +58,14 @@ const MaintenanceActions: Component<{
             class="px-3 py-1.5 border border-theme-border-em text-theme-text-secondary rounded text-sm disabled:opacity-50 hover:text-theme-text-primary hover:border-theme-accent transition-colors"
           >
             {props.rebuildRunning && props.rebuildMode === "ref_thumbnails" ? "Running..." : "Fetch DSS"}
+          </button>
+          <button
+            onClick={() => props.onRegenThumbnails()}
+            disabled={anyDisabled()}
+            title="Re-creates all thumbnails using current stretch settings. Does not affect database records."
+            class="px-3 py-1.5 bg-theme-warning/15 text-theme-warning border border-theme-warning/30 rounded text-sm font-medium disabled:opacity-50 hover:bg-theme-warning/25 transition-colors"
+          >
+            Regen Thumbs
           </button>
           <button
             onClick={() => setShowFullConfirm(true)}

--- a/frontend/src/components/TargetFeed.tsx
+++ b/frontend/src/components/TargetFeed.tsx
@@ -1,5 +1,5 @@
 import { Component, Show, For } from "solid-js";
-import { useDashboardFilters } from "./DashboardFilterProvider";
+import { useDashboardFilters, type SortKey } from "./DashboardFilterProvider";
 import TargetTable from "./TargetTable";
 
 const SkeletonRow: Component = () => (
@@ -33,8 +33,15 @@ const SkeletonCard: Component = () => (
 );
 
 const TargetFeed: Component = () => {
-  const { targetData, refetchTargets, fetchError, page, totalPages, totalCount, setPage, pageSize, setPageSize } = useDashboardFilters();
+  const { targetData, refetchTargets, fetchError, page, totalPages, totalCount, setPage, pageSize, setPageSize, sortKey, sortDir, toggleSort } = useDashboardFilters();
   const PAGE_SIZES = [10, 25, 50, 100, 250];
+
+  const SORT_LABELS: Record<SortKey, string> = {
+    name: "Name",
+    integration: "Integration",
+    lastSession: "Last Session",
+    equipment: "Equipment",
+  };
 
 
   const pageRange = () => {
@@ -115,7 +122,7 @@ const TargetFeed: Component = () => {
                 fallback={<div class="text-center text-theme-text-secondary py-8">No targets match your filters</div>}
               >
                 <div class="rounded-[var(--radius-sm)] bg-theme-elevated border border-theme-border-em p-3 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
-                  <div class="flex items-center gap-3">
+                  <div class="flex items-center gap-3 flex-wrap">
                     <span class="text-xs text-theme-text-tertiary">
                       Showing {showingRange().start}-{showingRange().end} of {totalCount()} targets
                     </span>
@@ -128,6 +135,25 @@ const TargetFeed: Component = () => {
                         {(size) => <option value={size}>{size} / page</option>}
                       </For>
                     </select>
+                    {/* Mobile sort controls - hidden on md+ where table headers handle sorting */}
+                    <div class="flex items-center gap-1 md:hidden">
+                      <select
+                        value={sortKey()}
+                        onChange={(e) => toggleSort(e.currentTarget.value as SortKey)}
+                        class="px-2 py-1 text-xs rounded border border-theme-border bg-theme-input text-theme-text-secondary cursor-pointer transition-colors hover:border-theme-border-em"
+                      >
+                        <For each={(Object.keys(SORT_LABELS) as SortKey[])}>
+                          {(key) => <option value={key}>{SORT_LABELS[key]}</option>}
+                        </For>
+                      </select>
+                      <button
+                        onClick={() => toggleSort(sortKey())}
+                        class="px-2 py-1 text-xs rounded border border-theme-border text-theme-text-secondary hover:bg-theme-elevated transition-colors"
+                        title={sortDir() === "asc" ? "Ascending" : "Descending"}
+                      >
+                        {sortDir() === "asc" ? "\u2191" : "\u2193"}
+                      </button>
+                    </div>
                   </div>
                   <Show when={totalPages() > 1}>
                     <div class="flex items-center gap-1">

--- a/frontend/src/pages/StatisticsPage.tsx
+++ b/frontend/src/pages/StatisticsPage.tsx
@@ -52,8 +52,7 @@ const StatisticsPage: Component = () => {
       <Show when={stats()}>
         {(data) => (
           <div class="rounded-[var(--radius-md)] bg-theme-surface border border-theme-border p-4 space-y-6">
-            <section class="rounded-[var(--radius-sm)] bg-theme-elevated border border-theme-border-em p-4 space-y-4">
-              <h2 class="text-sm font-semibold text-theme-text-primary">Overview</h2>
+            <section class="rounded-[var(--radius-sm)] bg-theme-elevated border border-theme-border-em p-4">
               <StatsOverview overview={data().overview} />
             </section>
 


### PR DESCRIPTION
**Summary**
This PR introduces sort controls for the mobile target list view, ensures display settings persist across sessions, and updates the styling of maintenance action buttons.

**Changes**
*   Adds sort controls for the mobile target list view.
*   Persists display settings changes.
*   Restyles maintenance action buttons.

**Impact**
*   Backend API for settings (`backend/app/api/settings.py`).
*   Frontend UI for maintenance actions (`frontend/src/components/MaintenanceActions.tsx`).
*   Frontend UI and functionality for target lists, specifically mobile view (`frontend/src/components/TargetFeed.tsx`).
*   Statistics Page (`frontend/src/pages/StatisticsPage.tsx`).