### PR TITLE
Add 24-hour clock setting to display preferences

### DIFF
--- a/backend/app/schemas/settings.py
+++ b/backend/app/schemas/settings.py
@@ -11,6 +11,7 @@ class GeneralSettings(BaseModel):
     theme: str = "glass-void"
     text_size: str = "large"
     timezone: str = "UTC"
+    use_24h_time: bool = False
     astrobin_filter_ids: dict[str, int] = {}
     astrobin_bortle: int | None = None
     content_width: str = "extra-wide"

--- a/frontend/src/components/ActivityFeed.tsx
+++ b/frontend/src/components/ActivityFeed.tsx
@@ -89,7 +89,7 @@ const ActivityFeed: Component<{
   };
 
   const formatTime = (ts: number) =>
-    formatDateTime(new Date(ts * 1000), settingsCtx.timezone()) + " " + timezoneLabel(settingsCtx.timezone());
+    formatDateTime(new Date(ts * 1000), settingsCtx.timezone(), settingsCtx.use24hTime()) + " " + timezoneLabel(settingsCtx.timezone());
 
   return (
     <div class="bg-theme-surface border border-theme-border rounded-[var(--radius-md)] shadow-[var(--shadow-sm)] p-4 flex flex-col h-full min-h-0">

--- a/frontend/src/components/DisplayTab.tsx
+++ b/frontend/src/components/DisplayTab.tsx
@@ -94,11 +94,26 @@ export default function DisplayTab() {
     if (tz) setSelectedTimezone(tz);
   });
 
+  const [use24h, setUse24h] = createSignal(false);
+
+  createEffect(() => {
+    const v = ctx.settings()?.general.use_24h_time;
+    if (v !== undefined) setUse24h(v);
+  });
+
   const handleTimezoneChange = async (tz: string) => {
     setSelectedTimezone(tz);
     const current = ctx.settings()?.general;
     if (current) {
       await ctx.saveGeneral({ ...current, timezone: tz });
+    }
+  };
+
+  const handle24hChange = async (enabled: boolean) => {
+    setUse24h(enabled);
+    const current = ctx.settings()?.general;
+    if (current) {
+      await ctx.saveGeneral({ ...current, use_24h_time: enabled });
     }
   };
 
@@ -295,6 +310,18 @@ export default function DisplayTab() {
             </select>
             <span class="text-xs text-theme-text-tertiary">{timezoneLabel(selectedTimezone())}</span>
           </div>
+        </div>
+        <div class="flex items-center justify-between">
+          <span class="text-sm text-theme-text-secondary">24-hour clock</span>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={use24h()}
+            class={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors ${use24h() ? "bg-theme-accent" : "bg-theme-text-tertiary"}`}
+            onClick={() => handle24hChange(!use24h())}
+          >
+            <span class={`pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow transition-transform ${use24h() ? "translate-x-4" : "translate-x-0"}`} />
+          </button>
         </div>
       </div>
 

--- a/frontend/src/components/SessionAccordionCard.tsx
+++ b/frontend/src/components/SessionAccordionCard.tsx
@@ -302,7 +302,7 @@ const SessionAccordionCard: Component<{
         <For each={sortedFrames(frames)}>
           {(frame) => (
             <tr class={`border-b border-theme-border/30 hover:bg-theme-hover transition-colors duration-100 ${isOutlier(frame, medianHfr, medianEcc) ? "bg-theme-error/20" : ""}`}>
-              <td class="py-1 px-2 text-theme-text-primary">{formatTimeUtil(frame.timestamp, settingsCtx.timezone())}</td>
+              <td class="py-1 px-2 text-theme-text-primary">{formatTimeUtil(frame.timestamp, settingsCtx.timezone(), settingsCtx.use24hTime())}</td>
               <td class="py-1 px-2 text-theme-text-primary text-center">{frame.filter_used ?? "—"}</td>
               <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.exposure_time ?? "—"}s</td>
               <Show when={visible("quality", "hfr")}>
@@ -601,7 +601,7 @@ const SessionAccordionCard: Component<{
                   <span>
                     <span class="text-theme-text-tertiary">Time:</span>{" "}
                     <span class="font-bold text-metric-time">
-                      {detail().first_frame_time ? `${formatTimeUtil(detail().first_frame_time!, settingsCtx.timezone())} → ${detail().last_frame_time ? formatTimeUtil(detail().last_frame_time!, settingsCtx.timezone()) : ""}` : "—"}
+                      {detail().first_frame_time ? `${formatTimeUtil(detail().first_frame_time!, settingsCtx.timezone(), settingsCtx.use24hTime())} → ${detail().last_frame_time ? formatTimeUtil(detail().last_frame_time!, settingsCtx.timezone(), settingsCtx.use24hTime()) : ""}` : "—"}
                     </span>
                   </span>
                 </div>

--- a/frontend/src/components/SessionMetricsChart.tsx
+++ b/frontend/src/components/SessionMetricsChart.tsx
@@ -38,7 +38,7 @@ export default function SessionMetricsChart(props: Props) {
     );
     const labels = allFrames.map((f) => {
       const d = new Date(f.timestamp);
-      return formatTime(d, settingsCtx.timezone());
+      return formatTime(d, settingsCtx.timezone(), settingsCtx.use24hTime());
     });
 
     const datasets: any[] = [];

--- a/frontend/src/components/SettingsProvider.tsx
+++ b/frontend/src/components/SettingsProvider.tsx
@@ -24,6 +24,7 @@ interface SettingsContextValue {
   toggleFilter: (filter: string) => void;
   saveGraphSettings: (updates: Partial<GraphSettings>) => Promise<void>;
   timezone: () => string;
+  use24hTime: () => boolean;
   contentWidth: () => string;
   customColumns: Resource<CustomColumn[] | undefined>;
   refetchCustomColumns: () => void;
@@ -67,6 +68,7 @@ export const SettingsProvider: ParentComponent = (props) => {
     filterAliasMap: () => getFilterAliasMap(store.settings()),
     filterBadgeStyle: () => (store.settings()?.general.filter_style as FilterBadgeStyle) || "text-only",
     timezone: () => store.settings()?.general.timezone ?? "UTC",
+    use24hTime: () => store.settings()?.general.use_24h_time ?? false,
     contentWidth: () => store.settings()?.general.content_width ?? "full",
     saveGeneral: store.saveGeneral,
     saveFilters: store.saveFilters,

--- a/frontend/src/components/TargetMetricsChart.tsx
+++ b/frontend/src/components/TargetMetricsChart.tsx
@@ -127,7 +127,7 @@ export default function TargetMetricsChart(props: Props) {
 
       for (const frame of frames) {
         const d = new Date(frame.timestamp);
-        const timeStr = formatTime(d, settingsCtx.timezone());
+        const timeStr = formatTime(d, settingsCtx.timezone(), settingsCtx.use24hTime());
         labels.push(sortedDates.length > 1 ? `${date.slice(5)} ${timeStr}` : timeStr);
         framesByIndex.push(frame);
       }

--- a/frontend/src/components/settings/GeneralTab.tsx
+++ b/frontend/src/components/settings/GeneralTab.tsx
@@ -26,6 +26,7 @@ export const GeneralTab: Component = () => {
     theme: "default-dark",
     text_size: "medium",
     timezone: "UTC",
+    use_24h_time: false,
     content_width: "full",
   });
   const [saving, setSaving] = createSignal(false);

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -529,6 +529,7 @@ export interface GeneralSettings {
   theme: string;
   text_size: string;
   timezone: string;
+  use_24h_time: boolean;
   astrobin_filter_ids?: Record<string, number>;
   astrobin_bortle?: number | null;
   content_width: string;

--- a/frontend/src/utils/dateTime.ts
+++ b/frontend/src/utils/dateTime.ts
@@ -1,8 +1,8 @@
-/** Short time: "10:32 PM" or "22:32" depending on locale */
-export function formatTime(date: Date | string, timezone: string): string {
+/** Short time: "10:32 PM" or "22:32" when use24h is true */
+export function formatTime(date: Date | string, timezone: string, use24h = false): string {
   const d = typeof date === "string" ? new Date(date) : date;
   if (isNaN(d.getTime())) return typeof date === "string" ? date : "";
-  return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", timeZone: timezone });
+  return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", timeZone: timezone, hour12: !use24h });
 }
 
 /** Short date: "3/31/2026" depending on locale */
@@ -12,11 +12,11 @@ export function formatDate(date: Date | string, timezone: string): string {
   return d.toLocaleDateString([], { timeZone: timezone });
 }
 
-/** Date + time: "3/31/2026, 10:32 PM" */
-export function formatDateTime(date: Date | string, timezone: string): string {
+/** Date + time: "3/31/2026, 10:32 PM" or "3/31/2026, 22:32" when use24h is true */
+export function formatDateTime(date: Date | string, timezone: string, use24h = false): string {
   const d = typeof date === "string" ? new Date(date) : date;
   if (isNaN(d.getTime())) return typeof date === "string" ? date : "";
-  return d.toLocaleString([], { timeZone: timezone, hour: "2-digit", minute: "2-digit" });
+  return d.toLocaleString([], { timeZone: timezone, hour: "2-digit", minute: "2-digit", hour12: !use24h });
 }
 
 /** Human-readable timezone abbreviation for labels: "UTC", "EST", "PST", etc. */


### PR DESCRIPTION
**Summary**
This PR introduces a user-configurable 24-hour clock setting. Users can now toggle between 12-hour and 24-hour time formats within their display preferences, affecting all time displays across the application.

**Changes**
*   Added a 24-hour clock toggle to the `DisplayTab` within user preferences.
*   Updated the backend `settings.py` schema to store the 24-hour clock preference.
*   Integrated the 24-hour clock setting into the `SettingsProvider` for frontend access.
*   Modified `dateTime.ts` utility functions to format times based on the selected 12-hour or 24-hour preference.
*   Updated `ActivityFeed`, `SessionAccordionCard`, `SessionMetricsChart`, and `TargetMetricsChart` components to display times according to the new setting.
*   Added a new type definition for the 24-hour clock setting in `types/index.ts`.

**Impact**
*   **Backend:** `backend/app/schemas/settings.py` is updated.
*   **Frontend:**
    *   **Settings UI:** `frontend/src/components/DisplayTab.tsx` and `frontend/src/components/settings/GeneralTab.tsx`.
    *   **Settings Management:** `frontend/src/components/SettingsProvider.tsx` and `frontend/src/types/index.ts`.
    *   **Date/Time Formatting:** `frontend/src/utils/dateTime.ts`.
    *   **UI Components:** `frontend/src/components/ActivityFeed.tsx`, `frontend/src/components/SessionAccordionCard.tsx`, `frontend/src/components/SessionMetricsChart.tsx`, `frontend/src/components/TargetMetricsChart.tsx`.