### PR TITLE
Image Gallery Navigation for File Preview Modal

### DIFF
--- a/frontend/src/components/ClickableFilePath.tsx
+++ b/frontend/src/components/ClickableFilePath.tsx
@@ -1,5 +1,5 @@
 import { createSignal, Show } from "solid-js";
-import { FilePreviewModal } from "./FilePreviewModal";
+import { FilePreviewModal, type PreviewFile } from "./FilePreviewModal";
 
 type Props = {
   imageId: string;
@@ -7,6 +7,8 @@ type Props = {
   thumbnailUrl?: string | null;
   display?: string;
   class?: string;
+  files?: PreviewFile[];
+  index?: number;
 };
 
 export function ClickableFilePath(props: Props) {
@@ -27,6 +29,8 @@ export function ClickableFilePath(props: Props) {
           imageId={props.imageId}
           filePath={props.filePath}
           thumbnailUrl={props.thumbnailUrl}
+          files={props.files}
+          initialIndex={props.index}
           onClose={() => setOpen(false)}
         />
       </Show>

--- a/frontend/src/components/FilePreviewModal.tsx
+++ b/frontend/src/components/FilePreviewModal.tsx
@@ -1,11 +1,20 @@
-import { createSignal, Show, onCleanup, onMount } from "solid-js";
+import { createSignal, Show, onCleanup, onMount, createEffect, createMemo } from "solid-js";
 import { Portal } from "solid-js/web";
 import { useSettingsContext } from "./SettingsProvider";
+import HelpPopover from "./HelpPopover";
+
+export type PreviewFile = {
+  imageId: string;
+  filePath: string;
+  thumbnailUrl?: string | null;
+};
 
 type Props = {
   imageId: string;
   filePath: string;
   thumbnailUrl?: string | null;
+  files?: PreviewFile[];
+  initialIndex?: number;
   onClose: () => void;
 };
 
@@ -15,6 +24,20 @@ export function FilePreviewModal(props: Props) {
   const [loading, setLoading] = createSignal(false);
   const [error, setError] = createSignal<string | null>(null);
   const [zoomUrl, setZoomUrl] = createSignal<string | null>(null);
+  const [index, setIndex] = createSignal(props.initialIndex ?? 0);
+  const [autoZoom, setAutoZoom] = createSignal(false);
+
+  const files = createMemo<PreviewFile[]>(() =>
+    props.files && props.files.length > 0
+      ? props.files
+      : [{ imageId: props.imageId, filePath: props.filePath, thumbnailUrl: props.thumbnailUrl ?? null }],
+  );
+  const current = () => {
+    const list = files();
+    const i = Math.min(Math.max(index(), 0), list.length - 1);
+    return list[i];
+  };
+  const hasList = () => files().length > 1;
 
   const [scale, setScale] = createSignal(1);
   const [tx, setTx] = createSignal(0);
@@ -31,6 +54,33 @@ export function FilePreviewModal(props: Props) {
     setTx(0);
     setTy(0);
   };
+
+  const resetForNewFile = () => {
+    const prev = zoomUrl();
+    if (prev) URL.revokeObjectURL(prev);
+    setZoomUrl(null);
+    setZoomed(false);
+    setLoading(false);
+    setError(null);
+    resetTransform();
+  };
+
+  const goTo = (next: number) => {
+    const list = files();
+    if (list.length === 0) return;
+    const n = ((next % list.length) + list.length) % list.length;
+    if (n === index()) return;
+    resetForNewFile();
+    setIndex(n);
+    if (autoZoom()) requestZoom();
+  };
+  const goPrev = () => goTo(index() - 1);
+  const goNext = () => goTo(index() + 1);
+
+  createEffect(() => {
+    const max = files().length - 1;
+    if (index() > max) setIndex(Math.max(0, max));
+  });
 
   const onWheel = (e: WheelEvent) => {
     e.preventDefault();
@@ -76,11 +126,19 @@ export function FilePreviewModal(props: Props) {
 
   const previewResolution = () => settings()?.general.preview_resolution ?? 2400;
 
-  const handleEscape = (e: KeyboardEvent) => {
-    if (e.key === "Escape") props.onClose();
+  const handleKey = (e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      props.onClose();
+    } else if (hasList() && e.key === "ArrowLeft") {
+      e.preventDefault();
+      goPrev();
+    } else if (hasList() && e.key === "ArrowRight") {
+      e.preventDefault();
+      goNext();
+    }
   };
-  onMount(() => window.addEventListener("keydown", handleEscape));
-  onCleanup(() => window.removeEventListener("keydown", handleEscape));
+  onMount(() => window.addEventListener("keydown", handleKey));
+  onCleanup(() => window.removeEventListener("keydown", handleKey));
 
   const requestZoom = async () => {
     const prev = zoomUrl();
@@ -89,14 +147,14 @@ export function FilePreviewModal(props: Props) {
     setLoading(true);
     setError(null);
     resetTransform();
-    const url = `/api/preview/${props.imageId}?resolution=${previewResolution()}`;
+    const target = current();
+    const url = `/api/preview/${target.imageId}?resolution=${previewResolution()}`;
     try {
       const resp = await fetch(url);
       if (!resp.ok) {
         const body = await resp.json().catch(() => ({ detail: resp.statusText }));
         throw new Error(body.detail || `HTTP ${resp.status}`);
       }
-      // Browser followed the X-Accel-Redirect internally; resp body is the JPEG bytes
       const blob = await resp.blob();
       setZoomUrl(URL.createObjectURL(blob));
       setZoomed(true);
@@ -132,7 +190,69 @@ export function FilePreviewModal(props: Props) {
           >
             &times;
           </button>
-          <div class="mb-2 text-xs text-neutral-400 truncate max-w-[80ch]">{props.filePath}</div>
+          <Show when={hasList()}>
+            <div class="mb-2 flex items-center gap-2 pr-8">
+              <button
+                class="rounded px-2 py-0.5 text-neutral-300 hover:bg-neutral-800 disabled:opacity-40"
+                onClick={goPrev}
+                title="Previous (←)"
+                disabled={loading()}
+              >
+                &#8592;
+              </button>
+              <span class="text-xs text-neutral-400 tabular-nums shrink-0">
+                {index() + 1} / {files().length}
+              </span>
+              <button
+                class="rounded px-2 py-0.5 text-neutral-300 hover:bg-neutral-800 disabled:opacity-40"
+                onClick={goNext}
+                title="Next (→)"
+                disabled={loading()}
+              >
+                &#8594;
+              </button>
+              <div class="ml-2 flex items-center gap-1 shrink-0">
+                <label class="flex items-center gap-1 text-xs text-neutral-400 cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    class="cursor-pointer"
+                    checked={autoZoom()}
+                    onChange={(e) => {
+                      const on = e.currentTarget.checked;
+                      setAutoZoom(on);
+                      if (on) {
+                        if (!zoomed() && !loading()) requestZoom();
+                      } else {
+                        const u = zoomUrl();
+                        if (u) URL.revokeObjectURL(u);
+                        setZoomUrl(null);
+                        setZoomed(false);
+                        resetTransform();
+                      }
+                    }}
+                  />
+                  Render full preview on navigation
+                </label>
+                <HelpPopover title="Render full preview on navigation" align="left">
+                  <p>
+                    Controls what is shown when stepping through files with the ← / → keys or buttons.
+                  </p>
+                  <p>
+                    <span class="font-medium text-theme-text-primary">Off (default):</span> shows only
+                    the cached thumbnail for each file. Fast scrolling through many frames.
+                  </p>
+                  <p>
+                    <span class="font-medium text-theme-text-primary">On:</span> automatically renders
+                    a fresh full-resolution preview for every file at the configured Preview resolution.
+                    Slower per step; useful for inspecting detail across frames.
+                  </p>
+                </HelpPopover>
+              </div>
+            </div>
+          </Show>
+          <div class="mb-2 pr-8 text-xs text-neutral-400 truncate" title={current().filePath}>
+            {current().filePath}
+          </div>
 
           <div
             ref={viewportEl}
@@ -149,13 +269,13 @@ export function FilePreviewModal(props: Props) {
               when={zoomed() && zoomUrl()}
               fallback={
                 <Show
-                  when={props.thumbnailUrl}
+                  when={current().thumbnailUrl}
                   fallback={
                     <div class="text-neutral-500 italic">No thumbnail available. Click Zoom to render.</div>
                   }
                 >
                   <img
-                    src={props.thumbnailUrl!}
+                    src={current().thumbnailUrl!}
                     alt="Thumbnail"
                     draggable={false}
                     class="max-h-[70vh] max-w-full"

--- a/frontend/src/components/SessionAccordionCard.tsx
+++ b/frontend/src/components/SessionAccordionCard.tsx
@@ -1,4 +1,4 @@
-import { Component, Show, For, createSignal, createEffect } from "solid-js";
+import { Component, Show, For, createSignal, createEffect, createMemo } from "solid-js";
 import type { SessionOverview, SessionDetail, FrameRecord } from "../types";
 import { api } from "../api/client";
 import ReferenceThumbnail from "./ReferenceThumbnail";
@@ -209,7 +209,16 @@ const SessionAccordionCard: Component<{
     return isHfrOutlier(frame, medianHfr) || isEccOutlier(frame, medianEcc);
   };
 
-  const renderFrameTable = (frames: FrameRecord[], medianHfr?: number | null, medianEcc?: number | null) => (
+  const renderFrameTable = (frames: FrameRecord[], medianHfr?: number | null, medianEcc?: number | null) => {
+    const sorted = createMemo(() => sortedFrames(frames));
+    const previewFiles = createMemo(() =>
+      sorted().map((f) => ({
+        imageId: f.image_id,
+        filePath: f.file_path,
+        thumbnailUrl: f.thumbnail_url,
+      })),
+    );
+    return (
     <table class="w-full text-label">
       <thead class="sticky top-0 bg-theme-base">
         <tr class="text-theme-text-secondary border-b border-theme-border">
@@ -300,8 +309,8 @@ const SessionAccordionCard: Component<{
         </tr>
       </thead>
       <tbody>
-        <For each={sortedFrames(frames)}>
-          {(frame) => (
+        <For each={sorted()}>
+          {(frame, i) => (
             <tr class={`border-b border-theme-border/30 hover:bg-theme-hover transition-colors duration-100 ${isOutlier(frame, medianHfr, medianEcc) ? "bg-theme-error/20" : ""}`}>
               <td class="py-1 px-2 text-theme-text-primary">{formatTimeUtil(frame.timestamp, settingsCtx.timezone(), settingsCtx.use24hTime())}</td>
               <td class="py-1 px-2 text-theme-text-primary text-center">{frame.filter_used ?? "—"}</td>
@@ -410,6 +419,8 @@ const SessionAccordionCard: Component<{
                   filePath={frame.file_path}
                   thumbnailUrl={frame.thumbnail_url}
                   display={frame.file_name}
+                  files={previewFiles()}
+                  index={i()}
                 />
               </td>
             </tr>
@@ -417,7 +428,8 @@ const SessionAccordionCard: Component<{
         </For>
       </tbody>
     </table>
-  );
+    );
+  };
 
   return (
     <>


### PR DESCRIPTION
**Summary**
This pull request adds image gallery navigation capabilities to the file preview modal. Users can now browse multiple images within the modal using dedicated controls and keyboard shortcuts.

**Changes**
*   Introduced image gallery navigation within the file preview modal.
*   Added previous and next controls for image browsing.
*   Implemented keyboard arrow key support for navigating between images.

**Impact**
*   The `FilePreviewModal` component now contains the core logic and UI for image gallery navigation.
*   `ClickableFilePath` and `SessionAccordionCard` components are updated to integrate with and trigger the enhanced file preview modal.
*   Users can directly navigate through multiple images when viewing files in the preview modal.