### PR TITLE
Set Imaging Timeline default to 1-year view

### DIFF
--- a/frontend/src/components/ImagingTimeline.tsx
+++ b/frontend/src/components/ImagingTimeline.tsx
@@ -160,9 +160,9 @@ function fillGaps(data: TimelineDetailEntry[], allPeriods: string[]): TimelineDe
 
 const ImagingTimeline: Component<Props> = (props) => {
   const navigate = useNavigate();
-  const [zoom, setZoom] = createSignal(1);
-  const [activePreset, setActivePreset] = createSignal<Preset | null>("all");
-  const [gapMode, setGapMode] = createSignal<GapMode>("imaged");
+  const [zoom, setZoom] = createSignal(presetToZoom("1y"));
+  const [activePreset, setActivePreset] = createSignal<Preset | null>("1y");
+  const [gapMode, setGapMode] = createSignal<GapMode>("all");
 
   // Drag-to-pan state
   const [isDragging, setIsDragging] = createSignal(false);


### PR DESCRIPTION
**Summary**
This PR establishes a 1-year preset view as the default for the Imaging Timeline component, ensuring all gaps are visible upon initial load.

**Changes**
*   Configured the Imaging Timeline component to default to a 1-year preset view.
*   Enabled visibility for all gaps within the default 1-year timeline display.

**Impact**
*   Affects the initial display and user experience of the `ImagingTimeline` component.
*   Modifies the `frontend/src/components/ImagingTimeline.tsx` file.