### PR TITLE
Fix Dashboard Filter Reset and Update Version Display

### DIFF
--- a/frontend/src/components/DashboardFilterProvider.tsx
+++ b/frontend/src/components/DashboardFilterProvider.tsx
@@ -330,6 +330,9 @@ const DashboardFilterProvider: Component<{ children: JSX.Element }> = (props) =>
       clear[key] = undefined;
     }
     set(clear);
+    try {
+      sessionStorage.removeItem("dashboard_params");
+    } catch { /* ignore */ }
   };
 
   const value: DashboardFilterAPI = {

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -24,9 +24,8 @@ const NavBar: Component = () => {
   const versionLabel = () => {
     const v = version();
     if (!v) return "";
-    const sha = v.git_sha && v.git_sha !== "unknown" ? ` (${v.git_sha.slice(0, 7)})` : "";
     const prefix = isSemver(v.version) ? "v" : "";
-    return `${prefix}${v.version}${sha}`;
+    return `${prefix}${v.version}`;
   };
   const versionUrl = () => {
     const v = version();

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -41,6 +41,8 @@ const DashboardPage: Component = () => {
     try {
       if (Object.keys(toSave).length > 0) {
         sessionStorage.setItem(SESSION_KEY, JSON.stringify(toSave));
+      } else {
+        sessionStorage.removeItem(SESSION_KEY);
       }
     } catch { /* ignore */ }
   });


### PR DESCRIPTION
**Summary**:
This PR fixes an issue where dashboard filters were not cleared from session storage on reset and removes the Git SHA from the navbar version display.

**Changes**:
*   Clear saved dashboard filters from session storage when a dashboard filter reset occurs.
*   Remove the Git SHA from the version string displayed in the navigation bar.

**Impact**:
*   Affects dashboard filter management logic.
*   Modifies the dashboard page's filter reset behavior.
*   Updates the version display in the navigation bar.