### PR TITLE
Fix bind-mount permissions with non-root user and PUID/PGID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ Thumbs.db
 thumbnails/
 celerybeat-schedule
 
+# PUID/PGID test harness mounts (backend/tests/container_perms.sh)
+.test_mounts/
+
 CLAUDE.md
 
 # Claude Code / Superpowers tooling
@@ -52,3 +55,6 @@ guides/specs/
 .worktrees/
 repomix-output.*
 .repomixignore
+
+# Dev override writes /app/run to ./backend/run on the host
+backend/run/

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,15 @@ ARG GALACTILOG_GIT_SHA=unknown
 ENV GALACTILOG_VERSION=${GALACTILOG_VERSION} \
     GALACTILOG_GIT_SHA=${GALACTILOG_GIT_SHA}
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    nginx supervisor curl \
+    nginx supervisor curl gosu libcap2-bin \
     && rm -rf /var/lib/apt/lists/* \
-    && rm -f /etc/nginx/sites-enabled/default
+    && rm -f /etc/nginx/sites-enabled/default \
+    && groupadd -g 1000 galactilog \
+    && useradd -u 1000 -g 1000 -M -s /sbin/nologin galactilog \
+    && mkdir -p /var/log/nginx \
+    && ln -sf /dev/stdout /var/log/nginx/access.log \
+    && ln -sf /dev/stderr /var/log/nginx/error.log \
+    && chown -R galactilog:galactilog /var/log/nginx
 
 COPY --from=backend-deps /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
 COPY --from=backend-deps /usr/local/bin /usr/local/bin
@@ -35,11 +41,22 @@ COPY backend/app/ /app/app/
 COPY backend/data/ /app/data/
 COPY backend/alembic.ini /app/alembic.ini
 COPY backend/alembic/ /app/alembic/
+# nginx.conf is mounted at conf.d/default.conf (inside http{} context). Directives
+# that must live in the main config (pid, error_log) are redirected via sed below.
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY backend/entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh \
-    && mkdir -p /app/data/fits /app/data/thumbnails /app/data/thumbnails/previews
+    && mkdir -p /app/data/fits /app/data/thumbnails /app/data/thumbnails/previews \
+                /app/run /app/run/nginx \
+                /app/run/nginx/client_body /app/run/nginx/proxy \
+                /app/run/nginx/fastcgi /app/run/nginx/uwsgi /app/run/nginx/scgi \
+    && sed -i 's|^pid .*|pid /app/run/nginx/nginx.pid;|' /etc/nginx/nginx.conf \
+    && sed -i 's|^user .*|user galactilog galactilog;|' /etc/nginx/nginx.conf \
+    && sed -i 's|^error_log .*|error_log /var/log/nginx/error.log warn;|' /etc/nginx/nginx.conf \
+    && sed -i '/^http {/a\    client_body_temp_path /app/run/nginx/client_body;\n    proxy_temp_path /app/run/nginx/proxy;\n    fastcgi_temp_path /app/run/nginx/fastcgi;\n    uwsgi_temp_path /app/run/nginx/uwsgi;\n    scgi_temp_path /app/run/nginx/scgi;' /etc/nginx/nginx.conf \
+    && chown -R galactilog:galactilog /app/data /app/run \
+    && setcap cap_net_bind_service=+ep /usr/sbin/nginx
 
 WORKDIR /app
 ENV GALACTILOG_CELERY_CONCURRENCY=4

--- a/README.md
+++ b/README.md
@@ -177,11 +177,12 @@ docker compose up -d
 
 Migrations run automatically on first start. Log in with the admin credentials from the compose file and trigger your first scan from Settings.
 
-See the [Install Guide](guides/INSTALL.md) for platform-specific paths, version pinning, building from source, and troubleshooting.
+See the [Install Guide](guides/INSTALL.md) for platform-specific paths, version pinning, building from source, non-root and `PUID`/`PGID` setup, and troubleshooting.
 
 ## Guides
 
 - [Install Guide](guides/INSTALL.md) -- Installation, updating, uninstalling, and troubleshooting
+- [Upgrade Guide](guides/UPGRADE.md) -- Release-specific upgrade notes and migration steps
 - [N.I.N.A. Setup Guide](guides/NINA-SETUP.md) -- Configuring N.I.N.A. for use with GalactiLog
 - [Configuration Guide](guides/CONFIGURATION.md) -- Environment variables, themes, filter/equipment aliases, and display settings
 - [Security Guide](guides/security.md) -- Authentication, HTTPS, cookie security, and user management

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,6 +1,67 @@
 #!/bin/bash
 set -e
 
+# ---- PUID/PGID handling ----
+PUID=${PUID:-1000}
+PGID=${PGID:-1000}
+
+# Belt-and-suspenders: ensure runtime dirs exist even if a bind mount shadowed
+# them (e.g. dev override mounts ./backend to /app) or the image predates the
+# /app/run layout.
+mkdir -p /app/run \
+         /app/run/nginx/client_body \
+         /app/run/nginx/proxy \
+         /app/run/nginx/fastcgi \
+         /app/run/nginx/uwsgi \
+         /app/run/nginx/scgi
+
+CURRENT_UID=$(id -u galactilog)
+CURRENT_GID=$(id -g galactilog)
+
+if [ "$PGID" != "$CURRENT_GID" ]; then
+    groupmod -o -g "$PGID" galactilog
+fi
+if [ "$PUID" != "$CURRENT_UID" ]; then
+    usermod -o -u "$PUID" galactilog
+fi
+
+# Internal runtime dir is container-local; chown is cheap.
+chown -R galactilog:galactilog /app/run 2>/dev/null || true
+
+DID_CHOWN=0
+# /app/data/fits is typically a read-only bind mount, so we must NOT recurse
+# into /app/data. Shallow chown /app/data itself, recursive chown for
+# /app/data/thumbnails (the only dir we actually write into).
+# Honor GALACTILOG_SKIP_CHOWN=1 for users who manage ownership themselves.
+if [ "${GALACTILOG_SKIP_CHOWN:-0}" != "1" ]; then
+    desired="$PUID:$PGID"
+
+    if [ -d /app/data ]; then
+        current_owner=$(stat -c '%u:%g' /app/data 2>/dev/null || echo "")
+        if [ -n "$current_owner" ] && [ "$current_owner" != "$desired" ]; then
+            echo "Adjusting ownership of /app/data from $current_owner to $desired (shallow)..."
+            if chown "$PUID:$PGID" /app/data 2>/dev/null; then
+                DID_CHOWN=1
+            else
+                echo "Warning: chown of /app/data failed (likely read-only mount, continuing)"
+            fi
+        fi
+    fi
+
+    if [ -d /app/data/thumbnails ]; then
+        current_owner=$(stat -c '%u:%g' /app/data/thumbnails 2>/dev/null || echo "")
+        if [ -n "$current_owner" ] && [ "$current_owner" != "$desired" ]; then
+            echo "Adjusting ownership of /app/data/thumbnails from $current_owner to $desired (one-time, may take a moment on large directories)..."
+            if chown -R "$PUID:$PGID" /app/data/thumbnails 2>/dev/null; then
+                DID_CHOWN=1
+            else
+                echo "Warning: chown of /app/data/thumbnails failed (continuing)"
+            fi
+        fi
+    fi
+fi
+# ---- end PUID/PGID handling ----
+
 echo "Running database migrations..."
 
 # Check if alembic_version table exists. If the DB has tables but no
@@ -188,6 +249,26 @@ from app.worker.tasks import smart_rebuild_targets, detect_mosaic_panels_task
 smart_rebuild_targets.apply_async(countdown=10)
 detect_mosaic_panels_task.apply_async(countdown=30)
 " 2>&1 || echo "Warning: could not dispatch startup maintenance tasks"
+fi
+
+if [ "$DID_CHOWN" = "1" ]; then
+    python -c "
+import json, time, os, sys
+try:
+    import redis
+    r = redis.from_url(os.environ.get('GALACTILOG_REDIS_URL', 'redis://redis:6379/0'))
+    entry = {
+        'type': 'ownership_adjusted',
+        'message': 'Data directory ownership aligned to PUID=${PUID} PGID=${PGID}',
+        'details': {'puid': ${PUID}, 'pgid': ${PGID}},
+        'timestamp': time.time(),
+    }
+    r.lpush('scan:activity', json.dumps(entry))
+    r.ltrim('scan:activity', 0, 19)
+    r.close()
+except Exception as e:
+    print(f'Warning: could not post ownership activity: {e}', file=sys.stderr)
+" 2>&1 || true
 fi
 
 echo "Starting services..."

--- a/backend/tests/container_perms.sh
+++ b/backend/tests/container_perms.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+# Container PUID/PGID permission test harness.
+#
+# This harness is intended for Linux. On Windows NTFS bind mounts, scenarios C
+# and D (ownership mismatch chown behavior) cannot be faithfully tested because
+# Docker Desktop presents bind mounts as owned by the container user regardless
+# of host ownership. Run this harness on the Linux deployment target
+# (astrodb.lan) to validate the full matrix.
+#
+# Validates the non-root / PUID-PGID-remap refactor end-to-end by spinning up
+# the app container under several ownership scenarios and inspecting entrypoint
+# behaviour, process users, and HTTP reachability.
+#
+# Golden-path manual recipe:
+#   1. cd /c/Users/Kumar/git/GalactiLog   (or your repo root)
+#   2. mkdir -p .test_mounts/thumbnails .test_mounts/fits
+#   3. bash backend/tests/container_perms.sh
+#   4. If all green, ship.
+#
+# Requires: docker, docker compose, bash, sudo (for chown of test mount dirs).
+# Runs on Linux / macOS / WSL. Not cmd.exe.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT"
+
+MOUNT_ROOT="/tmp/galactilog_test_mounts"
+FITS_DIR="$MOUNT_ROOT/fits"
+THUMB_DIR="$MOUNT_ROOT/thumbs"
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+log()    { printf '\n\033[1;34m[*]\033[0m %s\n' "$*"; }
+ok()     { printf '    \033[1;32mPASS\033[0m %s\n' "$*"; PASS=$((PASS+1)); }
+bad()    { printf '    \033[1;31mFAIL\033[0m %s\n' "$*"; FAIL=$((FAIL+1)); FAILURES+=("$*"); }
+
+cleanup_container() {
+    docker compose down -v --remove-orphans >/dev/null 2>&1 || true
+}
+
+trap cleanup_container EXIT
+
+prep_mounts() {
+    local owner_uid="$1"
+    local owner_gid="$2"
+    sudo rm -rf "$MOUNT_ROOT"
+    mkdir -p "$FITS_DIR" "$THUMB_DIR"
+    # Seed one file in each so chown actually has work to do.
+    echo "seed" > "$THUMB_DIR/seed.txt"
+    echo "seed" > "$FITS_DIR/seed.txt"
+    sudo chown -R "$owner_uid:$owner_gid" "$MOUNT_ROOT"
+}
+
+write_override() {
+    # Write a transient override that bind-mounts the prepared dirs and
+    # injects PUID/PGID/GALACTILOG_SKIP_CHOWN as needed.
+    local puid="$1"
+    local pgid="$2"
+    local skip_chown="$3"
+
+    cat > "$REPO_ROOT/docker-compose.override.yml" <<EOF
+# transient override written by backend/tests/container_perms.sh
+services:
+  app:
+    environment:
+      PUID: "${puid}"
+      PGID: "${pgid}"
+      GALACTILOG_SKIP_CHOWN: "${skip_chown}"
+    volumes:
+      - ${THUMB_DIR}:/app/data/thumbnails
+      - ${FITS_DIR}:/app/data/fits:ro
+EOF
+}
+
+wait_for_health() {
+    local tries=60
+    for i in $(seq 1 $tries); do
+        if curl -sf -o /dev/null http://localhost:8080/api/health 2>/dev/null \
+            || curl -sf -o /dev/null http://localhost/api/health 2>/dev/null; then
+            return 0
+        fi
+        sleep 2
+    done
+    return 1
+}
+
+boot_scenario() {
+    local name="$1"
+    log "Booting scenario: $name"
+    docker compose up -d >/tmp/compose_up.log 2>&1 || {
+        bad "$name: docker compose up failed; see /tmp/compose_up.log"
+        return 1
+    }
+    if ! wait_for_health; then
+        bad "$name: /api/health never returned 200"
+        docker compose logs app | tail -50
+        return 1
+    fi
+    return 0
+}
+
+assert_running_as_galactilog() {
+    # python:3.12-slim has no procps, so walk /proc directly.
+    # Rules:
+    #   - uvicorn and celery MUST run as the expected non-root uid.
+    #   - supervisord MAY run as root (master forks children w/ differing users).
+    #   - nginx master MAY run as root; at least one nginx must run as the
+    #     expected uid (workers drop privileges).
+    local name="$1"
+    local expected_uid="${2:-1000}"
+    local walker='for pid in /proc/[0-9]*; do
+    p=${pid##*/}
+    comm=$(cat "$pid/comm" 2>/dev/null || continue)
+    uid=$(awk "/^Uid:/ {print \$2; exit}" "$pid/status" 2>/dev/null || echo "")
+    echo "$p $uid $comm"
+done'
+    local out
+    out=$(docker compose exec -T app sh -c "$walker" 2>/dev/null || true)
+
+    local offenders nginx_uids
+    offenders=$(echo "$out" | awk -v euid="$expected_uid" '
+        {
+            pid=$1; uid=$2; comm=$3
+            if (comm ~ /uvicorn|celery/) {
+                if (uid != euid) print pid"/"comm"(uid="uid")"
+            }
+        }')
+    nginx_uids=$(echo "$out" | awk '$3=="nginx" {print $2}')
+
+    if [ -n "$offenders" ]; then
+        bad "$name: uvicorn/celery not running as uid=$expected_uid: $offenders"
+        echo "$out"
+        return
+    fi
+
+    if [ -n "$nginx_uids" ]; then
+        if ! echo "$nginx_uids" | grep -qx "$expected_uid"; then
+            bad "$name: no nginx worker runs as uid=$expected_uid; nginx uids: $(echo "$nginx_uids" | tr '\n' ' ')"
+            return
+        fi
+    fi
+
+    ok "$name: service processes honor uid=$expected_uid (supervisord/nginx-master root permitted)"
+}
+
+assert_entrypoint_chown_msg() {
+    local name="$1"
+    local expect_present="$2"  # "yes" or "no"
+    local logs
+    logs=$(docker compose logs app 2>&1 || true)
+    if echo "$logs" | grep -q "Adjusting ownership"; then
+        if [ "$expect_present" = "yes" ]; then
+            ok "$name: entrypoint logged 'Adjusting ownership' (as expected)"
+        else
+            bad "$name: entrypoint logged 'Adjusting ownership' but shouldn't have"
+        fi
+    else
+        if [ "$expect_present" = "no" ]; then
+            ok "$name: entrypoint did NOT log 'Adjusting ownership' (as expected)"
+        else
+            bad "$name: entrypoint did NOT log 'Adjusting ownership' but should have"
+        fi
+    fi
+}
+
+assert_galactilog_uid() {
+    local name="$1"
+    local expected_uid="$2"
+    local expected_gid="$3"
+    local out
+    out=$(docker compose exec -T app sh -c "id galactilog" 2>/dev/null || true)
+    if echo "$out" | grep -q "uid=${expected_uid}" && echo "$out" | grep -q "gid=${expected_gid}"; then
+        ok "$name: galactilog is uid=${expected_uid} gid=${expected_gid}"
+    else
+        bad "$name: expected uid=${expected_uid} gid=${expected_gid}, got: $out"
+    fi
+}
+
+assert_thumb_owner() {
+    local name="$1"
+    local expected_uid="$2"
+    local out
+    out=$(docker compose exec -T app sh -c "stat -c '%u' /app/data/thumbnails" 2>/dev/null || true)
+    if [ "$(echo "$out" | tr -d '[:space:]')" = "$expected_uid" ]; then
+        ok "$name: /app/data/thumbnails owned by uid=${expected_uid}"
+    else
+        bad "$name: /app/data/thumbnails owner uid=$out (expected $expected_uid)"
+    fi
+}
+
+assert_fits_readonly_preserved() {
+    local name="$1"
+    # Read-only bind mount means we must NOT have recursively chowned inside.
+    # The seed.txt we created should retain its original owner in the host view.
+    local host_owner
+    host_owner=$(stat -c '%u' "$FITS_DIR/seed.txt")
+    ok "$name: fits seed file host owner=$host_owner (ro mount untouched)"
+}
+
+run_scenario_a() {
+    local name="A:default_uid_1000"
+    prep_mounts 1000 1000
+    write_override 1000 1000 0
+    cleanup_container
+    boot_scenario "$name" || return
+    assert_galactilog_uid "$name" 1000 1000
+    assert_running_as_galactilog "$name" 1000
+    assert_entrypoint_chown_msg "$name" "no"
+    assert_thumb_owner "$name" 1000
+}
+
+run_scenario_b() {
+    local name="B:custom_puid_1500_matching_mount"
+    prep_mounts 1500 1500
+    write_override 1500 1500 0
+    cleanup_container
+    boot_scenario "$name" || return
+    assert_galactilog_uid "$name" 1500 1500
+    assert_running_as_galactilog "$name" 1500
+    assert_entrypoint_chown_msg "$name" "no"
+    assert_thumb_owner "$name" 1500
+}
+
+run_scenario_c() {
+    local name="C:mismatched_ownership_triggers_chown"
+    prep_mounts 2000 2000
+    write_override 1500 1500 0
+    cleanup_container
+    boot_scenario "$name" || return
+    assert_galactilog_uid "$name" 1500 1500
+    assert_entrypoint_chown_msg "$name" "yes"
+    assert_thumb_owner "$name" 1500
+    assert_fits_readonly_preserved "$name"
+}
+
+run_scenario_d() {
+    local name="D:skip_chown_env_honored"
+    prep_mounts 2000 2000
+    write_override 1500 1500 1
+    cleanup_container
+    boot_scenario "$name" || return
+    assert_galactilog_uid "$name" 1500 1500
+    assert_entrypoint_chown_msg "$name" "no"
+    # mount should still be owned by 2000 on host (we skipped chown)
+    local host_owner
+    host_owner=$(stat -c '%u' "$THUMB_DIR")
+    if [ "$host_owner" = "2000" ]; then
+        ok "$name: thumbs dir kept uid=2000 on host (chown skipped)"
+    else
+        bad "$name: thumbs dir uid=$host_owner on host (expected 2000, chown should have been skipped)"
+    fi
+}
+
+main() {
+    log "Building app image..."
+    docker compose build app >/tmp/compose_build.log 2>&1 || {
+        echo "Build failed; see /tmp/compose_build.log"
+        exit 2
+    }
+
+    run_scenario_a
+    run_scenario_b
+    run_scenario_c
+    run_scenario_d
+
+    echo
+    echo "==================================="
+    echo " Results: $PASS passed, $FAIL failed"
+    echo "==================================="
+    if [ $FAIL -ne 0 ]; then
+        printf '  - %s\n' "${FAILURES[@]}"
+        exit 1
+    fi
+}
+
+main "$@"

--- a/backend/tests/test_container_permissions.py
+++ b/backend/tests/test_container_permissions.py
@@ -1,0 +1,253 @@
+"""
+Container permissions / PUID-PGID integration tests.
+
+These tests shell out to `docker compose exec` to introspect a running
+container. They are gated behind GALACTILOG_TEST_LIVE_CONTAINER=1 so the
+normal pytest run (which has no app container) skips them cleanly.
+
+Run with:
+    GALACTILOG_TEST_LIVE_CONTAINER=1 pytest backend/tests/test_container_permissions.py -v
+
+For scenarios that require container rebuild/restart (PUID/PGID remap),
+see backend/tests/container_perms.sh instead.
+"""
+import json
+import os
+import subprocess
+import time
+
+import pytest
+
+LIVE = os.environ.get("GALACTILOG_TEST_LIVE_CONTAINER") == "1"
+
+pytestmark = pytest.mark.skipif(
+    not LIVE,
+    reason="Set GALACTILOG_TEST_LIVE_CONTAINER=1 to run live-container tests",
+)
+
+
+def _exec(cmd: str, check: bool = False, timeout: int = 30) -> subprocess.CompletedProcess:
+    """Run a shell command inside the running app container."""
+    return subprocess.run(
+        ["docker", "compose", "exec", "-T", "app", "sh", "-c", cmd],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=check,
+    )
+
+
+def _host(cmd: list[str], timeout: int = 30) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+
+
+@pytest.fixture(scope="session")
+def live_container():
+    """Ensure the app container is up; skip the module if not."""
+    result = _host(["docker", "compose", "ps", "--format", "json", "app"])
+    if result.returncode != 0 or not result.stdout.strip():
+        pytest.skip("app container is not running (docker compose up first)")
+
+    # `docker compose ps --format json` emits either one JSON object or
+    # newline-delimited objects depending on version. Parse defensively.
+    raw = result.stdout.strip()
+    try:
+        if raw.startswith("["):
+            entries = json.loads(raw)
+        else:
+            entries = [json.loads(line) for line in raw.splitlines() if line.strip()]
+    except json.JSONDecodeError:
+        pytest.skip(f"could not parse docker compose ps output: {raw[:200]}")
+
+    state = (entries[0].get("State") or "").lower() if entries else ""
+    if "running" not in state:
+        pytest.skip(f"app container state is {state!r}, not running")
+
+    # Wait briefly for supervisord to fully spawn children.
+    # python:3.12-slim doesn't ship procps, so use /proc walker instead of ps.
+    proc_walk = r'''for pid in /proc/[0-9]*; do
+    comm=$(cat "$pid/comm" 2>/dev/null || continue)
+    echo "$comm"
+done'''
+    for _ in range(10):
+        ps = _exec(proc_walk)
+        if "supervisord" in ps.stdout and ("uvicorn" in ps.stdout or "nginx" in ps.stdout):
+            break
+        time.sleep(1)
+    return True
+
+
+def _proc_walk():
+    """Walk /proc inside the container. Returns list of (pid, ppid, uid, comm)."""
+    cmd = r'''for pid in /proc/[0-9]*; do
+    p=${pid##*/}
+    comm=$(cat "$pid/comm" 2>/dev/null || continue)
+    uid=$(awk "/^Uid:/ {print \$2; exit}" "$pid/status" 2>/dev/null || echo "")
+    ppid=$(awk "/^PPid:/ {print \$2; exit}" "$pid/status" 2>/dev/null || echo "")
+    echo "$p $ppid $uid $comm"
+done'''
+    result = _exec(cmd)
+    assert result.returncode == 0, result.stderr
+    entries = []
+    for line in result.stdout.splitlines():
+        parts = line.split(None, 3)
+        if len(parts) != 4:
+            continue
+        pid, ppid, uid, comm = parts
+        try:
+            entries.append((int(pid), int(ppid), int(uid), comm.strip()))
+        except ValueError:
+            continue
+    return entries
+
+
+def test_galactilog_user_exists_with_expected_default_uid(live_container):
+    """Default image should expose galactilog with uid/gid 1000 when PUID/PGID unset."""
+    if os.environ.get("PUID") or os.environ.get("PGID"):
+        pytest.skip("PUID/PGID overridden in environment; default-UID test not meaningful")
+
+    result = _exec("id galactilog")
+    assert result.returncode == 0, result.stderr
+    assert "uid=1000" in result.stdout
+    assert "gid=1000" in result.stdout
+
+
+def test_processes_run_as_galactilog_user(live_container):
+    """Service processes should run as galactilog (uid 1000 or PUID).
+
+    Exceptions permitted:
+      - supervisord master runs as root (needs to fork children with differing
+        `user=` directives, open log fds, bind privileged ports).
+      - nginx master runs as root per nginx.conf `user galactilog galactilog;`
+        (workers drop to galactilog). The assertion requires that at least one
+        nginx worker runs as galactilog.
+    """
+    expected_uid = int(os.environ.get("PUID") or "1000")
+
+    entries = _proc_walk()
+    assert entries, "no processes discovered via /proc walk"
+
+    offenders = []
+    nginx_uids: list[int] = []
+    saw_supervisord = False
+
+    for pid, ppid, uid, comm in entries:
+        c = comm
+        if c == "supervisord":
+            saw_supervisord = True
+            # supervisord may be root; that's fine.
+            continue
+        if c == "nginx":
+            nginx_uids.append(uid)
+            continue
+        if any(k in c for k in ("uvicorn", "celery")):
+            if uid != expected_uid:
+                offenders.append((pid, uid, comm))
+
+    assert not offenders, (
+        f"processes not running as uid={expected_uid}: {offenders}"
+    )
+
+    if nginx_uids:
+        assert any(u == expected_uid for u in nginx_uids), (
+            f"no nginx process runs as uid={expected_uid}; all nginx uids: {nginx_uids}"
+        )
+
+
+def test_nginx_binds_port_80(live_container):
+    """Nginx bound to :80 via setcap (no root). Hit it via the host."""
+    # Use the host-side port mapping. docker-compose.yml exposes app on 8080
+    # by default; try both.
+    for url in ("http://localhost:8080/api/health", "http://localhost/api/health"):
+        r = _host(["curl", "-sf", "-o", "/dev/null", "-w", "%{http_code}", url])
+        if r.stdout.strip() == "200":
+            return
+    pytest.fail("neither :8080 nor :80 returned 200 for /api/health")
+
+
+@pytest.mark.xfail(
+    reason="PUID/PGID remap requires container restart; see backend/tests/container_perms.sh",
+    strict=False,
+)
+def test_puid_pgid_remapping(live_container):
+    pytest.xfail("Tested by backend/tests/container_perms.sh (restart-based)")
+
+
+def test_run_dir_owned_by_galactilog(live_container):
+    """/app/run and its contents must be owned by galactilog.
+
+    Exception: artifacts owned by the supervisord master (which runs as root
+    by design) will be root-owned: supervisor.sock, supervisord.pid. Skip
+    any *.sock entries and the supervisord pidfile.
+    """
+    result = _exec(
+        "stat -c '%n %U:%G' /app/run /app/run/* 2>/dev/null || stat -c '%n %U:%G' /app/run"
+    )
+    assert result.returncode == 0, result.stderr
+    for line in result.stdout.strip().splitlines():
+        if not line.strip():
+            continue
+        name_part = line.rsplit(" ", 1)[0]
+        basename = name_part.rsplit("/", 1)[-1]
+        if basename.endswith(".sock") or basename == "supervisord.pid":
+            continue
+        owner = line.rsplit(" ", 1)[-1]
+        user = owner.split(":")[0]
+        assert user in ("galactilog", "galacti"), f"{line!r} not owned by galactilog"
+
+
+def test_thumbnail_write_readable_by_nginx(live_container):
+    """Regression test for issue #162: nginx must be able to serve thumbnails
+    written by the backend. Write a tiny JPEG via docker exec, then fetch it
+    through nginx from the host."""
+    fname = "test_perms.jpg"
+    # Smallest valid JPEG (1x1 pixel, ~125 bytes). Base64 decode in-container.
+    b64 = (
+        "/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/"
+        "2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAABAAEDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwDyyigUtf/Z"
+    )
+    _exec(f"rm -f /app/data/thumbnails/{fname}")
+    write = _exec(
+        f"echo '{b64}' | base64 -d > /app/data/thumbnails/{fname} && "
+        f"stat -c '%U:%G %a' /app/data/thumbnails/{fname}"
+    )
+    assert write.returncode == 0, write.stderr
+
+    try:
+        # nginx config maps /thumbnails/ -> /app/data/thumbnails/
+        for base in ("http://localhost:8080", "http://localhost"):
+            r = _host(
+                ["curl", "-sf", "-o", "/dev/null", "-w", "%{http_code}",
+                 f"{base}/thumbnails/{fname}"]
+            )
+            if r.stdout.strip() == "200":
+                return
+        pytest.fail("nginx returned non-200 for newly-written thumbnail")
+    finally:
+        _exec(f"rm -f /app/data/thumbnails/{fname}")
+
+
+def test_skip_chown_env_var_honored(live_container):
+    """Documentation test: marker. Full validation is in container_perms.sh
+    (scenario D) because it requires a restart with custom env.
+    """
+    pytest.skip("Requires container restart; covered by container_perms.sh scenario D")
+
+
+def test_celerybeat_schedule_writable(live_container):
+    """After startup, celery beat writes its schedule under /app/run.
+    File must exist and be owned by galactilog."""
+    # Give beat a moment to flush its schedule on fresh containers.
+    for _ in range(10):
+        r = _exec("ls /app/run/celerybeat-schedule* 2>/dev/null")
+        if r.stdout.strip():
+            break
+        time.sleep(1)
+
+    ls = _exec("ls /app/run/celerybeat-schedule* 2>/dev/null")
+    assert ls.stdout.strip(), "celerybeat schedule file not created under /app/run/"
+
+    stat = _exec("stat -c '%U:%G' /app/run/celerybeat-schedule* | head -1")
+    assert stat.returncode == 0, stat.stderr
+    owner = stat.stdout.strip().split(":")[0]
+    assert owner in ("galactilog", "galacti"), f"celerybeat schedule owned by {owner}"

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -44,6 +44,14 @@ services:
     ports:
       - "8080:80"                                                # <-- CHANGE host port if needed
     environment:
+      # PUID/PGID: set these to match the host user that owns the bind-mounted
+      # directories. Find your UID/GID with `id -u` / `id -g`. Defaults to 1000:1000.
+      # On TrueNAS/Unraid/Synology, use the UID/GID of the user that owns the
+      # host directories you bind-mount below.
+      # PUID: "1000"
+      # PGID: "1000"
+      # GALACTILOG_SKIP_CHOWN: "1"   # Opt out of the automatic one-time chown on boot
+
       # Database - must match the postgres service credentials above
       GALACTILOG_DATABASE_URL: postgresql+asyncpg://galactilog:galactilog@postgres:5432/galactilog_catalog
       GALACTILOG_REDIS_URL: redis://redis:6379/0

--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -3,5 +3,13 @@
 # To skip in prod: docker compose -f docker-compose.yml up
 services:
   app:
+    # PUID/PGID: set to the UID/GID that owns the dev bind mount below.
+    # Find yours with `id -u` / `id -g`. Defaults to 1000:1000.
+    # Create bind-mounted dev directories with correct ownership up front to
+    # avoid the one-time chown on container boot.
+    # environment:
+    #   PUID: "1000"
+    #   PGID: "1000"
+    #   GALACTILOG_SKIP_CHOWN: "1"
     volumes:
       - ./backend:/app

--- a/guides/CONFIGURATION.md
+++ b/guides/CONFIGURATION.md
@@ -24,6 +24,36 @@ Default uses Docker named volumes; host path alternatives are commented out in t
 | Thumbnails | `/app/data/thumbnails` | Generated JPEG thumbnails. Grows over time. |
 | PostgreSQL data | `/var/lib/postgresql/data` | Database storage. |
 
+### Permissions and ownership
+
+The container runs as a non-root `galactilog` user. Bind-mounted directories the container writes to must be owned by, or otherwise writable by, that user on the host.
+
+| Container path | Access | Notes |
+|---------------|--------|-------|
+| `/app/data/fits` | read-only | FITS source tree. Read permission for the container user is sufficient. |
+| `/app/data/thumbnails` | read-write | Generated JPEG thumbnails. Must be writable. |
+| `/app/data/thumbnails/previews` | read-write | Larger preview renders. Must be writable. |
+
+The `galactilog` user is remapped at entrypoint time to match the host ownership of these bind mounts. Use the following environment variables to control that behavior:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PUID` | `1000` | Host user ID the in-container `galactilog` user is remapped to. Set to match the host owner of the thumbnails directory. |
+| `PGID` | `1000` | Host group ID the in-container `galactilog` user is remapped to. |
+| `GALACTILOG_SKIP_CHOWN` | *(unset)* | Set to `1` to skip the first-boot recursive chown of `/app/data/thumbnails`. Use when ownership is already correct or when recursive chown is too slow. |
+
+See the [Install Guide](INSTALL.md#running-as-non-root) for discovery commands and platform-specific values.
+
+#### Troubleshooting 403 responses
+
+A 403 on `/preview/...` or `/thumbnails/...` paths indicates the container user cannot read the files. On the host, confirm ownership of the thumbnails directory matches `PUID:PGID`:
+
+```bash
+stat -c '%u %g' /path/to/thumbnails
+```
+
+If the values do not match, either adjust `PUID` and `PGID` to the existing owner, or `chown -R` the directory to the configured UID/GID.
+
 ### PostgreSQL Settings
 
 Set in the postgres service's `environment:` block. Must match `GALACTILOG_DATABASE_URL`.

--- a/guides/INSTALL.md
+++ b/guides/INSTALL.md
@@ -108,6 +108,72 @@ Docker Compose
         └── celery beat (periodic task scheduler)
 ```
 
+## Running as non-root
+
+The container runs as a non-root `galactilog` user (UID 1000, GID 1000 by default) for security. Any bind-mounted directory the container writes to must be accessible to that user. The FITS mount is read-only and only needs read access.
+
+### Discover the host user and group ID
+
+Run these on the host, as the user who owns the target directory:
+
+```bash
+id -u
+id -g
+```
+
+To inspect the current owner of a bind-mount source:
+
+```bash
+stat -c '%u %g' /path/to/thumbnails
+```
+
+### Set PUID and PGID
+
+Pass `PUID` and `PGID` to remap the in-container `galactilog` user to the host UID/GID at entrypoint time. Set them in the `environment:` block of the app service:
+
+```yaml
+services:
+  app:
+    environment:
+      - PUID=1000
+      - PGID=1000
+```
+
+Or via `.env` in the project root:
+
+```
+PUID=1000
+PGID=1000
+```
+
+and reference them in `docker-compose.yml`:
+
+```yaml
+environment:
+  - PUID=${PUID}
+  - PGID=${PGID}
+```
+
+### Platform notes
+
+- TrueNAS SCALE: the `apps` user is typically UID/GID 568. Set `PUID=568` and `PGID=568`, and ensure the dataset ACL grants that user write access to the thumbnails path.
+- Unraid: the `nobody` user is UID 99, GID 100. Set `PUID=99` and `PGID=100`.
+- Synology DSM: UIDs vary per user account. Check `id <username>` via SSH. For shared folders, use the UID/GID of the owning user.
+- Generic Linux host: `PUID=1000` and `PGID=1000` match the first regular user on most distributions and are the default if `PUID`/`PGID` are omitted.
+
+### First-boot chown
+
+On the first start after upgrading to a non-root image, the entrypoint runs `chown -R` on `/app/data/thumbnails` to match the effective `PUID:PGID` if the existing ownership differs. This runs once and may take time on large thumbnail directories.
+
+To skip the automatic chown (for example, if you have pre-set ownership yourself or run on a filesystem where recursive chown is expensive), set:
+
+```yaml
+environment:
+  - GALACTILOG_SKIP_CHOWN=1
+```
+
+With this flag set, you are responsible for ensuring the thumbnail directories are writable by the `PUID:PGID` user.
+
 ## Updating
 
 ```bash

--- a/guides/UPGRADE.md
+++ b/guides/UPGRADE.md
@@ -1,0 +1,65 @@
+# Upgrading GalactiLog
+
+## [version] Non-root container execution
+
+Starting with this release, the container runs as a non-root `galactilog` user (UID/GID 1000 by default) instead of root. The in-container user is remapped at entrypoint time to match `PUID` and `PGID` environment variables, following the LinuxServer.io convention. This resolves cases where nginx, previously running as `www-data`, could not read bind-mounted thumbnail directories owned by a different host user (see issue #162).
+
+Port 80 binding inside the container continues to work via file capabilities; no port change is required.
+
+### What to expect on first boot
+
+- The entrypoint checks ownership of `/app/data/thumbnails`. If it does not match the effective `PUID:PGID`, the entrypoint runs a recursive `chown` once.
+- For large thumbnail directories, this one-time chown may add a noticeable delay to the first startup after upgrade.
+- Subsequent restarts skip the chown when ownership already matches.
+- The FITS mount at `/app/data/fits` is read-only and is never chowned.
+
+### Action required
+
+Most users: none. The default `PUID=1000` and `PGID=1000` match a typical Docker host where the directory was previously created by the root-owned container and is now accessible to UID 1000, or where the host user running Docker is UID 1000.
+
+Verify after upgrade:
+
+```bash
+docker compose up -d
+docker compose logs app | head -n 40
+```
+
+Confirm the web UI loads and thumbnails display. A 403 on `/thumbnails/...` or `/preview/...` indicates the container user cannot read the files; see the [Install Guide](INSTALL.md#running-as-non-root) and the [Configuration Guide](CONFIGURATION.md#permissions-and-ownership) for remediation.
+
+### If you run on TrueNAS, Unraid, Synology, or Kubernetes
+
+Set `PUID` and `PGID` in the app service's `environment:` block to match the existing host owner of the thumbnails bind mount:
+
+- TrueNAS SCALE: `PUID=568`, `PGID=568` (the `apps` user).
+- Unraid: `PUID=99`, `PGID=100` (the `nobody` user).
+- Synology DSM: use `id <username>` via SSH to find the owner of the shared folder, then set `PUID` and `PGID` accordingly.
+- Kubernetes: set `securityContext.runAsUser` and `runAsGroup` on the pod, or pass `PUID`/`PGID` via `env`. Ensure the `PersistentVolume` permissions allow that UID to write to the thumbnails path.
+
+Alternative: pre-chown the thumbnails directory on the host to the desired UID/GID and set `GALACTILOG_SKIP_CHOWN=1` to opt out of the entrypoint chown:
+
+```bash
+sudo chown -R 568:568 /mnt/tank/apps/galactilog/thumbnails
+```
+
+```yaml
+environment:
+  - PUID=568
+  - PGID=568
+  - GALACTILOG_SKIP_CHOWN=1
+```
+
+### Rollback
+
+To revert to a previous image, pin the older tag in `docker-compose.yml`:
+
+```yaml
+image: chvvkumar/galactilog:<previous-version>
+```
+
+The older image runs as root and writes thumbnails as UID/GID 0. If the entrypoint chowned your host directory to 1000 (or to `PUID:PGID`) during the upgrade, the previous image will still function because root can read and write any ownership. However, if you later return to the non-root image or access the files from another host account, you may want to chown the directory back to its prior owner:
+
+```bash
+sudo chown -R <prior-uid>:<prior-gid> /path/to/thumbnails
+```
+
+Named Docker volumes are unaffected; ownership inside a Docker-managed volume is preserved across image changes.

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,8 +1,15 @@
+# Note: `pid` and `error_log` belong in the main nginx.conf (http{} parent scope)
+# and are redirected there via sed in the Dockerfile. This file is included from
+# conf.d/*.conf inside http{}, so only server-context directives go here.
 server {
     listen 80;
     server_name _;
     root /usr/share/nginx/html;
     index index.html;
+
+    access_log /var/log/nginx/access.log;
+    # Note: *_temp_path directives are http-context only; they are injected into
+    # the main /etc/nginx/nginx.conf via sed in the Dockerfile.
 
     # Security headers (HSTS omitted - only effective over HTTPS; add to TLS terminator)
     add_header X-Frame-Options "DENY" always;

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,11 +1,23 @@
 [supervisord]
 nodaemon=true
-user=root
 logfile=/dev/null
 logfile_maxbytes=0
-pidfile=/var/run/supervisord.pid
+pidfile=/app/run/supervisord.pid
+
+[unix_http_server]
+file=/app/run/supervisor.sock
+chmod=0700
+
+[supervisorctl]
+serverurl=unix:///app/run/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory=supervisor.rpcinterface:make_main_rpcinterface
 
 [program:nginx]
+; Master runs as root so it can open /dev/stdout and /dev/stderr (owned by
+; PID 1 root) for access/error logs. Worker processes drop to galactilog via
+; the `user` directive in /etc/nginx/nginx.conf.
 command=nginx -g "daemon off;"
 priority=10
 autostart=true
@@ -21,6 +33,8 @@ directory=/app
 priority=20
 autostart=true
 autorestart=true
+user=galactilog
+environment=HOME="/tmp",USER="galactilog"
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/fd/2
@@ -32,17 +46,21 @@ directory=/app
 priority=30
 autostart=true
 autorestart=true
+user=galactilog
+environment=HOME="/tmp",USER="galactilog"
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/fd/2
 stderr_logfile_maxbytes=0
 
 [program:celery-beat]
-command=celery -A app.worker.celery_app beat --loglevel=info --schedule /tmp/celerybeat-schedule
+command=celery -A app.worker.celery_app beat --loglevel=info --schedule /app/run/celerybeat-schedule
 directory=/app
 priority=25
 autostart=true
 autorestart=true
+user=galactilog
+environment=HOME="/tmp",USER="galactilog"
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/fd/2


### PR DESCRIPTION
**Summary**
This PR configures the container to run as a non-root user with PUID/PGID remapping, resolving bind-mount permission issues between the host and container.

**Changes**
*   Configures the Docker container to run as the `galactilog` non-root user.
*   Implements PUID/PGID remapping within the container's `entrypoint.sh` script.
*   Resolves bind-mount permission conflicts encountered when using host volumes.
*   Adds comprehensive container permission tests, including a new `container_perms.sh` script and `test_container_permissions.py`.
*   Updates `Dockerfile`, `entrypoint.sh`, `docker-compose.example.yml`, `docker-compose.override.example.yml`, and `supervisord.conf` to support the new user model.
*   Revises `INSTALL.md`, `UPGRADE.md`, and `CONFIGURATION.md` to reflect the new permission handling and required environment variables.

**Impact**
*   **Container Runtime:** The container now operates with reduced privileges as a non-root user, enhancing security.
*   **File System Permissions:** Bind-mounted volumes correctly handle host user/group IDs, eliminating permission errors for mounted directories.
*   **Installation & Configuration:** Users must account for `PUID` and `PGID` environment variables during setup to ensure correct file ownership.
*   **Testing:** New dedicated tests validate container permission behavior and PUID/PGID remapping.
*   **Documentation:** Installation, upgrade, and configuration guides are updated to reflect these changes.