### PR TITLE
Implement Session Date and Imaging Night Grouping

### DIFF
--- a/backend/alembic/versions/0009_add_image_session_date.py
+++ b/backend/alembic/versions/0009_add_image_session_date.py
@@ -1,0 +1,39 @@
+"""add image session_date column
+
+Revision ID: 0009
+Revises: 0008_add_composite_indexes_for_performance
+Create Date: 2026-04-13
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0009_add_image_session_date"
+down_revision = "0008_add_composite_indexes_for_performance"
+branch_labels = None
+depends_on = None
+
+
+def _add_column_if_not_exists(table, column_name, column):
+    from sqlalchemy import inspect as sa_inspect
+    bind = op.get_bind()
+    inspector = sa_inspect(bind)
+    columns = [c["name"] for c in inspector.get_columns(table)]
+    if column_name not in columns:
+        op.add_column(table, column)
+
+
+def upgrade():
+    _add_column_if_not_exists(
+        "images", "session_date",
+        sa.Column("session_date", sa.Date(), nullable=True),
+    )
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS ix_images_session_date
+        ON images (session_date)
+    """)
+
+
+def downgrade():
+    op.drop_index("ix_images_session_date", table_name="images")
+    op.drop_column("images", "session_date")

--- a/backend/alembic/versions/0009_add_image_session_date.py
+++ b/backend/alembic/versions/0009_add_image_session_date.py
@@ -8,8 +8,8 @@ from alembic import op
 import sqlalchemy as sa
 
 
-revision = "0009_add_image_session_date"
-down_revision = "0008_add_composite_indexes_for_performance"
+revision = "0009"
+down_revision = "0008"
 branch_labels = None
 depends_on = None
 

--- a/backend/app/api/analysis.py
+++ b/backend/app/api/analysis.py
@@ -1,7 +1,7 @@
 import math
 import statistics
 from collections import defaultdict
-from datetime import datetime
+from datetime import date as date_type, datetime
 
 from fastapi import APIRouter, Depends, Query, HTTPException
 from sqlalchemy import select, func, cast, Date, distinct
@@ -92,9 +92,9 @@ async def _apply_filters(
     if filter_used:
         q = q.where(Image.filter_used == filter_used)
     if date_from:
-        q = q.where(Image.capture_date >= datetime.fromisoformat(date_from))
+        q = q.where(Image.session_date >= date_type.fromisoformat(date_from))
     if date_to:
-        q = q.where(Image.capture_date <= datetime.fromisoformat(date_to + "T23:59:59"))
+        q = q.where(Image.session_date <= date_type.fromisoformat(date_to))
     return q
 
 
@@ -301,7 +301,7 @@ async def get_correlation(
         select(
             x_col.label("x_val"),
             y_col.label("y_val"),
-            cast(Image.capture_date, Date).label("night"),
+            Image.session_date.label("night"),
             Image.resolved_target_id,
         )
         .where(Image.image_type == "LIGHT")
@@ -383,7 +383,7 @@ async def get_distribution(
 
     col = METRIC_MAP[metric]
     q = (
-        select(col.label("val"), cast(Image.capture_date, Date).label("night"), Image.resolved_target_id)
+        select(col.label("val"), Image.session_date.label("night"), Image.resolved_target_id)
         .where(Image.image_type == "LIGHT")
         .where(col.is_not(None))
         .where(Image.capture_date.is_not(None))
@@ -533,7 +533,7 @@ async def get_timeseries(
     q = (
         select(
             col.label("val"),
-            cast(Image.capture_date, Date).label("night"),
+            Image.session_date.label("night"),
             Image.resolved_target_id,
         )
         .where(Image.image_type == "LIGHT")
@@ -669,9 +669,9 @@ async def get_compare(
             .where(Image.capture_date.is_not(None))
         )
         if date_from:
-            q = q.where(Image.capture_date >= datetime.fromisoformat(date_from))
+            q = q.where(Image.session_date >= date_type.fromisoformat(date_from))
         if date_to:
-            q = q.where(Image.capture_date <= datetime.fromisoformat(date_to + "T23:59:59"))
+            q = q.where(Image.session_date <= date_type.fromisoformat(date_to))
 
         if mode == "equipment":
             parts = group.split("|||")

--- a/backend/app/api/mosaics.py
+++ b/backend/app/api/mosaics.py
@@ -63,7 +63,7 @@ async def _panel_stats(panel: MosaicPanel, session: AsyncSession) -> PanelStats:
         select(
             func.sum(Image.exposure_time).label("integration"),
             func.count(Image.id).label("frames"),
-            func.max(cast(Image.capture_date, Date)).label("last_date"),
+            func.max(Image.session_date).label("last_date"),
         )
         .where(*base_filter)
     )
@@ -159,7 +159,7 @@ async def _batch_panel_stats(
             Image.resolved_target_id,
             func.sum(Image.exposure_time).label("integration"),
             func.count(Image.id).label("frames"),
-            func.max(cast(Image.capture_date, Date)).label("last_date"),
+            func.max(Image.session_date).label("last_date"),
         )
         .where(Image.resolved_target_id.in_(target_ids), Image.image_type == "LIGHT")
         .group_by(Image.resolved_target_id)
@@ -309,7 +309,7 @@ async def get_suggestions(
         sq = (
             select(
                 obj_col.label("obj"),
-                cast(Image.capture_date, Date).label("night"),
+                Image.session_date.label("night"),
                 Image.filter_used,
                 func.count(Image.id).label("frames"),
                 func.sum(Image.exposure_time).label("integration"),

--- a/backend/app/api/settings.py
+++ b/backend/app/api/settings.py
@@ -214,13 +214,27 @@ async def update_general(
 ):
     """Update general settings and return the full settings object."""
     row = await _get_or_create_settings(session)
+    old_general = row.general or {}
     row.general = {
-        **(row.general or {}),
+        **old_general,
         **payload.model_dump(),
         "_migrated": True,
     }
     await session.commit()
     await session.refresh(row)
+
+    # Trigger session_date recompute if imaging night setting changed
+    old_night = old_general.get("use_imaging_night", False)
+    new_night = payload.use_imaging_night
+    old_lon = old_general.get("observer_longitude")
+    new_lon = payload.observer_longitude
+    if old_night != new_night or (new_night and old_lon != new_lon):
+        try:
+            from app.worker.tasks import recompute_session_dates
+            recompute_session_dates.delay()
+        except Exception:
+            pass  # Worker may not be available in dev
+
     return _row_to_response(row)
 
 

--- a/backend/app/api/stats.py
+++ b/backend/app/api/stats.py
@@ -169,7 +169,7 @@ async def get_stats(session: AsyncSession = Depends(get_session), user: User = D
     # --- Define parallel query coroutines (each opens its own session) ---
 
     async def _query_overview():
-        capture_date_col = func.cast(Image.capture_date, Date)
+        capture_date_col = Image.session_date
         q = select(
             func.coalesce(func.sum(Image.exposure_time), 0),
             func.count(func.distinct(Image.resolved_target_id)),
@@ -238,12 +238,12 @@ async def get_stats(session: AsyncSession = Depends(get_session), user: User = D
             return (await s.execute(q)).all()
 
     async def _query_timeline_monthly():
-        month_label = func.to_char(Image.capture_date, 'YYYY-MM').label('month')
+        month_label = func.to_char(Image.session_date, 'YYYY-MM').label('month')
         q = select(
             month_label,
             func.coalesce(func.sum(Image.exposure_time), 0),
         ).where(
-            Image.capture_date.isnot(None), Image.image_type == "LIGHT"
+            Image.session_date.isnot(None), Image.image_type == "LIGHT"
         ).group_by(month_label).order_by(month_label)
         async with async_session() as s:
             return (await s.execute(q)).all()
@@ -253,23 +253,23 @@ async def get_stats(session: AsyncSession = Depends(get_session), user: User = D
             return await _extract_site_coords(s)
 
     async def _query_timeline_weekly():
-        week_label = func.to_char(Image.capture_date, 'IYYY-"W"IW').label('week')
+        week_label = func.to_char(Image.session_date, 'IYYY-"W"IW').label('week')
         q = select(
             week_label,
             func.coalesce(func.sum(Image.exposure_time), 0),
         ).where(
-            Image.capture_date.isnot(None), Image.image_type == "LIGHT"
+            Image.session_date.isnot(None), Image.image_type == "LIGHT"
         ).group_by(week_label).order_by(week_label)
         async with async_session() as s:
             return (await s.execute(q)).all()
 
     async def _query_timeline_daily():
-        day_label = func.to_char(Image.capture_date, 'YYYY-MM-DD').label('day')
+        day_label = func.to_char(Image.session_date, 'YYYY-MM-DD').label('day')
         q = select(
             day_label,
             func.coalesce(func.sum(Image.exposure_time), 0),
         ).where(
-            Image.capture_date.isnot(None), Image.image_type == "LIGHT"
+            Image.session_date.isnot(None), Image.image_type == "LIGHT"
         ).group_by(day_label).order_by(day_label)
         async with async_session() as s:
             return (await s.execute(q)).all()
@@ -315,11 +315,11 @@ async def get_stats(session: AsyncSession = Depends(get_session), user: User = D
                 return 0
 
     async def _query_ingest_history():
-        capture_day = func.date(Image.capture_date).label('capture_day')
+        capture_day = Image.session_date.label('capture_day')
         q = select(
             capture_day, func.count(Image.id)
         ).where(
-            Image.capture_date.isnot(None)
+            Image.session_date.isnot(None)
         ).group_by(capture_day).order_by(capture_day.desc()).limit(30)
         async with async_session() as s:
             return (await s.execute(q)).all()
@@ -658,7 +658,7 @@ async def get_calendar(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(get_current_user),
 ):
-    date_col = cast(Image.capture_date, Date)
+    date_col = Image.session_date
     q = (
         select(
             date_col.label("night"),
@@ -667,12 +667,12 @@ async def get_calendar(
             func.count(Image.id).label("frames"),
         )
         .where(Image.image_type == "LIGHT")
-        .where(Image.capture_date.is_not(None))
+        .where(Image.session_date.is_not(None))
         .group_by(date_col)
         .order_by(date_col)
     )
     if year:
-        q = q.where(func.extract("year", Image.capture_date) == year)
+        q = q.where(func.extract("year", Image.session_date) == year)
     else:
         from datetime import datetime, timedelta
         cutoff = datetime.utcnow() - timedelta(days=365)

--- a/backend/app/api/targets.py
+++ b/backend/app/api/targets.py
@@ -495,7 +495,7 @@ async def export_target(
     filter_aliases, _, _ = await load_alias_maps(session)
 
     for img in images:
-        date_key = img.capture_date.strftime("%Y-%m-%d")
+        date_key = str(img.session_date) if img.session_date else "unknown"
         if selected_dates and date_key not in selected_dates:
             continue
         filter_name = img.filter_used or "Unknown"
@@ -655,7 +655,7 @@ async def get_target_detail(
     total_exp = 0.0
 
     for img in images:
-        date_key = img.capture_date.strftime("%Y-%m-%d") if img.capture_date else "unknown"
+        date_key = str(img.session_date) if img.session_date else "unknown"
         sessions_map[date_key].append(img)
         total_exp += img.exposure_time or 0
         if img.median_hfr is not None:
@@ -951,11 +951,11 @@ async def list_targets_aggregated(
         where_parts.append("i.filter_used = ANY(:filter_variants)")
         params["filter_variants"] = all_filter_variants
     if date_from:
-        where_parts.append("i.capture_date >= :date_from")
+        where_parts.append("i.session_date >= :date_from")
         params["date_from"] = datetime.strptime(date_from, "%Y-%m-%d").date()
     if date_to:
-        where_parts.append("i.capture_date <= :date_to")
-        params["date_to"] = datetime.strptime(date_to, "%Y-%m-%d").date() + timedelta(days=1)
+        where_parts.append("i.session_date <= :date_to")
+        params["date_to"] = datetime.strptime(date_to, "%Y-%m-%d").date()
     if target_id:
         where_parts.append("i.resolved_target_id = CAST(:exact_target_id AS uuid)")
         params["exact_target_id"] = target_id
@@ -1077,10 +1077,10 @@ async def list_targets_aggregated(
                coalesce(min(t.primary_name), min(i.raw_headers->>'OBJECT'), 'Uncategorized') AS primary_name,
                sum(coalesce(i.exposure_time, 0)) AS total_integration,
                count(i.id) AS total_frames,
-               count(distinct CAST(i.capture_date AS DATE)) AS session_count,
-               max(CAST(i.capture_date AS DATE)) AS last_session_date,
-               min(CAST(i.capture_date AS DATE)) AS oldest_date,
-               max(CAST(i.capture_date AS DATE)) AS newest_date
+               count(distinct i.session_date) AS session_count,
+               max(i.session_date) AS last_session_date,
+               min(i.session_date) AS oldest_date,
+               max(i.session_date) AS newest_date
         FROM images i LEFT JOIN targets t ON i.resolved_target_id = t.id
         WHERE {where_sql}
         GROUP BY {gk}
@@ -1174,7 +1174,7 @@ async def list_targets_aggregated(
     detail_sql = text(f"""
         SELECT CAST(i.resolved_target_id AS VARCHAR) AS target_uuid,
                i.raw_headers->>'OBJECT' AS fits_object,
-               i.exposure_time, i.filter_used, i.camera, i.telescope, i.capture_date
+               i.exposure_time, i.filter_used, i.camera, i.telescope, i.capture_date, i.session_date
         FROM images i LEFT JOIN targets t ON i.resolved_target_id = t.id
         WHERE {where_sql} AND {key_filter}
     """)
@@ -1215,7 +1215,7 @@ async def list_targets_aggregated(
         if row.fits_object:
             aliases_map[tk].add(row.fits_object)
 
-        date_key = row.capture_date.strftime("%Y-%m-%d") if row.capture_date else "unknown"
+        date_key = str(row.session_date) if row.session_date else "unknown"
         if date_key not in sessions_detail[tk]:
             sessions_detail[tk][date_key] = {
                 "session_date": date_key,
@@ -1462,15 +1462,9 @@ async def get_session_detail(
     """Return detailed session data for a target on a specific date.
 
     The date string is interpreted as a UTC calendar day to match the
-    listing endpoint, which groups by `capture_date.strftime("%Y-%m-%d")`
-    against the tz-aware (UTC) column value. Passing a naive datetime to
-    a `timestamptz` comparison would make Postgres coerce it via the
-    session TimeZone, which shifts the window at the midnight boundary
-    and returns zero rows for sessions the listing placed on the other
-    side of UTC midnight.
+    listing endpoint, which groups by `session_date`.
     """
-    day_start = datetime.fromisoformat(date).replace(tzinfo=timezone.utc)
-    day_end = day_start + timedelta(days=1)
+    session_date_val = date_type.fromisoformat(date)
     if target_id == "obj:__uncategorized__":
         target_name = "Uncategorized"
         target_obj = None
@@ -1484,8 +1478,7 @@ async def get_session_detail(
             .where(
                 Image.resolved_target_id.is_(None),
                 _no_object,
-                Image.capture_date >= day_start,
-                Image.capture_date < day_end,
+                Image.session_date == session_date_val,
             )
             .order_by(Image.capture_date)
         )
@@ -1502,8 +1495,7 @@ async def get_session_detail(
             select(Image)
             .where(
                 Image.raw_headers["OBJECT"].astext == object_name,
-                Image.capture_date >= day_start,
-                Image.capture_date < day_end,
+                Image.session_date == session_date_val,
                 Image.image_type == "LIGHT",
             )
             .order_by(Image.capture_date)
@@ -1526,8 +1518,7 @@ async def get_session_detail(
             select(Image)
             .where(
                 Image.resolved_target_id == tid,
-                Image.capture_date >= day_start,
-                Image.capture_date < day_end,
+                Image.session_date == session_date_val,
                 Image.image_type == "LIGHT",
             )
             .order_by(Image.capture_date)
@@ -1660,7 +1651,7 @@ async def get_session_detail(
     if median_hfr is not None:
         # Query HFR data across all sessions for this target
         if target_id == "obj:__uncategorized__":
-            all_hfr_q = select(Image.capture_date, Image.median_hfr).where(
+            all_hfr_q = select(Image.session_date, Image.median_hfr).where(
                 Image.resolved_target_id.is_(None),
                 or_(
                     ~Image.raw_headers.has_key("OBJECT"),
@@ -1670,23 +1661,22 @@ async def get_session_detail(
                 Image.median_hfr.isnot(None),
             )
         elif target_id.startswith("obj:"):
-            all_hfr_q = select(Image.capture_date, Image.median_hfr).where(
+            all_hfr_q = select(Image.session_date, Image.median_hfr).where(
                 Image.raw_headers["OBJECT"].astext == target_id[4:],
                 Image.image_type == "LIGHT",
                 Image.median_hfr.isnot(None),
             )
         else:
-            all_hfr_q = select(Image.capture_date, Image.median_hfr).where(
+            all_hfr_q = select(Image.session_date, Image.median_hfr).where(
                 Image.resolved_target_id == tid,
                 Image.image_type == "LIGHT",
                 Image.median_hfr.isnot(None),
             )
         all_hfr_rows = (await session.execute(all_hfr_q)).all()
         all_session_dates: dict[str, list[float]] = defaultdict(list)
-        for capture_date, hfr_val in all_hfr_rows:
-            if capture_date:
-                dk = capture_date.strftime("%Y-%m-%d")
-                all_session_dates[dk].append(hfr_val)
+        for session_date_val, hfr_val in all_hfr_rows:
+            if session_date_val:
+                all_session_dates[str(session_date_val)].append(hfr_val)
         all_session_medians = [statistics.median(v) for v in all_session_dates.values() if v]
         if all_session_medians:
             is_best_hfr = median_hfr <= min(all_session_medians)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -65,6 +65,24 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.warning("Failed to dispatch dark hours backfill: %s", e)
 
+    # Backfill session_date for any images that don't have one yet
+    try:
+        from sqlalchemy import select, func as sa_func
+        from app.models import Image
+        async with async_session() as db:
+            null_count = (await db.execute(
+                select(sa_func.count(Image.id)).where(
+                    Image.capture_date.isnot(None),
+                    Image.session_date.is_(None),
+                )
+            )).scalar_one()
+            if null_count > 0:
+                from app.worker.tasks import recompute_session_dates
+                recompute_session_dates.apply_async(countdown=10)
+                logger.info("Queued session_date backfill for %d images", null_count)
+    except Exception as e:
+        logger.warning("Failed to check/dispatch session_date backfill: %s", e)
+
     # Start queue depth probe in the uvicorn process so gauges are visible
     # at the /metrics endpoint (worker and uvicorn have separate registries)
     from app.metrics import start_queue_depth_probe, register_celery_collector

--- a/backend/app/models/image.py
+++ b/backend/app/models/image.py
@@ -1,7 +1,7 @@
 import uuid
-from datetime import datetime
+from datetime import date, datetime
 
-from sqlalchemy import String, Float, Integer, BigInteger, DateTime, ForeignKey, Index
+from sqlalchemy import String, Float, Integer, BigInteger, Date, DateTime, ForeignKey, Index
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -15,6 +15,7 @@ class Image(Base):
     file_path: Mapped[str] = mapped_column(String(1024), nullable=False, unique=True)
     file_name: Mapped[str] = mapped_column(String(255), nullable=False)
     capture_date: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    session_date: Mapped[date | None] = mapped_column(Date, nullable=True)
     thumbnail_path: Mapped[str | None] = mapped_column(String(1024), nullable=True)
     resolved_target_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("targets.id"), nullable=True
@@ -84,6 +85,7 @@ class Image(Base):
 
     __table_args__ = (
         Index("ix_images_capture_date", "capture_date"),
+        Index("ix_images_session_date", "session_date"),
         Index("ix_images_filter_used", "filter_used"),
         Index("ix_images_resolved_target_id", "resolved_target_id"),
         Index("ix_images_image_type", "image_type"),

--- a/backend/app/schemas/settings.py
+++ b/backend/app/schemas/settings.py
@@ -20,6 +20,7 @@ class GeneralSettings(BaseModel):
     observer_latitude: float | None = None
     observer_longitude: float | None = None
     observer_name: str | None = None
+    use_imaging_night: bool = False
 
 
 class FilterConfig(BaseModel):

--- a/backend/app/schemas/settings.py
+++ b/backend/app/schemas/settings.py
@@ -20,7 +20,7 @@ class GeneralSettings(BaseModel):
     observer_latitude: float | None = None
     observer_longitude: float | None = None
     observer_name: str | None = None
-    use_imaging_night: bool = False
+    use_imaging_night: bool = True
 
 
 class FilterConfig(BaseModel):

--- a/backend/app/services/mosaic_detection.py
+++ b/backend/app/services/mosaic_detection.py
@@ -122,7 +122,7 @@ async def detect_mosaic_panels(session: AsyncSession, gap_days: int = 0) -> int:
                 # Build a pattern that matches the original name used for this panel
                 obj_pattern = f"%{base_name}%{panel_num}%"
                 dates_q = select(
-                    func.distinct(cast(Image.capture_date, Date))
+                    func.distinct(Image.session_date)
                 ).where(
                     Image.image_type == "LIGHT",
                     Image.raw_headers["OBJECT"].astext.ilike(obj_pattern),

--- a/backend/app/services/session_date.py
+++ b/backend/app/services/session_date.py
@@ -1,0 +1,47 @@
+"""Session date computation for imaging night grouping.
+
+When 'imaging night' mode is enabled, sessions are grouped by local solar noon
+rather than UTC midnight. This keeps nighttime imaging runs that cross midnight
+together as a single session.
+
+The local solar noon for a given longitude is approximately:
+    solar_noon_utc = 12:00 - (longitude / 15) hours
+
+Subtracting this offset from the UTC capture time and taking .date() yields
+the session date: frames captured between one solar noon and the next all
+share the same session date.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+
+
+_LONGITUDE_KEYS = ("SITELONG", "OBSLONG", "LONG-OBS")
+
+
+def compute_session_date(
+    capture_date: datetime | None,
+    *,
+    use_imaging_night: bool = False,
+    longitude: float | None = None,
+) -> date | None:
+    if capture_date is None:
+        return None
+    if not use_imaging_night or longitude is None:
+        return capture_date.date()
+    offset_hours = 12.0 - longitude / 15.0
+    shifted = capture_date - timedelta(hours=offset_hours)
+    return shifted.date()
+
+
+def extract_longitude(raw_headers: dict | None) -> float | None:
+    if not raw_headers:
+        return None
+    for key in _LONGITUDE_KEYS:
+        val = raw_headers.get(key)
+        if val is not None:
+            try:
+                return float(val)
+            except (ValueError, TypeError):
+                continue
+    return None

--- a/backend/app/worker/tasks.py
+++ b/backend/app/worker/tasks.py
@@ -19,6 +19,8 @@ from app.services.simbad import (
 from app.services.target_resolver import resolve_target, normalize_sql_expr
 from app.services.thumbnail import generate_thumbnail
 from app.services.xisf_parser import extract_xisf_metadata, generate_xisf_thumbnail
+from app.services.session_date import compute_session_date, extract_longitude
+from app.schemas.settings import GeneralSettings
 from app.worker.celery_app import celery_app
 
 logger = logging.getLogger(__name__)
@@ -353,6 +355,22 @@ def _do_ingest(fits_path: str, include_calibration: bool = True) -> dict:
         file_size = None
         file_mtime = None
 
+    # Compute session_date from capture_date + longitude
+    raw_hdrs = meta.get("raw_headers", {})
+    site_lon = extract_longitude(raw_hdrs)
+
+    # Load imaging night setting (cached per-process via module-level settings row)
+    with Session(_sync_engine) as settings_session:
+        settings_row = settings_session.get(UserSettings, SETTINGS_ROW_ID)
+        general = GeneralSettings(**(settings_row.general if settings_row and settings_row.general else {}))
+
+    effective_lon = site_lon if site_lon is not None else general.observer_longitude
+    session_date_val = compute_session_date(
+        meta.get("capture_date"),
+        use_imaging_night=general.use_imaging_night,
+        longitude=effective_lon,
+    )
+
     try:
         with Session(_sync_engine) as session:
             image = Image(
@@ -361,6 +379,7 @@ def _do_ingest(fits_path: str, include_calibration: bool = True) -> dict:
                 file_size=file_size,
                 file_mtime=file_mtime,
                 capture_date=meta.get("capture_date"),
+                session_date=session_date_val,
                 thumbnail_path=str(thumb_path) if thumb_path else None,
                 resolved_target_id=target_id,
                 exposure_time=meta.get("exposure_time"),

--- a/backend/app/worker/tasks.py
+++ b/backend/app/worker/tasks.py
@@ -1,9 +1,10 @@
 import logging
 import time
+from datetime import datetime
 from pathlib import Path
 
 import fitsio
-from sqlalchemy import create_engine, select, text, update as sa_update
+from sqlalchemy import create_engine, func, select, text, update as sa_update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -1290,9 +1291,9 @@ def backfill_dark_hours() -> dict:
             existing_dates = {row[0] for row in session.execute(existing_q).all()}
 
             all_dates_q = select(
-                text("DISTINCT capture_date::date")
-            ).select_from(Image.__table__).where(
-                Image.capture_date.isnot(None),
+                func.distinct(Image.session_date)
+            ).where(
+                Image.session_date.isnot(None),
                 Image.image_type == "LIGHT",
             )
             all_imaging_dates = {row[0] for row in session.execute(all_dates_q).all()}
@@ -1549,3 +1550,120 @@ def run_xmatch_enrichment(self) -> dict:
         "timestamp": time.time(),
     })
     return stats
+
+
+@celery_app.task(name="recompute_session_dates", bind=True)
+def recompute_session_dates(self):
+    """Recompute session_date for all images and re-key session notes/custom values."""
+    from collections import Counter
+    from datetime import date as date_type, timedelta
+    from app.models.session_note import SessionNote
+    from app.models.custom_column import CustomColumnValue
+
+    with Session(_sync_engine) as session:
+        # Load settings
+        settings_row = session.get(UserSettings, SETTINGS_ROW_ID)
+        general = GeneralSettings(**(settings_row.general if settings_row and settings_row.general else {}))
+        fallback_lon = general.observer_longitude
+        use_night = general.use_imaging_night
+
+        # Phase 1: Recompute all image session_dates in batches
+        BATCH = 5000
+        offset = 0
+        total = 0
+        while True:
+            rows = session.execute(
+                select(Image.id, Image.capture_date, Image.raw_headers)
+                .where(Image.capture_date.isnot(None))
+                .order_by(Image.id)
+                .offset(offset)
+                .limit(BATCH)
+            ).all()
+            if not rows:
+                break
+
+            for img_id, capture_date, raw_headers in rows:
+                site_lon = extract_longitude(raw_headers)
+                effective_lon = site_lon if site_lon is not None else fallback_lon
+                new_date = compute_session_date(
+                    capture_date,
+                    use_imaging_night=use_night,
+                    longitude=effective_lon,
+                )
+                session.execute(
+                    sa_update(Image)
+                    .where(Image.id == img_id)
+                    .values(session_date=new_date)
+                )
+
+            session.commit()
+            total += len(rows)
+            offset += BATCH
+            self.update_state(state="PROGRESS", meta={"images_updated": total})
+
+        # Phase 2: Re-key SessionNote rows
+        notes = session.execute(select(SessionNote)).scalars().all()
+        for note in notes:
+            old_date = note.session_date
+            window_start = datetime.combine(old_date - timedelta(days=1), datetime.min.time())
+            window_end = datetime.combine(old_date + timedelta(days=2), datetime.min.time())
+            img_dates = session.execute(
+                select(Image.session_date)
+                .where(
+                    Image.resolved_target_id == note.target_id,
+                    Image.capture_date >= window_start,
+                    Image.capture_date < window_end,
+                    Image.session_date.isnot(None),
+                )
+            ).scalars().all()
+            if img_dates:
+                most_common = Counter(img_dates).most_common(1)[0][0]
+                if most_common != note.session_date:
+                    existing = session.execute(
+                        select(SessionNote.id).where(
+                            SessionNote.target_id == note.target_id,
+                            SessionNote.session_date == most_common,
+                            SessionNote.id != note.id,
+                        )
+                    ).scalar_one_or_none()
+                    if existing is None:
+                        note.session_date = most_common
+
+        session.commit()
+
+        # Phase 3: Re-key CustomColumnValue rows
+        cvs = session.execute(
+            select(CustomColumnValue).where(CustomColumnValue.session_date.isnot(None))
+        ).scalars().all()
+        for cv in cvs:
+            old_date = cv.session_date
+            window_start = datetime.combine(old_date - timedelta(days=1), datetime.min.time())
+            window_end = datetime.combine(old_date + timedelta(days=2), datetime.min.time())
+            img_dates = session.execute(
+                select(Image.session_date)
+                .where(
+                    Image.resolved_target_id == cv.target_id,
+                    Image.capture_date >= window_start,
+                    Image.capture_date < window_end,
+                    Image.session_date.isnot(None),
+                )
+            ).scalars().all()
+            if img_dates:
+                from sqlalchemy import func
+                most_common = Counter(img_dates).most_common(1)[0][0]
+                if most_common != cv.session_date:
+                    existing = session.execute(
+                        select(CustomColumnValue.id).where(
+                            CustomColumnValue.column_id == cv.column_id,
+                            CustomColumnValue.target_id == cv.target_id,
+                            func.coalesce(CustomColumnValue.session_date, date_type(1970, 1, 1)) == most_common,
+                            CustomColumnValue.id != cv.id,
+                        )
+                    ).scalar_one_or_none()
+                    if existing is None:
+                        cv.session_date = most_common
+
+        session.commit()
+
+        logger.info("recompute_session_dates: updated %d images", total)
+        return {"status": "done", "images_updated": total}

--- a/backend/tests/test_session_date.py
+++ b/backend/tests/test_session_date.py
@@ -1,0 +1,106 @@
+from datetime import datetime, date, timezone
+from app.services.session_date import compute_session_date
+
+
+class TestComputeSessionDate:
+    """Test session date computation with longitude-based noon boundary."""
+
+    def test_disabled_returns_utc_date(self):
+        dt = datetime(2024, 11, 16, 2, 0, tzinfo=timezone.utc)
+        result = compute_session_date(dt, use_imaging_night=False)
+        assert result == date(2024, 11, 16)
+
+    def test_no_longitude_returns_utc_date(self):
+        dt = datetime(2024, 11, 16, 2, 0, tzinfo=timezone.utc)
+        result = compute_session_date(dt, use_imaging_night=True, longitude=None)
+        assert result == date(2024, 11, 16)
+
+    def test_us_central_before_midnight(self):
+        """US Central observer (lon=-97), imaging at 9PM local = 03:00 UTC next day.
+        Solar noon UTC ~ 12 - (-97/15) = 12 + 6.47 = 18:28 UTC.
+        03:00 UTC < 18:28 UTC => session_date = previous day."""
+        dt = datetime(2024, 11, 16, 3, 0, tzinfo=timezone.utc)
+        result = compute_session_date(dt, use_imaging_night=True, longitude=-97.0)
+        assert result == date(2024, 11, 15)
+
+    def test_us_central_after_midnight_same_session(self):
+        dt = datetime(2024, 11, 16, 10, 0, tzinfo=timezone.utc)
+        result = compute_session_date(dt, use_imaging_night=True, longitude=-97.0)
+        assert result == date(2024, 11, 15)
+
+    def test_us_central_afternoon_next_session(self):
+        dt = datetime(2024, 11, 16, 21, 0, tzinfo=timezone.utc)
+        result = compute_session_date(dt, use_imaging_night=True, longitude=-97.0)
+        assert result == date(2024, 11, 16)
+
+    def test_australia_sydney_before_midnight(self):
+        """Sydney (lon=151), 9PM local = 11:00 UTC. Solar noon UTC ~ 01:53.
+        11:00 > 01:53 => current day."""
+        dt = datetime(2024, 11, 15, 11, 0, tzinfo=timezone.utc)
+        result = compute_session_date(dt, use_imaging_night=True, longitude=151.0)
+        assert result == date(2024, 11, 15)
+
+    def test_australia_sydney_after_midnight(self):
+        dt = datetime(2024, 11, 15, 17, 0, tzinfo=timezone.utc)
+        result = compute_session_date(dt, use_imaging_night=True, longitude=151.0)
+        assert result == date(2024, 11, 15)
+
+    def test_australia_sydney_after_local_midnight_crosses_utc_day(self):
+        dt = datetime(2024, 11, 15, 15, 0, tzinfo=timezone.utc)
+        result = compute_session_date(dt, use_imaging_night=True, longitude=151.0)
+        assert result == date(2024, 11, 15)
+
+    def test_greenwich_matches_utc_noon(self):
+        dt = datetime(2024, 6, 15, 1, 0, tzinfo=timezone.utc)
+        result = compute_session_date(dt, use_imaging_night=True, longitude=0.0)
+        assert result == date(2024, 6, 14)
+
+    def test_greenwich_afternoon(self):
+        dt = datetime(2024, 6, 15, 13, 0, tzinfo=timezone.utc)
+        result = compute_session_date(dt, use_imaging_night=True, longitude=0.0)
+        assert result == date(2024, 6, 15)
+
+    def test_naive_datetime_treated_as_utc(self):
+        dt = datetime(2024, 11, 16, 3, 0)
+        result = compute_session_date(dt, use_imaging_night=True, longitude=-97.0)
+        assert result == date(2024, 11, 15)
+
+    def test_none_capture_date_returns_none(self):
+        result = compute_session_date(None, use_imaging_night=True, longitude=-97.0)
+        assert result is None
+
+
+class TestExtractLongitude:
+    def test_sitelong_header(self):
+        from app.services.session_date import extract_longitude
+        headers = {"SITELONG": "-97.5"}
+        assert extract_longitude(headers) == -97.5
+
+    def test_obslong_header(self):
+        from app.services.session_date import extract_longitude
+        headers = {"OBSLONG": "151.2"}
+        assert extract_longitude(headers) == 151.2
+
+    def test_long_obs_header(self):
+        from app.services.session_date import extract_longitude
+        headers = {"LONG-OBS": "2.3"}
+        assert extract_longitude(headers) == 2.3
+
+    def test_priority_order(self):
+        from app.services.session_date import extract_longitude
+        headers = {"SITELONG": "-97.5", "OBSLONG": "151.2"}
+        assert extract_longitude(headers) == -97.5
+
+    def test_no_longitude_returns_none(self):
+        from app.services.session_date import extract_longitude
+        headers = {"OBJECT": "M31"}
+        assert extract_longitude(headers) is None
+
+    def test_non_numeric_returns_none(self):
+        from app.services.session_date import extract_longitude
+        headers = {"SITELONG": "bad"}
+        assert extract_longitude(headers) is None
+
+    def test_none_headers_returns_none(self):
+        from app.services.session_date import extract_longitude
+        assert extract_longitude(None) is None

--- a/frontend/src/components/DisplayTab.tsx
+++ b/frontend/src/components/DisplayTab.tsx
@@ -101,6 +101,13 @@ export default function DisplayTab() {
     if (v !== undefined) setUse24h(v);
   });
 
+  const [useImagingNight, setUseImagingNight] = createSignal(false);
+
+  createEffect(() => {
+    const v = ctx.settings()?.general.use_imaging_night;
+    if (v !== undefined) setUseImagingNight(v);
+  });
+
   const handleTimezoneChange = async (tz: string) => {
     setSelectedTimezone(tz);
     const current = ctx.settings()?.general;
@@ -114,6 +121,20 @@ export default function DisplayTab() {
     const current = ctx.settings()?.general;
     if (current) {
       await ctx.saveGeneral({ ...current, use_24h_time: enabled });
+    }
+  };
+
+  const handleImagingNightChange = async (enabled: boolean) => {
+    setUseImagingNight(enabled);
+    const current = ctx.settings()?.general;
+    if (current) {
+      await ctx.saveGeneral({ ...current, use_imaging_night: enabled });
+      showToast(
+        enabled
+          ? "Imaging night grouping enabled. Sessions are being recomputed..."
+          : "Imaging night grouping disabled. Sessions are being recomputed...",
+        "info"
+      );
     }
   };
 
@@ -321,6 +342,24 @@ export default function DisplayTab() {
             onClick={() => handle24hChange(!use24h())}
           >
             <span class={`pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow transition-transform ${use24h() ? "translate-x-4" : "translate-x-0"}`} />
+          </button>
+        </div>
+        <div class="flex items-center justify-between">
+          <div>
+            <span class="text-sm text-theme-text-secondary">Imaging night grouping</span>
+            <p class="text-xs text-theme-text-tertiary mt-0.5">
+              Group sessions by local solar noon instead of UTC midnight.
+              Uses SITELONG from FITS headers, falls back to observer longitude.
+            </p>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={useImagingNight()}
+            class={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors ${useImagingNight() ? "bg-theme-accent" : "bg-theme-text-tertiary"}`}
+            onClick={() => handleImagingNightChange(!useImagingNight())}
+          >
+            <span class={`pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow transition-transform ${useImagingNight() ? "translate-x-4" : "translate-x-0"}`} />
           </button>
         </div>
       </div>

--- a/frontend/src/components/DisplayTab.tsx
+++ b/frontend/src/components/DisplayTab.tsx
@@ -348,8 +348,9 @@ export default function DisplayTab() {
           <div>
             <span class="text-sm text-theme-text-secondary">Imaging night grouping</span>
             <p class="text-xs text-theme-text-tertiary mt-0.5">
-              Group sessions by local solar noon instead of UTC midnight.
-              Uses SITELONG from FITS headers, falls back to observer longitude.
+              Keep a full night of imaging together as one session, even when
+              it crosses midnight. Uses your location from FITS headers to
+              determine the boundary.
             </p>
           </div>
           <button

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -538,6 +538,7 @@ export interface GeneralSettings {
   observer_latitude?: number | null;
   observer_longitude?: number | null;
   observer_name?: string | null;
+  use_imaging_night?: boolean;
 }
 
 export interface FilterConfig {


### PR DESCRIPTION
**Summary**
This PR introduces `session_date` to replace `capture_date` for grouping images, defining an "imaging night" based on a longitude-based noon boundary. It includes database schema updates, new computation logic, background tasks, and a user-facing toggle.

**Changes**
*   Added `session_date` column to the `images` table, including an index and a database migration.
*   Introduced a dedicated module for `session_date` computation, defining the boundary using longitude-based noon.
*   Integrated `session_date` computation into the image ingestion process.
*   Updated `analysis.py`, `mosaics.py`, `targets.py`, and `stats.py` to use `session_date` instead of `capture_date` for all derivations.
*   Added a user interface toggle in display settings to enable or disable `imaging night` grouping.
*   Set `use_imaging_night` to `true` by default for new installations.
*   Improved the clarity of the `imaging night` toggle description.
*   Implemented a background task to recompute `session_date` values, triggered by settings changes and performing a backfill on application startup.
*   Corrected the `down_revision` value in the `0009_add_image_session_date.py` migration script.

**Impact**
*   **Database:** `images` table schema, migration scripts.
*   **Backend Services:** Image ingestion, `session_date` computation logic, background worker tasks.
*   **API Endpoints:** `analysis`, `mosaics`, `stats`, `targets`, and `settings` APIs.
*   **Frontend:** Display settings user interface.
*   **Configuration:** Default settings for new installations.