### PR TITLE
Fix File Preview Drag; Update Imaging Timeline Default

### DIFF
--- a/frontend/src/components/FilePreviewModal.tsx
+++ b/frontend/src/components/FilePreviewModal.tsx
@@ -117,6 +117,10 @@ export function FilePreviewModal(props: Props) {
       <div
         class="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm"
         onClick={props.onClose}
+        onPointerDown={(e) => e.stopPropagation()}
+        onPointerMove={(e) => e.stopPropagation()}
+        onPointerUp={(e) => e.stopPropagation()}
+        onPointerCancel={(e) => e.stopPropagation()}
       >
         <div
           class="relative max-h-[90vh] max-w-[90vw] rounded-lg bg-neutral-900 p-4 shadow-2xl"

--- a/frontend/src/components/ImagingTimeline.tsx
+++ b/frontend/src/components/ImagingTimeline.tsx
@@ -160,9 +160,9 @@ function fillGaps(data: TimelineDetailEntry[], allPeriods: string[]): TimelineDe
 
 const ImagingTimeline: Component<Props> = (props) => {
   const navigate = useNavigate();
-  const [zoom, setZoom] = createSignal(1);
-  const [activePreset, setActivePreset] = createSignal<Preset | null>("all");
-  const [gapMode, setGapMode] = createSignal<GapMode>("imaged");
+  const [zoom, setZoom] = createSignal(presetToZoom("1y"));
+  const [activePreset, setActivePreset] = createSignal<Preset | null>("1y");
+  const [gapMode, setGapMode] = createSignal<GapMode>("all");
 
   // Drag-to-pan state
   const [isDragging, setIsDragging] = createSignal(false);


### PR DESCRIPTION
**Summary**
This PR fixes an issue where the file preview modal closed during internal dragging and updates the default view for the imaging timeline.

**Changes**
*   Fixed an issue where the file preview modal closed unexpectedly when dragging content within its boundaries.
*   Set the default view for the imaging timeline to a 1-year preset, ensuring all gaps are visible.

**Impact**
*   `frontend/src/components/FilePreviewModal.tsx`: Affects the behavior of the file preview modal, specifically its drag interaction.
*   `frontend/src/components/ImagingTimeline.tsx`: Affects the initial display state of the imaging timeline component.