### PR TITLE
Fix calendar data refresh and Statistics page layout

### DIFF
--- a/frontend/src/components/ImagingCalendar.tsx
+++ b/frontend/src/components/ImagingCalendar.tsx
@@ -71,8 +71,8 @@ const ImagingCalendar: Component = () => {
   const [tooltip, setTooltip] = createSignal<{ x: number; y: number; text: string } | null>(null);
 
   const [data] = createResource(
-    () => selectedYear(),
-    (year) => api.getCalendar(year ?? undefined),
+    () => ({ year: selectedYear() }),
+    ({ year }) => api.getCalendar(year ?? undefined),
   );
 
   const weeks = createMemo(() => {
@@ -196,7 +196,7 @@ const ImagingCalendar: Component = () => {
           <Show when={tooltip()}>
             {(t) => (
               <div
-                class="absolute pointer-events-none bg-theme-bg border border-theme-border rounded px-2 py-1 text-xs text-white whitespace-nowrap z-50"
+                class="absolute pointer-events-none bg-theme-surface glass-popover border border-theme-border rounded px-2 py-1 text-xs text-white whitespace-nowrap z-50 shadow-lg"
                 style={{
                   left: `${t().x}px`,
                   top: `${t().y - 28}px`,

--- a/frontend/src/pages/StatisticsPage.tsx
+++ b/frontend/src/pages/StatisticsPage.tsx
@@ -52,7 +52,8 @@ const StatisticsPage: Component = () => {
       <Show when={stats()}>
         {(data) => (
           <div class="rounded-[var(--radius-md)] bg-theme-surface border border-theme-border p-4 space-y-6">
-            <section class="rounded-[var(--radius-sm)] bg-theme-elevated border border-theme-border-em p-4">
+            <section class="rounded-[var(--radius-sm)] bg-theme-elevated border border-theme-border-em p-4 space-y-4">
+              <h2 class="text-sm font-semibold text-theme-text-primary">Overview</h2>
               <StatsOverview overview={data().overview} />
             </section>
 


### PR DESCRIPTION
**Summary**
This PR resolves an issue with calendar data not refreshing on year changes, improves calendar tooltip styling, and refines the layout of the Statistics page.

**Changes**
*   Fix calendar data not refreshing when the year changes.
*   Improve the styling of calendar tooltips.
*   Add an "Overview" heading to the Statistics page.
*   Add spacing to the Statistics page.

**Impact**
*   `frontend/src/components/ImagingCalendar.tsx`: Affects the `ImagingCalendar` component's data loading logic and tooltip presentation.
*   `frontend/src/pages/StatisticsPage.tsx`: Affects the `StatisticsPage` layout and content structure.