### PR TITLE
Add cancellation for rebuild and thumbnail tasks

### DIFF
--- a/backend/app/api/scan.py
+++ b/backend/app/api/scan.py
@@ -136,13 +136,16 @@ async def scan_status(user: User = Depends(get_current_user)):
 
 @router.post("/stop")
 async def stop_scan(user: User = Depends(require_admin)):
-    """Request cancellation of the current scan."""
+    """Request cancellation of the current scan or rebuild-family task."""
     async with async_redis() as r:
         state = await get_scan_state(r)
-        if state.state not in ("scanning", "ingesting"):
+        rebuild = await get_rebuild_state(r)
+        scan_active = state.state in ("scanning", "ingesting")
+        rebuild_active = rebuild.state == "running"
+        if not scan_active and not rebuild_active:
             return {"status": "not_running", "state": state.state}
         await request_cancel(r)
-        return {"status": "stopping", "message": "Cancel requested - scan will stop shortly"}
+        return {"status": "stopping", "message": "Cancel requested - task will stop shortly"}
 
 
 @router.get("/activity")

--- a/backend/app/services/scan_state.py
+++ b/backend/app/services/scan_state.py
@@ -394,3 +394,19 @@ def set_rebuild_complete_sync(r: sync_redis.Redis, message: str, details: dict) 
         "details": json.dumps(details),
     })
     r.expire(REBUILD_KEY, REBUILD_EXPIRE)
+
+
+def set_rebuild_cancelled_sync(
+    r: sync_redis.Redis,
+    message: str = "Cancelled by user",
+    details: dict | None = None,
+) -> None:
+    import json
+    r.hset(REBUILD_KEY, mapping={
+        "state": "cancelled",
+        "message": message,
+        "completed_at": time.time(),
+        "details": json.dumps(details or {}),
+    })
+    r.expire(REBUILD_KEY, EXPIRE_AFTER_COMPLETE)
+    clear_cancel_sync(r)

--- a/backend/app/worker/tasks.py
+++ b/backend/app/worker/tasks.py
@@ -37,6 +37,7 @@ from app.services.scan_state import (
     increment_skipped_calibration_sync,
     start_scanning_sync, set_ingesting_sync, set_idle_sync,
     set_rebuild_running_sync, set_rebuild_progress_sync, set_rebuild_complete_sync,
+    set_rebuild_cancelled_sync,
     set_discovered_sync, is_cancel_requested_sync, clear_cancel_sync, set_cancelled_sync,
     append_activity_sync, check_complete_sync,
     add_skipped_path_sync, get_skipped_paths_sync, clear_skipped_paths_sync,
@@ -591,6 +592,16 @@ def purge_and_regenerate_thumbnails() -> dict:
         })
         return {"status": "complete", "deleted": 0, "queued": 0}
 
+    if is_cancel_requested_sync(_redis):
+        set_cancelled_sync(_redis)
+        append_activity_sync(_redis, {
+            "type": "rebuild_cancelled",
+            "message": "Thumbnail purge cancelled before start",
+            "details": {"deleted": 0, "queued": 0, "total": total},
+            "timestamp": time.time(),
+        })
+        return {"status": "cancelled", "deleted": 0, "queued": 0}
+
     append_activity_sync(_redis, {
         "type": "thumb_purge_start",
         "message": f"Deleting existing thumbnails for {total} image{'s' if total != 1 else ''}...",
@@ -642,6 +653,16 @@ def purge_and_regenerate_thumbnails() -> dict:
         "timestamp": time.time(),
     })
 
+    if is_cancel_requested_sync(_redis):
+        set_cancelled_sync(_redis)
+        append_activity_sync(_redis, {
+            "type": "rebuild_cancelled",
+            "message": f"Thumbnail purge cancelled after deleting {deleted} files; regen skipped",
+            "details": {"deleted": deleted, "missing": missing, "queued": 0, "total": total},
+            "timestamp": time.time(),
+        })
+        return {"status": "cancelled", "deleted": deleted, "missing": missing, "queued": 0}
+
     set_ingesting_sync(_redis, total=total)
 
     queued = 0
@@ -658,6 +679,12 @@ def regenerate_thumbnail(self, image_id: str, fits_path: str, thumb_path: str) -
     """Regenerate a single thumbnail using the current stretch algorithm."""
     path = Path(fits_path)
     output = Path(thumb_path)
+
+    # Drain queued tasks on cancel so scan state transitions to complete via check_complete_sync.
+    if is_cancel_requested_sync(_redis):
+        increment_completed_sync(_redis)
+        return {"file": str(path), "status": "cancelled"}
+
     logger.info("Regenerating thumbnail: %s", path.name)
 
     try:
@@ -832,6 +859,8 @@ def rebuild_targets(self) -> dict:
     6. Re-link images to new targets
     """
     logger.info("rebuild_targets: starting full rebuild")
+    # Clear a sticky cancel flag from a prior run so this run isn't killed immediately.
+    clear_cancel_sync(_redis)
     set_rebuild_running_sync(_redis, "full", "Clearing existing targets...")
 
     # Phase 1: Clear everything
@@ -866,6 +895,22 @@ def rebuild_targets(self) -> dict:
 
     # Phase 3: Resolve each and link images
     for i, (obj_name, img_count) in enumerate(object_names):
+        if is_cancel_requested_sync(_redis):
+            details = {"resolved": resolved, "failed": failed, "total": total, "processed": i}
+            set_rebuild_cancelled_sync(
+                _redis,
+                f"Cancelled after {i}/{total} names ({resolved} resolved, {failed} failed)",
+                details,
+            )
+            append_activity_sync(_redis, {
+                "type": "rebuild_cancelled",
+                "message": f"Full Rebuild cancelled after {i}/{total} names",
+                "details": details,
+                "timestamp": time.time(),
+            })
+            logger.info("rebuild_targets: cancelled after %d/%d", i, total)
+            return {"status": "cancelled", **details}
+
         with Session(_sync_engine) as session:
             target_id = resolve_target(obj_name, session, redis=_redis)
 
@@ -917,6 +962,7 @@ def retry_unresolved(self) -> dict:
     Useful after adding SESAME fallback or when upstream resolvers have new data.
     """
     logger.info("retry_unresolved: starting")
+    clear_cancel_sync(_redis)
     set_rebuild_running_sync(_redis, "retry", "Clearing caches...")
 
     # Phase 1: Clear negative caches so names get a fresh shot
@@ -950,6 +996,22 @@ def retry_unresolved(self) -> dict:
 
     # Phase 3: Resolve each and link images
     for i, (obj_name, img_count) in enumerate(object_names):
+        if is_cancel_requested_sync(_redis):
+            details = {"resolved": resolved, "failed": failed, "total": total, "processed": i}
+            set_rebuild_cancelled_sync(
+                _redis,
+                f"Cancelled after {i}/{total} names ({resolved} resolved, {failed} still unresolved)",
+                details,
+            )
+            append_activity_sync(_redis, {
+                "type": "rebuild_cancelled",
+                "message": f"Retry Unresolved cancelled after {i}/{total} names",
+                "details": details,
+                "timestamp": time.time(),
+            })
+            logger.info("retry_unresolved: cancelled after %d/%d", i, total)
+            return {"status": "cancelled", **details}
+
         with Session(_sync_engine) as session:
             target_id = resolve_target(obj_name, session, redis=_redis)
 
@@ -1016,8 +1078,25 @@ def smart_rebuild_targets(self, manual: bool = False) -> dict:
 
 def _smart_rebuild_inner(manual: bool = False) -> dict:
     logger.info("smart_rebuild: starting")
+    clear_cancel_sync(_redis)
     set_rebuild_running_sync(_redis, "smart", "Running quick fix...")
     stats = {}
+
+    def _emit_cancelled(extra: dict | None = None) -> dict:
+        details = {**stats, **(extra or {})}
+        set_rebuild_cancelled_sync(_redis, "Quick Fix cancelled", details)
+        if manual:
+            append_activity_sync(_redis, {
+                "type": "rebuild_cancelled",
+                "message": "Quick Fix cancelled by user",
+                "details": details,
+                "timestamp": time.time(),
+            })
+        logger.info("smart_rebuild: cancelled")
+        return {"status": "cancelled", **details}
+
+    if is_cancel_requested_sync(_redis):
+        return _emit_cancelled()
 
     with Session(_sync_engine) as session:
         # Phase 1: Redirect images pointing to merged targets
@@ -1074,6 +1153,9 @@ def _smart_rebuild_inner(manual: bool = False) -> dict:
         logger.info("smart_rebuild: updated aliases for %d targets", result.rowcount)
 
         # Phase 4: Re-derive catalog_id/common_name from SIMBAD cache
+        if is_cancel_requested_sync(_redis):
+            session.commit()
+            return _emit_cancelled()
         from app.models.simbad_cache import SimbadCache
         targets = session.execute(
             select(Target).where(Target.merged_into_id.is_(None))
@@ -1081,6 +1163,10 @@ def _smart_rebuild_inner(manual: bool = False) -> dict:
 
         rederived = 0
         for target in targets:
+            if is_cancel_requested_sync(_redis):
+                stats["rederived"] = rederived
+                session.commit()
+                return _emit_cancelled()
             # Try to find cached SIMBAD data for this target
             cached = get_cached_simbad(normalize_object_name(target.catalog_id or target.primary_name), session)
             if cached and not cached.get("_negative"):
@@ -1555,6 +1641,7 @@ def generate_reference_thumbnails(self, force: bool = False) -> dict:
     """Fetch DSS reference thumbnails for all targets."""
     from app.services.skyview import fetch_reference_thumbnail
 
+    clear_cancel_sync(_redis)
     set_rebuild_running_sync(_redis, "ref_thumbnails", "Finding targets needing thumbnails...")
     output_dir = Path(settings.thumbnails_path) / "reference"
 
@@ -1573,7 +1660,11 @@ def generate_reference_thumbnails(self, force: bool = False) -> dict:
             _redis, f"Fetching reference thumbnails 0/{total}..."
         )
         fetched = 0
+        cancelled = False
         for i, target in enumerate(targets):
+            if is_cancel_requested_sync(_redis):
+                cancelled = True
+                break
             path = fetch_reference_thumbnail(target, output_dir)
             if path:
                 target.reference_thumbnail_path = path
@@ -1584,6 +1675,19 @@ def generate_reference_thumbnails(self, force: bool = False) -> dict:
                 )
             time.sleep(1.0)  # Rate limit
         session.commit()
+
+    if cancelled:
+        stats = {"fetched": fetched, "total": total}
+        set_rebuild_cancelled_sync(
+            _redis, f"Cancelled after fetching {fetched}/{total} reference thumbnails", stats
+        )
+        append_activity_sync(_redis, {
+            "type": "rebuild_cancelled",
+            "message": f"Reference Thumbnails cancelled after {fetched}/{total}",
+            "details": stats,
+            "timestamp": time.time(),
+        })
+        return {"status": "cancelled", **stats}
 
     _invalidate_stats_cache()
     stats = {"fetched": fetched, "total": total}
@@ -1604,6 +1708,7 @@ def run_xmatch_enrichment(self) -> dict:
     """Run CDS xMatch bulk cross-matching."""
     from app.services.xmatch import bulk_xmatch_targets
 
+    clear_cancel_sync(_redis)
     set_rebuild_running_sync(_redis, "xmatch", "Running xMatch enrichment...")
 
     with Session(_sync_engine) as session:
@@ -1619,6 +1724,17 @@ def run_xmatch_enrichment(self) -> dict:
             {"id": str(t.id), "ra": t.ra, "dec": t.dec}
             for t in targets
         ]
+
+        if is_cancel_requested_sync(_redis):
+            details = {"matched": 0, "total": len(target_dicts)}
+            set_rebuild_cancelled_sync(_redis, "xMatch cancelled before start", details)
+            append_activity_sync(_redis, {
+                "type": "rebuild_cancelled",
+                "message": "xMatch Enrichment cancelled before start",
+                "details": details,
+                "timestamp": time.time(),
+            })
+            return {"status": "cancelled", **details}
 
         set_rebuild_progress_sync(
             _redis, f"Cross-matching {len(target_dicts)} targets..."

--- a/frontend/src/components/ScanControls.tsx
+++ b/frontend/src/components/ScanControls.tsx
@@ -6,6 +6,7 @@ type FrameFilter = "all" | "light_only";
 const ScanControls: Component<{
   isActive: boolean;
   stopping: boolean;
+  rebuildRunning: boolean;
   frameFilter: FrameFilter;
   onFrameFilterChange: (filter: FrameFilter) => void;
   onStartScan: () => void;
@@ -46,7 +47,7 @@ const ScanControls: Component<{
       </div>
       <Show when={isAdmin()}>
         <div class="flex gap-2 flex-shrink-0 ml-auto">
-          <Show when={props.isActive}>
+          <Show when={props.isActive || props.rebuildRunning}>
             <button
               onClick={props.onStopScan}
               disabled={props.stopping}

--- a/frontend/src/components/ScanManager.tsx
+++ b/frontend/src/components/ScanManager.tsx
@@ -342,6 +342,7 @@ const ScanManager: Component = () => {
               <ScanControls
                 isActive={isActive()}
                 stopping={stopping()}
+                rebuildRunning={rebuildState().state === "running"}
                 frameFilter={frameFilter()}
                 onFrameFilterChange={setFrameFilter}
                 onStartScan={() => startScan({ includeCalibration: frameFilter() === "all" })}


### PR DESCRIPTION
**Summary**
This pull request implements the ability to cancel ongoing rebuild and thumbnail generation tasks. It introduces new backend logic to handle cancellation requests and updates the frontend with controls to trigger these cancellations.

**Changes**
*   Added cancel support for rebuild tasks.
*   Added cancel support for thumbnail generation tasks.

**Impact**
*   `backend/app/api/scan.py`: API endpoints related to scan operations.
*   `backend/app/services/scan_state.py`: Backend service for managing scan states.
*   `backend/app/worker/tasks.py`: Core background worker tasks for rebuild and thumbnail generation.
*   `frontend/src/components/ScanControls.tsx`: Frontend user interface for controlling scan processes.
*   `frontend/src/components/ScanManager.tsx`: Frontend logic for managing scan operations.