### PR TITLE
Activity Log Redesign, Task Tracking, and Unified Notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ Thumbs.db
 thumbnails/
 celerybeat-schedule
 
+# PUID/PGID test harness mounts (backend/tests/container_perms.sh)
+.test_mounts/
+
 CLAUDE.md
 
 # Claude Code / Superpowers tooling
@@ -52,3 +55,6 @@ guides/specs/
 .worktrees/
 repomix-output.*
 .repomixignore
+
+# Dev override writes /app/run to ./backend/run on the host
+backend/run/

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,15 @@ ARG GALACTILOG_GIT_SHA=unknown
 ENV GALACTILOG_VERSION=${GALACTILOG_VERSION} \
     GALACTILOG_GIT_SHA=${GALACTILOG_GIT_SHA}
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    nginx supervisor curl \
+    nginx supervisor curl gosu libcap2-bin \
     && rm -rf /var/lib/apt/lists/* \
-    && rm -f /etc/nginx/sites-enabled/default
+    && rm -f /etc/nginx/sites-enabled/default \
+    && groupadd -g 1000 galactilog \
+    && useradd -u 1000 -g 1000 -M -s /sbin/nologin galactilog \
+    && mkdir -p /var/log/nginx \
+    && ln -sf /dev/stdout /var/log/nginx/access.log \
+    && ln -sf /dev/stderr /var/log/nginx/error.log \
+    && chown -R galactilog:galactilog /var/log/nginx
 
 COPY --from=backend-deps /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
 COPY --from=backend-deps /usr/local/bin /usr/local/bin
@@ -35,11 +41,22 @@ COPY backend/app/ /app/app/
 COPY backend/data/ /app/data/
 COPY backend/alembic.ini /app/alembic.ini
 COPY backend/alembic/ /app/alembic/
+# nginx.conf is mounted at conf.d/default.conf (inside http{} context). Directives
+# that must live in the main config (pid, error_log) are redirected via sed below.
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY backend/entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh \
-    && mkdir -p /app/data/fits /app/data/thumbnails /app/data/thumbnails/previews
+    && mkdir -p /app/data/fits /app/data/thumbnails /app/data/thumbnails/previews \
+                /app/run /app/run/nginx \
+                /app/run/nginx/client_body /app/run/nginx/proxy \
+                /app/run/nginx/fastcgi /app/run/nginx/uwsgi /app/run/nginx/scgi \
+    && sed -i 's|^pid .*|pid /app/run/nginx/nginx.pid;|' /etc/nginx/nginx.conf \
+    && sed -i 's|^user .*|user galactilog galactilog;|' /etc/nginx/nginx.conf \
+    && sed -i 's|^error_log .*|error_log /var/log/nginx/error.log warn;|' /etc/nginx/nginx.conf \
+    && sed -i '/^http {/a\    client_body_temp_path /app/run/nginx/client_body;\n    proxy_temp_path /app/run/nginx/proxy;\n    fastcgi_temp_path /app/run/nginx/fastcgi;\n    uwsgi_temp_path /app/run/nginx/uwsgi;\n    scgi_temp_path /app/run/nginx/scgi;' /etc/nginx/nginx.conf \
+    && chown -R galactilog:galactilog /app/data /app/run \
+    && setcap cap_net_bind_service=+ep /usr/sbin/nginx
 
 WORKDIR /app
 ENV GALACTILOG_CELERY_CONCURRENCY=4

--- a/README.md
+++ b/README.md
@@ -177,11 +177,12 @@ docker compose up -d
 
 Migrations run automatically on first start. Log in with the admin credentials from the compose file and trigger your first scan from Settings.
 
-See the [Install Guide](guides/INSTALL.md) for platform-specific paths, version pinning, building from source, and troubleshooting.
+See the [Install Guide](guides/INSTALL.md) for platform-specific paths, version pinning, building from source, non-root and `PUID`/`PGID` setup, and troubleshooting.
 
 ## Guides
 
 - [Install Guide](guides/INSTALL.md) -- Installation, updating, uninstalling, and troubleshooting
+- [Upgrade Guide](guides/UPGRADE.md) -- Release-specific upgrade notes and migration steps
 - [N.I.N.A. Setup Guide](guides/NINA-SETUP.md) -- Configuring N.I.N.A. for use with GalactiLog
 - [Configuration Guide](guides/CONFIGURATION.md) -- Environment variables, themes, filter/equipment aliases, and display settings
 - [Security Guide](guides/security.md) -- Authentication, HTTPS, cookie security, and user management

--- a/backend/alembic/versions/0011_add_activity_events.py
+++ b/backend/alembic/versions/0011_add_activity_events.py
@@ -1,0 +1,68 @@
+"""Add activity_events table.
+
+Creates the activity_events table with all columns and indexes defined in
+the activity log redesign spec. Uses defensive IF NOT EXISTS guards per
+project convention.
+"""
+from alembic import op
+from sqlalchemy import text
+
+revision = "0011"
+down_revision = "0010"
+branch_labels = None
+depends_on = None
+
+
+def _table_exists(name: str) -> bool:
+    conn = op.get_bind()
+    result = conn.execute(
+        text(
+            "SELECT 1 FROM information_schema.tables "
+            "WHERE table_schema = 'public' AND table_name = :name"
+        ),
+        {"name": name},
+    )
+    return result.fetchone() is not None
+
+
+def upgrade():
+    if not _table_exists("activity_events"):
+        op.execute("""
+            CREATE TABLE activity_events (
+                id          bigserial PRIMARY KEY,
+                timestamp   timestamptz NOT NULL DEFAULT now(),
+                severity    varchar(16) NOT NULL,
+                category    varchar(32) NOT NULL,
+                event_type  varchar(64) NOT NULL,
+                message     text NOT NULL,
+                details     jsonb,
+                target_id   uuid REFERENCES targets(id) ON DELETE SET NULL,
+                actor       varchar(64),
+                duration_ms integer
+            )
+        """)
+
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_activity_timestamp_desc "
+        "ON activity_events (timestamp DESC)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_activity_severity_ts "
+        "ON activity_events (severity, timestamp DESC)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_activity_category_ts "
+        "ON activity_events (category, timestamp DESC)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_activity_target "
+        "ON activity_events (target_id) WHERE target_id IS NOT NULL"
+    )
+
+
+def downgrade():
+    op.execute("DROP INDEX IF EXISTS idx_activity_target")
+    op.execute("DROP INDEX IF EXISTS idx_activity_category_ts")
+    op.execute("DROP INDEX IF EXISTS idx_activity_severity_ts")
+    op.execute("DROP INDEX IF EXISTS idx_activity_timestamp_desc")
+    op.execute("DROP TABLE IF EXISTS activity_events")

--- a/backend/app/api/activity.py
+++ b/backend/app/api/activity.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_current_user, require_admin
+from app.database import get_session
+from app.models.activity_event import ActivityEvent
+from app.models.user import User
+from app.schemas.activity import ActivityItem, PaginatedActivityResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/activity", tags=["activity"])
+
+_VALID_SEVERITIES = {"info", "warning", "error"}
+_VALID_CATEGORIES = {
+    "scan", "rebuild", "thumbnail", "enrichment",
+    "mosaic", "migration", "user_action", "system",
+}
+
+
+def _encode_cursor(ts: datetime, row_id: int) -> str:
+    payload = json.dumps({"ts": ts.isoformat(), "id": row_id})
+    return base64.urlsafe_b64encode(payload.encode()).decode()
+
+
+def _decode_cursor(cursor: str) -> tuple[datetime, int] | None:
+    try:
+        payload = json.loads(base64.urlsafe_b64decode(cursor.encode()).decode())
+        return datetime.fromisoformat(payload["ts"]), int(payload["id"])
+    except Exception:
+        return None
+
+
+@router.get("", response_model=PaginatedActivityResponse)
+async def list_activity(
+    severity: list[str] = Query(default=[]),
+    category: list[str] = Query(default=[]),
+    limit: int = Query(default=50, ge=1, le=200),
+    cursor: str | None = Query(default=None),
+    since: datetime | None = Query(default=None),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(get_current_user),
+):
+    """Return paginated activity events, newest first.
+
+    Keyset pagination via `cursor` (encodes timestamp + id of last row from
+    previous page). `since` is used by the error toast poller.
+    """
+    count_q = select(func.count(ActivityEvent.id))
+    items_q = select(ActivityEvent)
+
+    valid_sev = [s for s in severity if s in _VALID_SEVERITIES]
+    if valid_sev:
+        count_q = count_q.where(ActivityEvent.severity.in_(valid_sev))
+        items_q = items_q.where(ActivityEvent.severity.in_(valid_sev))
+
+    valid_cat = [c for c in category if c in _VALID_CATEGORIES]
+    if valid_cat:
+        count_q = count_q.where(ActivityEvent.category.in_(valid_cat))
+        items_q = items_q.where(ActivityEvent.category.in_(valid_cat))
+
+    if since is not None:
+        count_q = count_q.where(ActivityEvent.timestamp > since)
+        items_q = items_q.where(ActivityEvent.timestamp > since)
+
+    total = (await session.execute(count_q)).scalar_one()
+
+    if cursor:
+        decoded = _decode_cursor(cursor)
+        if decoded:
+            cursor_ts, cursor_id = decoded
+            items_q = items_q.where(
+                (ActivityEvent.timestamp < cursor_ts)
+                | (
+                    (ActivityEvent.timestamp == cursor_ts)
+                    & (ActivityEvent.id < cursor_id)
+                )
+            )
+
+    items_q = (
+        items_q
+        .order_by(ActivityEvent.timestamp.desc(), ActivityEvent.id.desc())
+        .limit(limit)
+    )
+
+    result = await session.execute(items_q)
+    rows = result.scalars().all()
+
+    next_cursor = None
+    if len(rows) == limit:
+        last = rows[-1]
+        next_cursor = _encode_cursor(last.timestamp, last.id)
+
+    return PaginatedActivityResponse(
+        items=[ActivityItem.model_validate(r) for r in rows],
+        next_cursor=next_cursor,
+        total=total,
+    )
+
+
+@router.delete("")
+async def clear_activity(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_admin),
+):
+    """Delete all activity_events rows. Admin only."""
+    await session.execute(delete(ActivityEvent))
+    await session.commit()
+    return {"status": "cleared"}

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -25,6 +25,7 @@ from .backup import router as backup_router
 from .planning import router as planning_router
 from .bootstrap import router as bootstrap_router
 from .preview import router as preview_router
+from .activity import router as activity_router
 from app.database import async_session
 from app.config import async_redis
 
@@ -44,6 +45,7 @@ api_router.include_router(backup_router)
 api_router.include_router(planning_router)
 api_router.include_router(bootstrap_router)
 api_router.include_router(preview_router)
+api_router.include_router(activity_router)
 
 
 @api_router.get("/version")

--- a/backend/app/api/scan.py
+++ b/backend/app/api/scan.py
@@ -20,10 +20,10 @@ from app.schemas.scan_filters import (
     ValidateRegexIn, ValidateRegexOut,
 )
 from app.services.scan_filters import ScanFilterConfig
+from app.services.activity import emit as _emit_activity
 from app.services.scan_state import (
     get_scan_state, get_failed_files, start_scanning, set_ingesting, set_idle, reset_scan,
     get_rebuild_state, request_cancel,
-    append_activity,
 )
 from app.services.simbad import resolve_target_name, normalize_object_name
 from app.worker.tasks import regenerate_thumbnail, run_scan, rebuild_targets, smart_rebuild_targets, retry_unresolved, backfill_csv_metrics, generate_reference_thumbnails, run_xmatch_enrichment, purge_and_regenerate_thumbnails
@@ -605,21 +605,19 @@ async def apply_filters_now(
         )
         await session.commit()
 
-        import time as _time
-        async with async_redis() as r:
-            await append_activity(r, {
-                "type": "scan_filters_applied",
-                "message": (
-                    f"Scan filters applied: {len(matched_ids)} image row"
-                    f"{'s' if len(matched_ids) != 1 else ''} removed "
-                    f"(by {user.username})"
-                ),
-                "details": {
-                    "removed": len(matched_ids),
-                    "by_user": user.username,
-                },
-                "timestamp": _time.time(),
-            })
+        await _emit_activity(
+            session,
+            category="scan",
+            severity="info",
+            event_type="scan_filters_applied",
+            message=(
+                f"Scan filters applied: {len(matched_ids)} image row"
+                f"{'s' if len(matched_ids) != 1 else ''} removed "
+                f"(by {user.username})"
+            ),
+            details={"removed": len(matched_ids), "by_user": user.username},
+            actor=user.username,
+        )
         logger.info(
             "scan_filters_applied: removed %d image rows by user %s",
             len(matched_ids), user.username,

--- a/backend/app/api/scan.py
+++ b/backend/app/api/scan.py
@@ -23,7 +23,7 @@ from app.services.scan_filters import ScanFilterConfig
 from app.services.scan_state import (
     get_scan_state, get_failed_files, start_scanning, set_ingesting, set_idle, reset_scan,
     get_rebuild_state, request_cancel,
-    get_activity, clear_activity, append_activity,
+    append_activity,
 )
 from app.services.simbad import resolve_target_name, normalize_object_name
 from app.worker.tasks import regenerate_thumbnail, run_scan, rebuild_targets, smart_rebuild_targets, retry_unresolved, backfill_csv_metrics, generate_reference_thumbnails, run_xmatch_enrichment, purge_and_regenerate_thumbnails
@@ -146,21 +146,6 @@ async def stop_scan(user: User = Depends(require_admin)):
             return {"status": "not_running", "state": state.state}
         await request_cancel(r)
         return {"status": "stopping", "message": "Cancel requested - task will stop shortly"}
-
-
-@router.get("/activity")
-async def get_activity_log(user: User = Depends(get_current_user)):
-    """Return persistent activity log (newest first)."""
-    async with async_redis() as r:
-        return await get_activity(r)
-
-
-@router.delete("/activity")
-async def clear_activity_log(user: User = Depends(require_admin)):
-    """Clear the activity log."""
-    async with async_redis() as r:
-        await clear_activity(r)
-        return {"status": "cleared"}
 
 
 @router.post("/reset")

--- a/backend/app/api/scan.py
+++ b/backend/app/api/scan.py
@@ -95,10 +95,11 @@ async def regenerate_thumbnails(
         if purge:
             # Defer DB work and file deletions to Celery so the HTTP call
             # returns immediately and progress is reported via activity log.
-            purge_and_regenerate_thumbnails.delay()
+            task = purge_and_regenerate_thumbnails.delay()
             return {
                 "status": "accepted",
                 "message": "Queued: delete and regenerate all thumbnails",
+                "task_id": task.id,
             }
 
         result = await session.execute(
@@ -294,8 +295,8 @@ async def trigger_rebuild_targets(user: User = Depends(require_admin)):
                 detail="A scan is already running. Wait for it to complete first.",
             )
 
-        rebuild_targets.delay()
-        return {"status": "accepted", "message": "Target rebuild queued as background task"}
+        task = rebuild_targets.delay()
+        return {"status": "accepted", "message": "Target rebuild queued as background task", "task_id": task.id}
 
 
 @router.post("/smart-rebuild-targets")
@@ -313,8 +314,8 @@ async def trigger_smart_rebuild(user: User = Depends(require_admin)):
                 detail="A scan is already running. Wait for it to complete first.",
             )
 
-        smart_rebuild_targets.delay(manual=True)
-        return {"status": "accepted", "message": "Smart rebuild queued as background task"}
+        task = smart_rebuild_targets.delay(manual=True)
+        return {"status": "accepted", "message": "Smart rebuild queued as background task", "task_id": task.id}
 
 
 @router.post("/retry-unresolved")
@@ -328,8 +329,8 @@ async def trigger_retry_unresolved(user: User = Depends(require_admin)):
                 detail="A scan is already running. Wait for it to complete first.",
             )
 
-        retry_unresolved.delay()
-        return {"status": "accepted", "message": "Retry unresolved queued as background task"}
+        task = retry_unresolved.delay()
+        return {"status": "accepted", "message": "Retry unresolved queued as background task", "task_id": task.id}
 
 
 @router.post("/generate-reference-thumbnails")
@@ -343,8 +344,8 @@ async def trigger_reference_thumbnails(force: bool = False, user: User = Depends
                 detail="A scan is already running. Wait for it to complete first.",
             )
 
-        generate_reference_thumbnails.delay(force=force)
-        return {"status": "accepted", "message": "Reference thumbnail generation queued as background task"}
+        task = generate_reference_thumbnails.delay(force=force)
+        return {"status": "accepted", "message": "Reference thumbnail generation queued as background task", "task_id": task.id}
 
 
 @router.post("/xmatch-enrichment")
@@ -358,8 +359,8 @@ async def trigger_xmatch_enrichment(user: User = Depends(require_admin)):
                 detail="A scan is already running. Wait for it to complete first.",
             )
 
-        run_xmatch_enrichment.delay()
-        return {"status": "accepted", "message": "xMatch enrichment queued as background task"}
+        task = run_xmatch_enrichment.delay()
+        return {"status": "accepted", "message": "xMatch enrichment queued as background task", "task_id": task.id}
 
 
 @router.post("/backfill-csv")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,10 +9,11 @@ from fastapi.staticfiles import StaticFiles
 from slowapi.errors import RateLimitExceeded
 from starlette.responses import JSONResponse
 
-from app.config import settings, limiter
+from app.config import settings, limiter, async_redis
+from app.database import async_session
 from app.api.router import api_router
 from app.api.metrics_endpoint import router as metrics_router
-from app.metrics import PrometheusMiddleware
+from app.metrics import PrometheusMiddleware, start_queue_depth_probe, register_celery_collector
 
 logger = logging.getLogger(__name__)
 
@@ -24,11 +25,18 @@ async def lifespan(app: FastAPI):
         logger.warning("GALACTILOG_JWT_SECRET is not set - using auto-generated secret. Sessions will not survive restarts. Set GALACTILOG_JWT_SECRET in .env for persistence.")
 
     # Ensure required PostgreSQL extensions exist (idempotent)
-    from app.database import async_session
     from sqlalchemy import text
     async with async_session() as session:
         await session.execute(text("CREATE EXTENSION IF NOT EXISTS pg_trgm"))
         await session.commit()
+
+    # Delete legacy scan:activity Redis list replaced by activity_events table.
+    try:
+        async with async_redis() as r:
+            await r.delete("scan:activity")
+        logger.info("Deleted legacy scan:activity Redis key")
+    except Exception as e:
+        logger.warning("Failed to delete scan:activity key: %s", e)
 
     # Auto-create accounts from env vars if they don't already exist
     if settings.admin_password or settings.viewer_password:
@@ -85,7 +93,6 @@ async def lifespan(app: FastAPI):
 
     # Start queue depth probe in the uvicorn process so gauges are visible
     # at the /metrics endpoint (worker and uvicorn have separate registries)
-    from app.metrics import start_queue_depth_probe, register_celery_collector
     from app.worker.celery_app import celery_app
     start_queue_depth_probe(celery_app, settings.redis_url)
     register_celery_collector(settings.redis_url)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -24,5 +24,6 @@ from .herschel400_catalog import Herschel400Entry
 from .arp_catalog import ArpEntry
 from .abell_catalog import AbellEntry
 from .catalog_membership import TargetCatalogMembership
+from .activity_event import ActivityEvent
 
-__all__ = ["Base", "Target", "Image", "UserSettings", "SETTINGS_ROW_ID", "MergeCandidate", "SimbadCache", "SesameCache", "User", "UserRole", "RefreshToken", "AppMetadata", "OpenNGCEntry", "VizierCache", "SiteDarkHours", "SessionNote", "Mosaic", "MosaicPanel", "MosaicSuggestion", "CustomColumn", "CustomColumnValue", "ColumnType", "AppliesTo", "FilenameCandidate", "GaiaCache", "SACEntry", "CaldwellEntry", "Herschel400Entry", "ArpEntry", "AbellEntry", "TargetCatalogMembership"]
+__all__ = ["Base", "Target", "Image", "UserSettings", "SETTINGS_ROW_ID", "MergeCandidate", "SimbadCache", "SesameCache", "User", "UserRole", "RefreshToken", "AppMetadata", "OpenNGCEntry", "VizierCache", "SiteDarkHours", "SessionNote", "Mosaic", "MosaicPanel", "MosaicSuggestion", "CustomColumn", "CustomColumnValue", "ColumnType", "AppliesTo", "FilenameCandidate", "GaiaCache", "SACEntry", "CaldwellEntry", "Herschel400Entry", "ArpEntry", "AbellEntry", "TargetCatalogMembership", "ActivityEvent"]

--- a/backend/app/models/activity_event.py
+++ b/backend/app/models/activity_event.py
@@ -1,0 +1,32 @@
+from datetime import datetime, timezone
+from uuid import UUID as _UUID
+
+from sqlalchemy import BigInteger, DateTime, ForeignKey, Integer, String, Text, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import Base
+
+
+class ActivityEvent(Base):
+    __tablename__ = "activity_events"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    timestamp: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+    )
+    severity: Mapped[str] = mapped_column(String(16), nullable=False)
+    category: Mapped[str] = mapped_column(String(32), nullable=False)
+    event_type: Mapped[str] = mapped_column(String(64), nullable=False)
+    message: Mapped[str] = mapped_column(Text, nullable=False)
+    details: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    target_id: Mapped[_UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("targets.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    actor: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    duration_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)

--- a/backend/app/schemas/activity.py
+++ b/backend/app/schemas/activity.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class ActivityItem(BaseModel):
+    id: int
+    timestamp: datetime
+    severity: str
+    category: str
+    event_type: str
+    message: str
+    details: dict[str, Any] | None = None
+    target_id: UUID | None = None
+    actor: str | None = None
+    duration_ms: int | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class PaginatedActivityResponse(BaseModel):
+    items: list[ActivityItem]
+    next_cursor: str | None = None
+    total: int
+
+
+class ActivityFilterParams(BaseModel):
+    severity: list[str] = Field(default_factory=list)
+    category: list[str] = Field(default_factory=list)
+    limit: int = Field(default=50, ge=1, le=200)
+    cursor: str | None = None
+    since: datetime | None = None
+
+    @field_validator("limit", mode="before")
+    @classmethod
+    def cap_limit(cls, v: int) -> int:
+        return min(int(v), 200)

--- a/backend/app/schemas/settings.py
+++ b/backend/app/schemas/settings.py
@@ -23,6 +23,7 @@ class GeneralSettings(BaseModel):
     use_imaging_night: bool = True
     preview_resolution: int = 2400  # 0 means native full resolution
     preview_cache_mb: int = 2048
+    activity_retention_days: int = Field(default=90, ge=1, le=3650)
 
 
 class FilterConfig(BaseModel):

--- a/backend/app/services/activity.py
+++ b/backend/app/services/activity.py
@@ -1,0 +1,148 @@
+"""Activity event emit helpers.
+
+emit()      - async, for FastAPI route handlers.
+emit_sync() - sync, for Celery tasks.
+
+Neither function raises to the caller (except for validation errors in
+development env). Failures are logged only.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Session
+
+from app.config import async_redis
+from app.models.activity_event import ActivityEvent
+
+logger = logging.getLogger(__name__)
+
+VALID_SEVERITIES = frozenset({"info", "warning", "error"})
+VALID_CATEGORIES = frozenset({
+    "scan", "rebuild", "thumbnail", "enrichment",
+    "mosaic", "migration", "user_action", "system",
+})
+
+_ENV = os.environ.get("GALACTILOG_ENV", "production")
+
+
+def _validate(severity: str, category: str) -> bool:
+    ok = True
+    if severity not in VALID_SEVERITIES:
+        msg = f"Invalid severity '{severity}'. Must be one of {sorted(VALID_SEVERITIES)}"
+        if _ENV == "development":
+            raise ValueError(msg)
+        logger.warning("activity.emit: %s", msg)
+        ok = False
+    if category not in VALID_CATEGORIES:
+        msg = f"Invalid category '{category}'. Must be one of {sorted(VALID_CATEGORIES)}"
+        if _ENV == "development":
+            raise ValueError(msg)
+        logger.warning("activity.emit: %s", msg)
+        ok = False
+    return ok
+
+
+def _build_event(
+    *,
+    category: str,
+    severity: str,
+    event_type: str,
+    message: str,
+    details: dict[str, Any] | None = None,
+    target_id: UUID | None = None,
+    actor: str | None = None,
+    duration_ms: int | None = None,
+) -> ActivityEvent:
+    return ActivityEvent(
+        severity=severity,
+        category=category,
+        event_type=event_type,
+        message=message,
+        details=details,
+        target_id=target_id,
+        actor=actor,
+        duration_ms=duration_ms,
+    )
+
+
+def _pubsub_payload(event: ActivityEvent) -> str:
+    return json.dumps({
+        "event_type": event.event_type,
+        "severity": event.severity,
+        "category": event.category,
+        "message": event.message,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    })
+
+
+async def emit(
+    db: AsyncSession,
+    *,
+    category: str,
+    severity: str,
+    event_type: str,
+    message: str,
+    details: dict[str, Any] | None = None,
+    target_id: UUID | None = None,
+    actor: str | None = None,
+    duration_ms: int | None = None,
+) -> None:
+    """Insert one ActivityEvent row and publish to Redis pubsub activity:new."""
+    if not _validate(severity, category):
+        return
+    event = _build_event(
+        category=category, severity=severity, event_type=event_type,
+        message=message, details=details, target_id=target_id,
+        actor=actor, duration_ms=duration_ms,
+    )
+    try:
+        db.add(event)
+        await db.commit()
+    except Exception:
+        logger.exception("activity.emit: DB insert failed for event_type=%s", event_type)
+        return
+    try:
+        async with async_redis() as r:
+            await r.publish("activity:new", _pubsub_payload(event))
+    except Exception:
+        logger.warning("activity.emit: Redis publish failed for event_type=%s", event_type)
+
+
+def emit_sync(
+    db: Session,
+    *,
+    redis,
+    category: str,
+    severity: str,
+    event_type: str,
+    message: str,
+    details: dict[str, Any] | None = None,
+    target_id: UUID | None = None,
+    actor: str | None = None,
+    duration_ms: int | None = None,
+) -> None:
+    """Sync version of emit() for Celery tasks."""
+    if not _validate(severity, category):
+        return
+    event = _build_event(
+        category=category, severity=severity, event_type=event_type,
+        message=message, details=details, target_id=target_id,
+        actor=actor, duration_ms=duration_ms,
+    )
+    try:
+        db.add(event)
+        db.commit()
+    except Exception:
+        logger.exception("activity.emit_sync: DB insert failed for event_type=%s", event_type)
+        return
+    try:
+        redis.publish("activity:new", _pubsub_payload(event))
+    except Exception:
+        logger.warning("activity.emit_sync: Redis publish failed for event_type=%s", event_type)

--- a/backend/app/services/mosaic_composite.py
+++ b/backend/app/services/mosaic_composite.py
@@ -17,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from astropy.wcs import WCS
 
 from app.models.image import Image
+from app.services.activity import emit as _emit_activity
 from app.services.thumbnail import _read_binned
 from app.services.stretch import (
     normalize_to_unit,
@@ -350,72 +351,88 @@ async def build_mosaic_composite(
     tile_max_width: int = 400,
 ) -> bytes:
     """Full orchestrator: select frames, check cache, generate composite."""
-    panel_frames = []
-    for panel in panels:
-        frame = await select_best_frame(panel.target_id, panel.object_pattern, session)
-        if frame and frame.file_path:
-            panel_frames.append((panel, frame))
+    try:
+        panel_frames = []
+        for panel in panels:
+            frame = await select_best_frame(panel.target_id, panel.object_pattern, session)
+            if frame and frame.file_path:
+                panel_frames.append((panel, frame))
 
-    if not panel_frames:
-        raise ValueError("No panels have accessible FITS frames")
+        if not panel_frames:
+            raise ValueError("No panels have accessible FITS frames")
 
-    frame_ids = [f.id for _, f in panel_frames]
-    cache_key = _compute_cache_key(mosaic_id, frame_ids)
-    cached = _get_cached(cache_key)
-    if cached:
-        return cached
+        frame_ids = [f.id for _, f in panel_frames]
+        cache_key = _compute_cache_key(mosaic_id, frame_ids)
+        cached = _get_cached(cache_key)
+        if cached:
+            return cached
 
-    panel_infos = []
-    tiles = {}
-    for panel, frame in panel_frames:
-        headers = frame.raw_headers or {}
-        ra_raw = headers.get("RA") or headers.get("OBJCTRA")
-        dec_raw = headers.get("DEC") or headers.get("OBJCTDEC")
-        ra = _parse_ra(ra_raw)
-        dec = _parse_coord(dec_raw)
-        if ra is None or dec is None:
-            continue
+        panel_infos = []
+        tiles = {}
+        for panel, frame in panel_frames:
+            headers = frame.raw_headers or {}
+            ra_raw = headers.get("RA") or headers.get("OBJCTRA")
+            dec_raw = headers.get("DEC") or headers.get("OBJCTDEC")
+            ra = _parse_ra(ra_raw)
+            dec = _parse_coord(dec_raw)
+            if ra is None or dec is None:
+                continue
 
-        pid = str(panel.id)
-        fits_path = Path(frame.file_path)
-        if not fits_path.exists():
-            continue
+            pid = str(panel.id)
+            fits_path = Path(frame.file_path)
+            if not fits_path.exists():
+                continue
+            try:
+                tile_img, native_width = generate_panel_thumbnail(fits_path, max_width=tile_max_width)
+                tiles[pid] = tile_img
+            except Exception:
+                logger.warning("Failed to generate thumbnail for panel %s", panel.id)
+                continue
+
+            panel_infos.append(PanelInfo(
+                panel_id=pid,
+                ra=ra,
+                dec=dec,
+                objctrot=float(headers.get("OBJCTROT", 0)),
+                pierside=str(headers.get("PIERSIDE", "West")),
+                fits_path=frame.file_path,
+                focallen=float(headers.get("FOCALLEN", 448)),
+                xpixsz=float(headers.get("XPIXSZ", 3.76)),
+            ))
+
+        if not tiles:
+            raise ValueError("No panels could be rendered from FITS files")
+
+        sample_tile = next(iter(tiles.values()))
+        # Scale factor: thumbnail pixels / native sensor pixels
+        thumb_scale = sample_tile.width / native_width if native_width > 0 else 1.0
+        layout = compute_panel_layout(
+            panel_infos,
+            tile_width=sample_tile.width,
+            tile_height=sample_tile.height,
+            scale=thumb_scale,
+        )
+
+        composite = composite_panels(tiles, layout)
+
+        buf = io.BytesIO()
+        composite.save(buf, "JPEG", quality=90)
+        jpeg_bytes = buf.getvalue()
+
+        _set_cached(cache_key, jpeg_bytes)
+        return jpeg_bytes
+    except Exception as exc:
+        logger.error("mosaic_composite: failed - %s", exc, exc_info=True)
         try:
-            tile_img, native_width = generate_panel_thumbnail(fits_path, max_width=tile_max_width)
-            tiles[pid] = tile_img
+            await _emit_activity(
+                session,
+                category="mosaic",
+                severity="error",
+                event_type="mosaic_composite_failed",
+                message=f"Mosaic composite generation failed: {exc}",
+                details={"error": str(exc), "mosaic_id": str(mosaic_id)},
+                actor="system",
+            )
         except Exception:
-            logger.warning("Failed to generate thumbnail for panel %s", panel.id)
-            continue
-
-        panel_infos.append(PanelInfo(
-            panel_id=pid,
-            ra=ra,
-            dec=dec,
-            objctrot=float(headers.get("OBJCTROT", 0)),
-            pierside=str(headers.get("PIERSIDE", "West")),
-            fits_path=frame.file_path,
-            focallen=float(headers.get("FOCALLEN", 448)),
-            xpixsz=float(headers.get("XPIXSZ", 3.76)),
-        ))
-
-    if not tiles:
-        raise ValueError("No panels could be rendered from FITS files")
-
-    sample_tile = next(iter(tiles.values()))
-    # Scale factor: thumbnail pixels / native sensor pixels
-    thumb_scale = sample_tile.width / native_width if native_width > 0 else 1.0
-    layout = compute_panel_layout(
-        panel_infos,
-        tile_width=sample_tile.width,
-        tile_height=sample_tile.height,
-        scale=thumb_scale,
-    )
-
-    composite = composite_panels(tiles, layout)
-
-    buf = io.BytesIO()
-    composite.save(buf, "JPEG", quality=90)
-    jpeg_bytes = buf.getvalue()
-
-    _set_cached(cache_key, jpeg_bytes)
-    return jpeg_bytes
+            pass
+        raise

--- a/backend/app/services/scan_state.py
+++ b/backend/app/services/scan_state.py
@@ -5,11 +5,18 @@ Keys used:
   scan:state is set to expire after 24h on completion so old results don't linger forever.
 """
 
+import logging
 import time
 from dataclasses import dataclass
 
 import redis.asyncio as aioredis
 import redis as sync_redis
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session as _SyncSession
+
+from app.services.activity import emit_sync
+
+logger = logging.getLogger(__name__)
 
 SCAN_KEY = "scan:state"
 SCAN_PROGRESS_KEY = "scan:last_progress"
@@ -218,12 +225,47 @@ def check_complete_sync(r: sync_redis.Redis) -> None:
         if snap.removed:
             parts.append(f"{snap.removed} deleted file{'s' if snap.removed != 1 else ''} purged")
         msg = "Scan complete: " + (", ".join(parts) if parts else "no changes")
-        append_activity_sync(r, {
-            "type": "scan_complete",
-            "message": msg,
-            "details": {"completed": snap.completed, "failed": snap.failed, "skipped_calibration": snap.skipped_calibration, "csv_enriched": snap.csv_enriched, "total": snap.total, "removed": snap.removed, "new_files": snap.new_files, "changed_files": snap.changed_files},
-            "timestamp": time.time(),
-        })
+        try:
+            from app.config import settings as _cfg
+            _engine = create_engine(
+                _cfg.database_url.replace("+asyncpg", "+psycopg2"),
+                pool_pre_ping=True,
+            )
+            with _SyncSession(_engine) as _db:
+                emit_sync(
+                    _db, redis=r, category="scan", severity="info",
+                    event_type="scan_complete", message=msg,
+                    details={
+                        "completed": snap.completed, "failed": snap.failed,
+                        "skipped_calibration": snap.skipped_calibration,
+                        "csv_enriched": snap.csv_enriched, "total": snap.total,
+                        "removed": snap.removed, "new_files": snap.new_files,
+                        "changed_files": snap.changed_files,
+                    },
+                    actor="system",
+                )
+                if snap.failed > 0:
+                    import json as _json
+                    raw = r.lrange(SCAN_FAILED_KEY, 0, -1)
+                    failed_files = []
+                    for item in raw[:500]:
+                        try:
+                            entry = _json.loads(item)
+                            failed_files.append({
+                                "path": entry.get("file", ""),
+                                "reason": entry.get("error", ""),
+                            })
+                        except Exception:
+                            pass
+                    emit_sync(
+                        _db, redis=r, category="scan", severity="warning",
+                        event_type="scan_files_failed",
+                        message=f"Scan completed with {snap.failed} file failure{'s' if snap.failed != 1 else ''}",
+                        details={"failed_files": failed_files, "truncated": len(raw) > 500},
+                        actor="system",
+                    )
+        except Exception:
+            logger.exception("scan_state: failed to emit scan_complete activity")
         # Invalidate stats cache immediately so the next request gets fresh data
         try:
             r.delete("galactilog:stats:cache", "galactilog:fits_keys")

--- a/backend/app/services/scan_state.py
+++ b/backend/app/services/scan_state.py
@@ -356,13 +356,6 @@ def set_cancelled_sync(r: sync_redis.Redis) -> None:
     r.delete(SCAN_CANCEL_KEY)
 
 
-def append_activity_sync(r: sync_redis.Redis, entry: dict) -> None:
-    """Append an activity entry and cap the list at SCAN_ACTIVITY_MAX."""
-    import json
-    r.lpush(SCAN_ACTIVITY_KEY, json.dumps(entry))
-    r.ltrim(SCAN_ACTIVITY_KEY, 0, SCAN_ACTIVITY_MAX - 1)
-
-
 # ── Rebuild status (Quick Fix / Full Rebuild) ────────────────────────────
 
 REBUILD_KEY = "rebuild:status"

--- a/backend/app/services/scan_state.py
+++ b/backend/app/services/scan_state.py
@@ -257,13 +257,27 @@ def check_complete_sync(r: sync_redis.Redis) -> None:
                             })
                         except Exception:
                             pass
-                    emit_sync(
-                        _db, redis=r, category="scan", severity="warning",
-                        event_type="scan_files_failed",
-                        message=f"Scan completed with {snap.failed} file failure{'s' if snap.failed != 1 else ''}",
-                        details={"failed_files": failed_files, "truncated": len(raw) > 500},
-                        actor="system",
-                    )
+                    from app.config import settings as _cfg2
+                    thumb_root = _cfg2.thumbnails_path
+                    thumb_failures = [f for f in failed_files if f["path"].startswith(thumb_root)]
+                    fits_failures = [f for f in failed_files if not f["path"].startswith(thumb_root)]
+
+                    if thumb_failures:
+                        emit_sync(
+                            _db, redis=r, category="thumbnail", severity="warning",
+                            event_type="thumbnail_regen_failed",
+                            message=f"Thumbnail regen: {len(thumb_failures)} failure{'s' if len(thumb_failures) != 1 else ''}",
+                            details={"failed_files": thumb_failures, "truncated": len(raw) > 500},
+                            actor="system",
+                        )
+                    if fits_failures:
+                        emit_sync(
+                            _db, redis=r, category="scan", severity="warning",
+                            event_type="scan_files_failed",
+                            message=f"Scan completed with {len(fits_failures)} file failure{'s' if len(fits_failures) != 1 else ''}",
+                            details={"failed_files": fits_failures, "truncated": len(raw) > 500},
+                            actor="system",
+                        )
         except Exception:
             logger.exception("scan_state: failed to emit scan_complete activity")
         # Invalidate stats cache immediately so the next request gets fresh data

--- a/backend/app/worker/celery_app.py
+++ b/backend/app/worker/celery_app.py
@@ -1,4 +1,5 @@
 from celery import Celery
+from celery.schedules import crontab
 
 from app.config import settings
 
@@ -29,6 +30,10 @@ celery_app.conf.update(
         "auto-scan-tick": {
             "task": "app.worker.tasks.auto_scan_tick",
             "schedule": 60.0,
+        },
+        "prune-activity-events": {
+            "task": "app.worker.prune_activity.prune_activity_events",
+            "schedule": crontab(hour=3, minute=0),
         },
     },
 )

--- a/backend/app/worker/prune_activity.py
+++ b/backend/app/worker/prune_activity.py
@@ -1,0 +1,80 @@
+"""Nightly Celery beat task: prune activity_events rows older than retention window."""
+import logging
+
+from celery.schedules import crontab
+from sqlalchemy import create_engine, select, text
+from sqlalchemy.orm import Session
+
+from app.config import settings, get_sync_redis
+from app.models.user_settings import UserSettings, SETTINGS_ROW_ID
+from app.services.activity import emit_sync
+from app.worker.celery_app import celery_app
+
+logger = logging.getLogger(__name__)
+
+_sync_url = settings.database_url.replace("+asyncpg", "+psycopg2")
+_sync_engine = create_engine(_sync_url, pool_pre_ping=True)
+
+_DEFAULT_RETENTION_DAYS = 90
+
+
+@celery_app.task(name="app.worker.prune_activity.prune_activity_events")
+def prune_activity_events() -> dict:
+    """Delete activity_events rows older than activity_retention_days.
+
+    Reads retention from GeneralSettings. Emits activity_pruned only when
+    deleted_count > 0.
+    """
+    redis = get_sync_redis()
+
+    try:
+        with Session(_sync_engine) as session:
+            row = session.execute(
+                select(UserSettings).where(UserSettings.id == SETTINGS_ROW_ID)
+            ).scalar_one_or_none()
+
+            general = (row.general or {}) if row else {}
+            retention_days = int(general.get("activity_retention_days", _DEFAULT_RETENTION_DAYS))
+            retention_days = max(1, min(3650, retention_days))
+
+            result = session.execute(
+                text(
+                    f"DELETE FROM activity_events "
+                    f"WHERE timestamp < now() - interval '{retention_days} days'"
+                )
+            )
+            deleted = result.rowcount
+            session.commit()
+
+        logger.info(
+            "prune_activity_events: deleted %d rows (retention=%d days)",
+            deleted, retention_days,
+        )
+
+        if deleted > 0:
+            with Session(_sync_engine) as emit_session:
+                emit_sync(
+                    emit_session,
+                    redis=redis,
+                    category="system",
+                    severity="info",
+                    event_type="activity_pruned",
+                    message=(
+                        f"Activity log pruned: {deleted} "
+                        f"entr{'ies' if deleted != 1 else 'y'} older than "
+                        f"{retention_days} days removed"
+                    ),
+                    details={"deleted_count": deleted, "retention_days": retention_days},
+                    actor="system",
+                )
+
+        return {"status": "complete", "deleted": deleted, "retention_days": retention_days}
+
+    except Exception as exc:
+        logger.exception("prune_activity_events: failed - %s", exc)
+        return {"status": "error", "error": str(exc)}
+    finally:
+        try:
+            redis.close()
+        except Exception:
+            pass

--- a/backend/app/worker/tasks.py
+++ b/backend/app/worker/tasks.py
@@ -39,7 +39,7 @@ from app.services.scan_state import (
     set_rebuild_running_sync, set_rebuild_progress_sync, set_rebuild_complete_sync,
     set_rebuild_cancelled_sync,
     set_discovered_sync, is_cancel_requested_sync, clear_cancel_sync, set_cancelled_sync,
-    append_activity_sync, check_complete_sync,
+    check_complete_sync,
     add_skipped_path_sync, get_skipped_paths_sync, clear_skipped_paths_sync,
 )
 from app.services.activity import emit_sync as _emit_activity_sync
@@ -597,30 +597,33 @@ def purge_and_regenerate_thumbnails() -> dict:
     total = len(rows)
     if not total:
         set_idle_sync(_redis)
-        append_activity_sync(_redis, {
-            "type": "thumb_purge_complete",
-            "message": "Regen thumbnails: no images to process",
-            "details": {"deleted": 0, "queued": 0},
-            "timestamp": time.time(),
-        })
+        with _activity_session() as _db:
+            _emit_activity_sync(
+                _db, redis=_redis, category="thumbnail", severity="info",
+                event_type="thumb_purge_complete",
+                message="Regen thumbnails: no images to process",
+                details={"deleted": 0, "queued": 0}, actor="system",
+            )
         return {"status": "complete", "deleted": 0, "queued": 0}
 
     if is_cancel_requested_sync(_redis):
         set_cancelled_sync(_redis)
-        append_activity_sync(_redis, {
-            "type": "rebuild_cancelled",
-            "message": "Thumbnail purge cancelled before start",
-            "details": {"deleted": 0, "queued": 0, "total": total},
-            "timestamp": time.time(),
-        })
+        with _activity_session() as _db:
+            _emit_activity_sync(
+                _db, redis=_redis, category="thumbnail", severity="info",
+                event_type="rebuild_cancelled",
+                message="Thumbnail purge cancelled before start",
+                details={"deleted": 0, "queued": 0, "total": total}, actor="system",
+            )
         return {"status": "cancelled", "deleted": 0, "queued": 0}
 
-    append_activity_sync(_redis, {
-        "type": "thumb_purge_start",
-        "message": f"Deleting existing thumbnails for {total} image{'s' if total != 1 else ''}...",
-        "details": {"total": total},
-        "timestamp": time.time(),
-    })
+    with _activity_session() as _db:
+        _emit_activity_sync(
+            _db, redis=_redis, category="thumbnail", severity="info",
+            event_type="thumb_purge_start",
+            message=f"Deleting existing thumbnails for {total} image{'s' if total != 1 else ''}...",
+            details={"total": total}, actor="system",
+        )
 
     from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -638,8 +641,6 @@ def purge_and_regenerate_thumbnails() -> dict:
     paths = [tp for (_id, _fp, tp) in rows if tp]
     deleted = 0
     missing = 0
-    progress_every = 1000
-    processed = 0
     with ThreadPoolExecutor(max_workers=32) as pool:
         futures = [pool.submit(_unlink_one, tp) for tp in paths]
         for fut in as_completed(futures):
@@ -648,32 +649,28 @@ def purge_and_regenerate_thumbnails() -> dict:
                 deleted += 1
             elif result == "missing":
                 missing += 1
-            processed += 1
-            if processed % progress_every == 0:
-                append_activity_sync(_redis, {
-                    "type": "thumb_purge_progress",
-                    "message": f"Deleted {deleted} thumbnails ({processed}/{len(paths)})...",
-                    "details": {"deleted": deleted, "processed": processed, "total": len(paths)},
-                    "timestamp": time.time(),
-                })
 
-    append_activity_sync(_redis, {
-        "type": "thumb_purge_complete",
-        "message": f"Deleted {deleted} thumbnail{'s' if deleted != 1 else ''}"
-                   + (f" ({missing} already missing)" if missing else "")
-                   + f", queueing {total} for regeneration...",
-        "details": {"deleted": deleted, "missing": missing, "queued": total},
-        "timestamp": time.time(),
-    })
+    with _activity_session() as _db:
+        _emit_activity_sync(
+            _db, redis=_redis, category="thumbnail", severity="info",
+            event_type="thumb_purge_complete",
+            message=f"Deleted {deleted} thumbnail{'s' if deleted != 1 else ''}"
+                    + (f" ({missing} already missing)" if missing else "")
+                    + f", queueing {total} for regeneration...",
+            details={"deleted": deleted, "missing": missing, "queued": total},
+            actor="system",
+        )
 
     if is_cancel_requested_sync(_redis):
         set_cancelled_sync(_redis)
-        append_activity_sync(_redis, {
-            "type": "rebuild_cancelled",
-            "message": f"Thumbnail purge cancelled after deleting {deleted} files; regen skipped",
-            "details": {"deleted": deleted, "missing": missing, "queued": 0, "total": total},
-            "timestamp": time.time(),
-        })
+        with _activity_session() as _db:
+            _emit_activity_sync(
+                _db, redis=_redis, category="thumbnail", severity="info",
+                event_type="rebuild_cancelled",
+                message=f"Thumbnail purge cancelled after deleting {deleted} files; regen skipped",
+                details={"deleted": deleted, "missing": missing, "queued": 0, "total": total},
+                actor="system",
+            )
         return {"status": "cancelled", "deleted": deleted, "missing": missing, "queued": 0}
 
     set_ingesting_sync(_redis, total=total)
@@ -915,12 +912,13 @@ def rebuild_targets(self) -> dict:
                 f"Cancelled after {i}/{total} names ({resolved} resolved, {failed} failed)",
                 details,
             )
-            append_activity_sync(_redis, {
-                "type": "rebuild_cancelled",
-                "message": f"Full Rebuild cancelled after {i}/{total} names",
-                "details": details,
-                "timestamp": time.time(),
-            })
+            with _activity_session() as _db:
+                _emit_activity_sync(
+                    _db, redis=_redis, category="rebuild", severity="info",
+                    event_type="rebuild_cancelled",
+                    message=f"Full Rebuild cancelled after {i}/{total} names",
+                    details=details, actor="system",
+                )
             logger.info("rebuild_targets: cancelled after %d/%d", i, total)
             return {"status": "cancelled", **details}
 
@@ -957,12 +955,14 @@ def rebuild_targets(self) -> dict:
         f"Resolved {resolved} targets, {failed} failed out of {total} object names",
         details,
     )
-    append_activity_sync(_redis, {
-        "type": "rebuild_complete",
-        "message": f"Full Rebuild: {resolved} resolved, {failed} failed out of {total} names",
-        "details": {"resolved": resolved, "failed": failed, "total": total},
-        "timestamp": time.time(),
-    })
+    with _activity_session() as _db:
+        _emit_activity_sync(
+            _db, redis=_redis, category="rebuild", severity="info",
+            event_type="rebuild_complete",
+            message=f"Full Rebuild: {resolved} resolved, {failed} failed out of {total} names",
+            details={"resolved": resolved, "failed": failed, "total": total},
+            actor="system",
+        )
     logger.info("rebuild_targets: done - resolved=%d, failed=%d", resolved, failed)
     return {"status": "complete", **details}
 
@@ -1016,12 +1016,13 @@ def retry_unresolved(self) -> dict:
                 f"Cancelled after {i}/{total} names ({resolved} resolved, {failed} still unresolved)",
                 details,
             )
-            append_activity_sync(_redis, {
-                "type": "rebuild_cancelled",
-                "message": f"Retry Unresolved cancelled after {i}/{total} names",
-                "details": details,
-                "timestamp": time.time(),
-            })
+            with _activity_session() as _db:
+                _emit_activity_sync(
+                    _db, redis=_redis, category="rebuild", severity="info",
+                    event_type="rebuild_cancelled",
+                    message=f"Retry Unresolved cancelled after {i}/{total} names",
+                    details=details, actor="system",
+                )
             logger.info("retry_unresolved: cancelled after %d/%d", i, total)
             return {"status": "cancelled", **details}
 
@@ -1053,12 +1054,13 @@ def retry_unresolved(self) -> dict:
         f"Retry: {resolved} resolved, {failed} still unresolved out of {total} names",
         details,
     )
-    append_activity_sync(_redis, {
-        "type": "rebuild_complete",
-        "message": f"Retry Unresolved: {resolved} resolved, {failed} still unresolved out of {total} names",
-        "details": details,
-        "timestamp": time.time(),
-    })
+    with _activity_session() as _db:
+        _emit_activity_sync(
+            _db, redis=_redis, category="rebuild", severity="info",
+            event_type="rebuild_complete",
+            message=f"Retry Unresolved: {resolved} resolved, {failed} still unresolved out of {total} names",
+            details=details, actor="system",
+        )
     logger.info("retry_unresolved: done - resolved=%d, failed=%d", resolved, failed)
     return {"status": "complete", **details}
 
@@ -1099,12 +1101,13 @@ def _smart_rebuild_inner(manual: bool = False) -> dict:
         details = {**stats, **(extra or {})}
         set_rebuild_cancelled_sync(_redis, "Quick Fix cancelled", details)
         if manual:
-            append_activity_sync(_redis, {
-                "type": "rebuild_cancelled",
-                "message": "Quick Fix cancelled by user",
-                "details": details,
-                "timestamp": time.time(),
-            })
+            with _activity_session() as _db:
+                _emit_activity_sync(
+                    _db, redis=_redis, category="rebuild", severity="info",
+                    event_type="rebuild_cancelled",
+                    message="Quick Fix cancelled by user",
+                    details=details, actor="system",
+                )
         logger.info("smart_rebuild: cancelled")
         return {"status": "cancelled", **details}
 
@@ -1259,12 +1262,13 @@ def _smart_rebuild_inner(manual: bool = False) -> dict:
     set_rebuild_complete_sync(_redis, message, stats)
     _invalidate_stats_cache()
     if manual:
-        append_activity_sync(_redis, {
-            "type": "rebuild_complete",
-            "message": f"Quick Fix: {message}",
-            "details": stats,
-            "timestamp": time.time(),
-        })
+        with _activity_session() as _db:
+            _emit_activity_sync(
+                _db, redis=_redis, category="rebuild", severity="info",
+                event_type="rebuild_complete",
+                message=f"Quick Fix: {message}",
+                details=stats, actor="system",
+            )
     logger.info("smart_rebuild: done - %s", stats)
     return {"status": "complete", **stats}
 
@@ -1412,21 +1416,25 @@ def run_data_migrations(self, from_version: int) -> dict:
                     session.rollback()
                     error_msg = f"Data upgrade failed at v{ver} ({desc}): {e}"
                     logger.exception("data_migrations: %s", error_msg)
-                    append_activity_sync(_redis, {
-                        "type": "data_upgrade_failed",
-                        "message": f"{error_msg}. Press Quick Fix to retry.",
-                        "details": {"version": ver, "error": str(e)},
-                        "timestamp": time.time(),
-                    })
+                    with _activity_session() as _db:
+                        _emit_activity_sync(
+                            _db, redis=_redis, category="migration", severity="error",
+                            event_type="data_upgrade_failed",
+                            message=f"{error_msg}. Press Quick Fix to retry.",
+                            details={"version": ver, "error": str(e)},
+                            actor="system",
+                        )
                     return {"status": "error", "version": ver, "error": str(e)}
 
         summary_msg = "Data upgrade complete: " + "; ".join(results)
-        append_activity_sync(_redis, {
-            "type": "data_upgrade_complete",
-            "message": summary_msg,
-            "details": {"from_version": from_version, "to_version": DATA_VERSION},
-            "timestamp": time.time(),
-        })
+        with _activity_session() as _db:
+            _emit_activity_sync(
+                _db, redis=_redis, category="migration", severity="info",
+                event_type="data_upgrade_complete",
+                message=summary_msg,
+                details={"from_version": from_version, "to_version": DATA_VERSION},
+                actor="system",
+            )
         logger.info("data_migrations: %s", summary_msg)
 
         # Queue quick fix + mosaic detection after data migrations
@@ -1694,12 +1702,13 @@ def generate_reference_thumbnails(self, force: bool = False) -> dict:
         set_rebuild_cancelled_sync(
             _redis, f"Cancelled after fetching {fetched}/{total} reference thumbnails", stats
         )
-        append_activity_sync(_redis, {
-            "type": "rebuild_cancelled",
-            "message": f"Reference Thumbnails cancelled after {fetched}/{total}",
-            "details": stats,
-            "timestamp": time.time(),
-        })
+        with _activity_session() as _db:
+            _emit_activity_sync(
+                _db, redis=_redis, category="thumbnail", severity="info",
+                event_type="rebuild_cancelled",
+                message=f"Reference Thumbnails cancelled after {fetched}/{total}",
+                details=stats, actor="system",
+            )
         return {"status": "cancelled", **stats}
 
     _invalidate_stats_cache()
@@ -1707,12 +1716,13 @@ def generate_reference_thumbnails(self, force: bool = False) -> dict:
     set_rebuild_complete_sync(
         _redis, f"Fetched {fetched}/{total} reference thumbnails", stats
     )
-    append_activity_sync(_redis, {
-        "type": "ref_thumbnails_complete",
-        "message": f"Reference Thumbnails: fetched {fetched}/{total}",
-        "details": stats,
-        "timestamp": time.time(),
-    })
+    with _activity_session() as _db:
+        _emit_activity_sync(
+            _db, redis=_redis, category="thumbnail", severity="info",
+            event_type="ref_thumbnails_complete",
+            message=f"Reference Thumbnails: fetched {fetched}/{total}",
+            details=stats, actor="system",
+        )
     return stats
 
 
@@ -1741,12 +1751,13 @@ def run_xmatch_enrichment(self) -> dict:
         if is_cancel_requested_sync(_redis):
             details = {"matched": 0, "total": len(target_dicts)}
             set_rebuild_cancelled_sync(_redis, "xMatch cancelled before start", details)
-            append_activity_sync(_redis, {
-                "type": "rebuild_cancelled",
-                "message": "xMatch Enrichment cancelled before start",
-                "details": details,
-                "timestamp": time.time(),
-            })
+            with _activity_session() as _db:
+                _emit_activity_sync(
+                    _db, redis=_redis, category="rebuild", severity="info",
+                    event_type="rebuild_cancelled",
+                    message="xMatch Enrichment cancelled before start",
+                    details=details, actor="system",
+                )
             return {"status": "cancelled", **details}
 
         set_rebuild_progress_sync(
@@ -1758,12 +1769,13 @@ def run_xmatch_enrichment(self) -> dict:
     set_rebuild_complete_sync(
         _redis, f"xMatch: {len(results)}/{len(target_dicts)} matched", stats
     )
-    append_activity_sync(_redis, {
-        "type": "xmatch_complete",
-        "message": f"xMatch Enrichment: {len(results)}/{len(target_dicts)} matched",
-        "details": stats,
-        "timestamp": time.time(),
-    })
+    with _activity_session() as _db:
+        _emit_activity_sync(
+            _db, redis=_redis, category="enrichment", severity="info",
+            event_type="xmatch_complete",
+            message=f"xMatch Enrichment: {len(results)}/{len(target_dicts)} matched",
+            details=stats, actor="system",
+        )
     return stats
 
 

--- a/backend/app/worker/tasks.py
+++ b/backend/app/worker/tasks.py
@@ -1301,6 +1301,16 @@ def detect_mosaic_panels_task():
 
         count = asyncio.run(_run())
         logger.info("detect_mosaic_panels_task: found %d new suggestions", count)
+        try:
+            with _activity_session() as _db:
+                _emit_activity_sync(
+                    _db, redis=_redis, category="mosaic", severity="info",
+                    event_type="mosaic_detection_complete",
+                    message=f"Mosaic detection complete: {count} new suggestion{'s' if count != 1 else ''} found",
+                    details={"candidates": count}, actor="system",
+                )
+        except Exception:
+            logger.warning("detect_mosaic_panels_task: failed to emit mosaic_detection_complete")
         return {"status": "complete", "new_suggestions": count}
     finally:
         _redis.delete(MOSAIC_DETECT_LOCK)

--- a/backend/app/worker/tasks.py
+++ b/backend/app/worker/tasks.py
@@ -495,6 +495,16 @@ def _do_ingest(fits_path: str, include_calibration: bool = True) -> dict:
                 session.commit()
         except Exception:
             logger.warning("Failed to create filename candidate for %s", path.name, exc_info=True)
+            try:
+                with _activity_session() as _db:
+                    _emit_activity_sync(
+                        _db, redis=_redis, category="scan", severity="warning",
+                        event_type="filename_candidate_failed",
+                        message=f"Filename candidate resolution failed for {path.name}",
+                        details={"path": str(path)}, actor="system",
+                    )
+            except Exception:
+                pass
 
     logger.info("Ingested: %s (target=%s)", path.name, target_id)
     increment_completed_sync(_redis)
@@ -963,6 +973,14 @@ def rebuild_targets(self) -> dict:
             details={"resolved": resolved, "failed": failed, "total": total},
             actor="system",
         )
+    if failed > 0:
+        with _activity_session() as _db:
+            _emit_activity_sync(
+                _db, redis=_redis, category="enrichment", severity="warning",
+                event_type="enrichment_query_failed",
+                message=f"Full Rebuild: enrichment failed for {failed} of {total} object names",
+                details={"failed_targets": failed, "total": total}, actor="system",
+            )
     logger.info("rebuild_targets: done - resolved=%d, failed=%d", resolved, failed)
     return {"status": "complete", **details}
 
@@ -1061,6 +1079,14 @@ def retry_unresolved(self) -> dict:
             message=f"Retry Unresolved: {resolved} resolved, {failed} still unresolved out of {total} names",
             details=details, actor="system",
         )
+    if failed > 0:
+        with _activity_session() as _db:
+            _emit_activity_sync(
+                _db, redis=_redis, category="enrichment", severity="warning",
+                event_type="enrichment_query_failed",
+                message=f"Retry Unresolved: enrichment failed for {failed} of {total} object names",
+                details={"failed_targets": failed, "total": total}, actor="system",
+            )
     logger.info("retry_unresolved: done - resolved=%d, failed=%d", resolved, failed)
     return {"status": "complete", **details}
 

--- a/backend/app/worker/tasks.py
+++ b/backend/app/worker/tasks.py
@@ -42,6 +42,13 @@ from app.services.scan_state import (
     append_activity_sync, check_complete_sync,
     add_skipped_path_sync, get_skipped_paths_sync, clear_skipped_paths_sync,
 )
+from app.services.activity import emit_sync as _emit_activity_sync
+
+
+def _activity_session():
+    """Return a context-managed sync Session for activity writes in Celery tasks."""
+    return Session(_sync_engine)
+
 
 _redis = get_sync_redis()
 
@@ -130,22 +137,24 @@ def run_scan(self, include_calibration: bool = True) -> dict:
 
     if is_cancel_requested_sync(_redis):
         set_cancelled_sync(_redis)
-        append_activity_sync(_redis, {
-            "type": "scan_stopped",
-            "message": f"Scan stopped by user ({len(new_files)} files discovered before stop)",
-            "details": {"discovered": len(new_files)},
-            "timestamp": time.time(),
-        })
+        with _activity_session() as _db:
+            _emit_activity_sync(
+                _db, redis=_redis, category="scan", severity="info",
+                event_type="scan_stopped",
+                message=f"Scan stopped by user ({len(new_files)} files discovered before stop)",
+                details={"discovered": len(new_files)}, actor="system",
+            )
         return {"status": "cancelled"}
 
     if changed_files:
         logger.info("Delta scan: %d changed files queued for re-ingest", len(changed_files))
-        append_activity_sync(_redis, {
-            "type": "delta_scan",
-            "message": f"Delta scan: {len(changed_files)} changed file{'s' if len(changed_files) != 1 else ''} detected and re-queued",
-            "details": {"changed_files": len(changed_files)},
-            "timestamp": time.time(),
-        })
+        with _activity_session() as _db:
+            _emit_activity_sync(
+                _db, redis=_redis, category="scan", severity="info",
+                event_type="delta_scan",
+                message=f"Delta scan: {len(changed_files)} changed file{'s' if len(changed_files) != 1 else ''} detected and re-queued",
+                details={"changed_files": len(changed_files)}, actor="system",
+            )
 
     # Detect and remove orphaned DB records (files deleted from disk).
     # CRITICAL: only consider rows the walker would have actually visited
@@ -183,24 +192,27 @@ def run_scan(self, include_calibration: bool = True) -> dict:
                 session.commit()
         if removed:
             logger.info("Removed %d orphaned image records (files deleted from disk)", removed)
-            append_activity_sync(_redis, {
-                "type": "orphan_cleanup",
-                "message": f"Removed {removed} deleted file{'s' if removed != 1 else ''} from catalog",
-                "details": {"removed": removed},
-                "timestamp": time.time(),
-            })
+            with _activity_session() as _db:
+                _emit_activity_sync(
+                    _db, redis=_redis, category="scan", severity="info",
+                    event_type="orphan_cleanup",
+                    message=f"Removed {removed} deleted file{'s' if removed != 1 else ''} from catalog",
+                    details={"removed": removed}, actor="system",
+                )
     elif orphaned_paths:
         logger.warning(
             "Skipped orphan cleanup: %d of %d in-scope files missing (>50%%) - "
             "possible unmounted share or unreachable storage",
             len(orphaned_paths), len(in_scope_known_paths),
         )
-        append_activity_sync(_redis, {
-            "type": "orphan_warning",
-            "message": f"Orphan cleanup skipped: {len(orphaned_paths)} of {len(in_scope_known_paths)} in-scope files missing (>50%) - possible unmounted share",
-            "details": {"missing": len(orphaned_paths), "total_known": len(in_scope_known_paths)},
-            "timestamp": time.time(),
-        })
+        with _activity_session() as _db:
+            _emit_activity_sync(
+                _db, redis=_redis, category="scan", severity="warning",
+                event_type="orphan_warning",
+                message=f"Orphan cleanup skipped: {len(orphaned_paths)} of {len(in_scope_known_paths)} in-scope files missing (>50%) - possible unmounted share",
+                details={"missing": len(orphaned_paths), "total_known": len(in_scope_known_paths)},
+                actor="system",
+            )
 
     total_queued = len(new_files) + len(changed_files)
     if not total_queued:
@@ -209,12 +221,13 @@ def run_scan(self, include_calibration: bool = True) -> dict:
         msg = f"Scan complete: no new files found ({cataloged} already cataloged)"
         if removed:
             msg += f", {removed} deleted files purged from catalog"
-        append_activity_sync(_redis, {
-            "type": "scan_complete",
-            "message": msg,
-            "details": {"completed": 0, "failed": 0, "already_known": cataloged, "removed": removed},
-            "timestamp": time.time(),
-        })
+        with _activity_session() as _db:
+            _emit_activity_sync(
+                _db, redis=_redis, category="scan", severity="info",
+                event_type="scan_complete", message=msg,
+                details={"completed": 0, "failed": 0, "already_known": cataloged, "removed": removed},
+                actor="system",
+            )
         return {"status": "complete", "new_files_queued": 0, "already_known": cataloged, "removed": removed}
 
     # Transition to ingesting with final total - ingest tasks are already running

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,6 +1,67 @@
 #!/bin/bash
 set -e
 
+# ---- PUID/PGID handling ----
+PUID=${PUID:-1000}
+PGID=${PGID:-1000}
+
+# Belt-and-suspenders: ensure runtime dirs exist even if a bind mount shadowed
+# them (e.g. dev override mounts ./backend to /app) or the image predates the
+# /app/run layout.
+mkdir -p /app/run \
+         /app/run/nginx/client_body \
+         /app/run/nginx/proxy \
+         /app/run/nginx/fastcgi \
+         /app/run/nginx/uwsgi \
+         /app/run/nginx/scgi
+
+CURRENT_UID=$(id -u galactilog)
+CURRENT_GID=$(id -g galactilog)
+
+if [ "$PGID" != "$CURRENT_GID" ]; then
+    groupmod -o -g "$PGID" galactilog
+fi
+if [ "$PUID" != "$CURRENT_UID" ]; then
+    usermod -o -u "$PUID" galactilog
+fi
+
+# Internal runtime dir is container-local; chown is cheap.
+chown -R galactilog:galactilog /app/run 2>/dev/null || true
+
+DID_CHOWN=0
+# /app/data/fits is typically a read-only bind mount, so we must NOT recurse
+# into /app/data. Shallow chown /app/data itself, recursive chown for
+# /app/data/thumbnails (the only dir we actually write into).
+# Honor GALACTILOG_SKIP_CHOWN=1 for users who manage ownership themselves.
+if [ "${GALACTILOG_SKIP_CHOWN:-0}" != "1" ]; then
+    desired="$PUID:$PGID"
+
+    if [ -d /app/data ]; then
+        current_owner=$(stat -c '%u:%g' /app/data 2>/dev/null || echo "")
+        if [ -n "$current_owner" ] && [ "$current_owner" != "$desired" ]; then
+            echo "Adjusting ownership of /app/data from $current_owner to $desired (shallow)..."
+            if chown "$PUID:$PGID" /app/data 2>/dev/null; then
+                DID_CHOWN=1
+            else
+                echo "Warning: chown of /app/data failed (likely read-only mount, continuing)"
+            fi
+        fi
+    fi
+
+    if [ -d /app/data/thumbnails ]; then
+        current_owner=$(stat -c '%u:%g' /app/data/thumbnails 2>/dev/null || echo "")
+        if [ -n "$current_owner" ] && [ "$current_owner" != "$desired" ]; then
+            echo "Adjusting ownership of /app/data/thumbnails from $current_owner to $desired (one-time, may take a moment on large directories)..."
+            if chown -R "$PUID:$PGID" /app/data/thumbnails 2>/dev/null; then
+                DID_CHOWN=1
+            else
+                echo "Warning: chown of /app/data/thumbnails failed (continuing)"
+            fi
+        fi
+    fi
+fi
+# ---- end PUID/PGID handling ----
+
 echo "Running database migrations..."
 
 # Check if alembic_version table exists. If the DB has tables but no
@@ -188,6 +249,26 @@ from app.worker.tasks import smart_rebuild_targets, detect_mosaic_panels_task
 smart_rebuild_targets.apply_async(countdown=10)
 detect_mosaic_panels_task.apply_async(countdown=30)
 " 2>&1 || echo "Warning: could not dispatch startup maintenance tasks"
+fi
+
+if [ "$DID_CHOWN" = "1" ]; then
+    python -c "
+import json, time, os, sys
+try:
+    import redis
+    r = redis.from_url(os.environ.get('GALACTILOG_REDIS_URL', 'redis://redis:6379/0'))
+    entry = {
+        'type': 'ownership_adjusted',
+        'message': 'Data directory ownership aligned to PUID=${PUID} PGID=${PGID}',
+        'details': {'puid': ${PUID}, 'pgid': ${PGID}},
+        'timestamp': time.time(),
+    }
+    r.lpush('scan:activity', json.dumps(entry))
+    r.ltrim('scan:activity', 0, 19)
+    r.close()
+except Exception as e:
+    print(f'Warning: could not post ownership activity: {e}', file=sys.stderr)
+" 2>&1 || true
 fi
 
 echo "Starting services..."

--- a/backend/tests/container_perms.sh
+++ b/backend/tests/container_perms.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+# Container PUID/PGID permission test harness.
+#
+# This harness is intended for Linux. On Windows NTFS bind mounts, scenarios C
+# and D (ownership mismatch chown behavior) cannot be faithfully tested because
+# Docker Desktop presents bind mounts as owned by the container user regardless
+# of host ownership. Run this harness on the Linux deployment target
+# (astrodb.lan) to validate the full matrix.
+#
+# Validates the non-root / PUID-PGID-remap refactor end-to-end by spinning up
+# the app container under several ownership scenarios and inspecting entrypoint
+# behaviour, process users, and HTTP reachability.
+#
+# Golden-path manual recipe:
+#   1. cd /c/Users/Kumar/git/GalactiLog   (or your repo root)
+#   2. mkdir -p .test_mounts/thumbnails .test_mounts/fits
+#   3. bash backend/tests/container_perms.sh
+#   4. If all green, ship.
+#
+# Requires: docker, docker compose, bash, sudo (for chown of test mount dirs).
+# Runs on Linux / macOS / WSL. Not cmd.exe.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT"
+
+MOUNT_ROOT="/tmp/galactilog_test_mounts"
+FITS_DIR="$MOUNT_ROOT/fits"
+THUMB_DIR="$MOUNT_ROOT/thumbs"
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+log()    { printf '\n\033[1;34m[*]\033[0m %s\n' "$*"; }
+ok()     { printf '    \033[1;32mPASS\033[0m %s\n' "$*"; PASS=$((PASS+1)); }
+bad()    { printf '    \033[1;31mFAIL\033[0m %s\n' "$*"; FAIL=$((FAIL+1)); FAILURES+=("$*"); }
+
+cleanup_container() {
+    docker compose down -v --remove-orphans >/dev/null 2>&1 || true
+}
+
+trap cleanup_container EXIT
+
+prep_mounts() {
+    local owner_uid="$1"
+    local owner_gid="$2"
+    sudo rm -rf "$MOUNT_ROOT"
+    mkdir -p "$FITS_DIR" "$THUMB_DIR"
+    # Seed one file in each so chown actually has work to do.
+    echo "seed" > "$THUMB_DIR/seed.txt"
+    echo "seed" > "$FITS_DIR/seed.txt"
+    sudo chown -R "$owner_uid:$owner_gid" "$MOUNT_ROOT"
+}
+
+write_override() {
+    # Write a transient override that bind-mounts the prepared dirs and
+    # injects PUID/PGID/GALACTILOG_SKIP_CHOWN as needed.
+    local puid="$1"
+    local pgid="$2"
+    local skip_chown="$3"
+
+    cat > "$REPO_ROOT/docker-compose.override.yml" <<EOF
+# transient override written by backend/tests/container_perms.sh
+services:
+  app:
+    environment:
+      PUID: "${puid}"
+      PGID: "${pgid}"
+      GALACTILOG_SKIP_CHOWN: "${skip_chown}"
+    volumes:
+      - ${THUMB_DIR}:/app/data/thumbnails
+      - ${FITS_DIR}:/app/data/fits:ro
+EOF
+}
+
+wait_for_health() {
+    local tries=60
+    for i in $(seq 1 $tries); do
+        if curl -sf -o /dev/null http://localhost:8080/api/health 2>/dev/null \
+            || curl -sf -o /dev/null http://localhost/api/health 2>/dev/null; then
+            return 0
+        fi
+        sleep 2
+    done
+    return 1
+}
+
+boot_scenario() {
+    local name="$1"
+    log "Booting scenario: $name"
+    docker compose up -d >/tmp/compose_up.log 2>&1 || {
+        bad "$name: docker compose up failed; see /tmp/compose_up.log"
+        return 1
+    }
+    if ! wait_for_health; then
+        bad "$name: /api/health never returned 200"
+        docker compose logs app | tail -50
+        return 1
+    fi
+    return 0
+}
+
+assert_running_as_galactilog() {
+    # python:3.12-slim has no procps, so walk /proc directly.
+    # Rules:
+    #   - uvicorn and celery MUST run as the expected non-root uid.
+    #   - supervisord MAY run as root (master forks children w/ differing users).
+    #   - nginx master MAY run as root; at least one nginx must run as the
+    #     expected uid (workers drop privileges).
+    local name="$1"
+    local expected_uid="${2:-1000}"
+    local walker='for pid in /proc/[0-9]*; do
+    p=${pid##*/}
+    comm=$(cat "$pid/comm" 2>/dev/null || continue)
+    uid=$(awk "/^Uid:/ {print \$2; exit}" "$pid/status" 2>/dev/null || echo "")
+    echo "$p $uid $comm"
+done'
+    local out
+    out=$(docker compose exec -T app sh -c "$walker" 2>/dev/null || true)
+
+    local offenders nginx_uids
+    offenders=$(echo "$out" | awk -v euid="$expected_uid" '
+        {
+            pid=$1; uid=$2; comm=$3
+            if (comm ~ /uvicorn|celery/) {
+                if (uid != euid) print pid"/"comm"(uid="uid")"
+            }
+        }')
+    nginx_uids=$(echo "$out" | awk '$3=="nginx" {print $2}')
+
+    if [ -n "$offenders" ]; then
+        bad "$name: uvicorn/celery not running as uid=$expected_uid: $offenders"
+        echo "$out"
+        return
+    fi
+
+    if [ -n "$nginx_uids" ]; then
+        if ! echo "$nginx_uids" | grep -qx "$expected_uid"; then
+            bad "$name: no nginx worker runs as uid=$expected_uid; nginx uids: $(echo "$nginx_uids" | tr '\n' ' ')"
+            return
+        fi
+    fi
+
+    ok "$name: service processes honor uid=$expected_uid (supervisord/nginx-master root permitted)"
+}
+
+assert_entrypoint_chown_msg() {
+    local name="$1"
+    local expect_present="$2"  # "yes" or "no"
+    local logs
+    logs=$(docker compose logs app 2>&1 || true)
+    if echo "$logs" | grep -q "Adjusting ownership"; then
+        if [ "$expect_present" = "yes" ]; then
+            ok "$name: entrypoint logged 'Adjusting ownership' (as expected)"
+        else
+            bad "$name: entrypoint logged 'Adjusting ownership' but shouldn't have"
+        fi
+    else
+        if [ "$expect_present" = "no" ]; then
+            ok "$name: entrypoint did NOT log 'Adjusting ownership' (as expected)"
+        else
+            bad "$name: entrypoint did NOT log 'Adjusting ownership' but should have"
+        fi
+    fi
+}
+
+assert_galactilog_uid() {
+    local name="$1"
+    local expected_uid="$2"
+    local expected_gid="$3"
+    local out
+    out=$(docker compose exec -T app sh -c "id galactilog" 2>/dev/null || true)
+    if echo "$out" | grep -q "uid=${expected_uid}" && echo "$out" | grep -q "gid=${expected_gid}"; then
+        ok "$name: galactilog is uid=${expected_uid} gid=${expected_gid}"
+    else
+        bad "$name: expected uid=${expected_uid} gid=${expected_gid}, got: $out"
+    fi
+}
+
+assert_thumb_owner() {
+    local name="$1"
+    local expected_uid="$2"
+    local out
+    out=$(docker compose exec -T app sh -c "stat -c '%u' /app/data/thumbnails" 2>/dev/null || true)
+    if [ "$(echo "$out" | tr -d '[:space:]')" = "$expected_uid" ]; then
+        ok "$name: /app/data/thumbnails owned by uid=${expected_uid}"
+    else
+        bad "$name: /app/data/thumbnails owner uid=$out (expected $expected_uid)"
+    fi
+}
+
+assert_fits_readonly_preserved() {
+    local name="$1"
+    # Read-only bind mount means we must NOT have recursively chowned inside.
+    # The seed.txt we created should retain its original owner in the host view.
+    local host_owner
+    host_owner=$(stat -c '%u' "$FITS_DIR/seed.txt")
+    ok "$name: fits seed file host owner=$host_owner (ro mount untouched)"
+}
+
+run_scenario_a() {
+    local name="A:default_uid_1000"
+    prep_mounts 1000 1000
+    write_override 1000 1000 0
+    cleanup_container
+    boot_scenario "$name" || return
+    assert_galactilog_uid "$name" 1000 1000
+    assert_running_as_galactilog "$name" 1000
+    assert_entrypoint_chown_msg "$name" "no"
+    assert_thumb_owner "$name" 1000
+}
+
+run_scenario_b() {
+    local name="B:custom_puid_1500_matching_mount"
+    prep_mounts 1500 1500
+    write_override 1500 1500 0
+    cleanup_container
+    boot_scenario "$name" || return
+    assert_galactilog_uid "$name" 1500 1500
+    assert_running_as_galactilog "$name" 1500
+    assert_entrypoint_chown_msg "$name" "no"
+    assert_thumb_owner "$name" 1500
+}
+
+run_scenario_c() {
+    local name="C:mismatched_ownership_triggers_chown"
+    prep_mounts 2000 2000
+    write_override 1500 1500 0
+    cleanup_container
+    boot_scenario "$name" || return
+    assert_galactilog_uid "$name" 1500 1500
+    assert_entrypoint_chown_msg "$name" "yes"
+    assert_thumb_owner "$name" 1500
+    assert_fits_readonly_preserved "$name"
+}
+
+run_scenario_d() {
+    local name="D:skip_chown_env_honored"
+    prep_mounts 2000 2000
+    write_override 1500 1500 1
+    cleanup_container
+    boot_scenario "$name" || return
+    assert_galactilog_uid "$name" 1500 1500
+    assert_entrypoint_chown_msg "$name" "no"
+    # mount should still be owned by 2000 on host (we skipped chown)
+    local host_owner
+    host_owner=$(stat -c '%u' "$THUMB_DIR")
+    if [ "$host_owner" = "2000" ]; then
+        ok "$name: thumbs dir kept uid=2000 on host (chown skipped)"
+    else
+        bad "$name: thumbs dir uid=$host_owner on host (expected 2000, chown should have been skipped)"
+    fi
+}
+
+main() {
+    log "Building app image..."
+    docker compose build app >/tmp/compose_build.log 2>&1 || {
+        echo "Build failed; see /tmp/compose_build.log"
+        exit 2
+    }
+
+    run_scenario_a
+    run_scenario_b
+    run_scenario_c
+    run_scenario_d
+
+    echo
+    echo "==================================="
+    echo " Results: $PASS passed, $FAIL failed"
+    echo "==================================="
+    if [ $FAIL -ne 0 ]; then
+        printf '  - %s\n' "${FAILURES[@]}"
+        exit 1
+    fi
+}
+
+main "$@"

--- a/backend/tests/test_activity_service.py
+++ b/backend/tests/test_activity_service.py
@@ -1,0 +1,121 @@
+import os, sys
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+import pytest
+
+os.environ.setdefault("GALACTILOG_DATABASE_URL", "postgresql+asyncpg://test:test@localhost:5432/test_catalog")
+os.environ.setdefault("GALACTILOG_REDIS_URL", "redis://localhost:6379/1")
+os.environ.setdefault("GALACTILOG_FITS_DATA_PATH", "/tmp/test_fits")
+os.environ.setdefault("GALACTILOG_THUMBNAILS_PATH", "/tmp/test_thumbnails")
+os.environ.setdefault("GALACTILOG_JWT_SECRET", "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
+os.environ.setdefault("GALACTILOG_HTTPS", "false")
+for _mod in ("fitsio",):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+sys.modules.setdefault("app.worker.tasks", MagicMock())
+
+
+def _redis_ctx(mock_r):
+    @asynccontextmanager
+    async def _ctx():
+        yield mock_r
+    return _ctx
+
+
+@pytest.mark.asyncio
+async def test_emit_inserts_row():
+    from app.services.activity import emit
+    db = AsyncMock()
+    db.add = MagicMock()
+    db.commit = AsyncMock()
+    mock_r = AsyncMock()
+    mock_r.publish = AsyncMock()
+    with patch("app.services.activity.async_redis", side_effect=_redis_ctx(mock_r)):
+        await emit(db, category="scan", severity="info",
+                   event_type="scan_complete", message="done", details={"n": 3})
+    db.add.assert_called_once()
+    db.commit.assert_called_once()
+    added = db.add.call_args[0][0]
+    assert added.severity == "info"
+    assert added.category == "scan"
+    assert added.details == {"n": 3}
+
+
+@pytest.mark.asyncio
+async def test_emit_publishes_to_redis():
+    import json
+    from app.services.activity import emit
+    db = AsyncMock()
+    db.add = MagicMock()
+    db.commit = AsyncMock()
+    published = []
+    mock_r = AsyncMock()
+    async def capture(ch, data): published.append((ch, data))
+    mock_r.publish = capture
+    with patch("app.services.activity.async_redis", side_effect=_redis_ctx(mock_r)):
+        await emit(db, category="scan", severity="warning",
+                   event_type="scan_stalled", message="stalled")
+    assert len(published) == 1
+    ch, payload = published[0]
+    assert ch == "activity:new"
+    assert json.loads(payload)["event_type"] == "scan_stalled"
+
+
+@pytest.mark.asyncio
+async def test_emit_invalid_severity_raises_in_dev():
+    import app.services.activity as activity_mod
+    from app.services.activity import emit
+    db = AsyncMock()
+    with patch.object(activity_mod, "_ENV", "development"):
+        with pytest.raises(ValueError, match="Invalid severity"):
+            await emit(db, category="scan", severity="critical",
+                       event_type="test", message="test")
+
+
+@pytest.mark.asyncio
+async def test_emit_invalid_severity_skips_in_prod():
+    import app.services.activity as activity_mod
+    from app.services.activity import emit
+    db = AsyncMock()
+    db.add = MagicMock()
+    with patch.object(activity_mod, "_ENV", "production"):
+        await emit(db, category="scan", severity="critical",
+                   event_type="test", message="test")
+    db.add.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_emit_db_failure_does_not_propagate():
+    from app.services.activity import emit
+    db = AsyncMock()
+    db.add = MagicMock()
+    db.commit = AsyncMock(side_effect=RuntimeError("DB down"))
+    mock_r = AsyncMock()
+    mock_r.publish = AsyncMock()
+    with patch("app.services.activity.async_redis", side_effect=_redis_ctx(mock_r)):
+        await emit(db, category="system", severity="error",
+                   event_type="startup", message="test")
+    # Must not raise
+
+
+@pytest.mark.asyncio
+async def test_emit_invalid_category_skips_in_prod():
+    import app.services.activity as activity_mod
+    from app.services.activity import emit
+    db = AsyncMock()
+    db.add = MagicMock()
+    with patch.object(activity_mod, "_ENV", "production"):
+        await emit(db, category="unknown_xyz", severity="info",
+                   event_type="test", message="test")
+    db.add.assert_not_called()
+
+
+def test_emit_sync_inserts_row():
+    from app.services.activity import emit_sync
+    db = MagicMock()
+    redis = MagicMock()
+    emit_sync(db, redis=redis, category="rebuild", severity="info",
+              event_type="rebuild_complete", message="done")
+    db.add.assert_called_once()
+    db.commit.assert_called_once()
+    assert db.add.call_args[0][0].event_type == "rebuild_complete"

--- a/backend/tests/test_activity_startup.py
+++ b/backend/tests/test_activity_startup.py
@@ -1,0 +1,48 @@
+import os, sys
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+import pytest
+
+os.environ.setdefault("GALACTILOG_DATABASE_URL", "postgresql+asyncpg://test:test@localhost:5432/test_catalog")
+os.environ.setdefault("GALACTILOG_REDIS_URL", "redis://localhost:6379/1")
+os.environ.setdefault("GALACTILOG_FITS_DATA_PATH", "/tmp/test_fits")
+os.environ.setdefault("GALACTILOG_THUMBNAILS_PATH", "/tmp/test_thumbnails")
+os.environ.setdefault("GALACTILOG_JWT_SECRET", "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
+os.environ.setdefault("GALACTILOG_HTTPS", "false")
+for _mod in ("fitsio",):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+sys.modules.setdefault("app.worker.tasks", MagicMock())
+
+
+@pytest.mark.asyncio
+async def test_startup_deletes_scan_activity_key():
+    deleted_keys = []
+
+    mock_r = AsyncMock()
+    async def capture_delete(*keys):
+        deleted_keys.extend(keys)
+    mock_r.delete = capture_delete
+
+    @asynccontextmanager
+    async def _ctx():
+        yield mock_r
+
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock()
+    mock_db.commit = AsyncMock()
+    mock_db.scalar = AsyncMock(return_value=0)
+
+    @asynccontextmanager
+    async def _session_ctx():
+        yield mock_db
+
+    with patch("app.main.async_redis", side_effect=_ctx), \
+         patch("app.main.async_session", side_effect=_session_ctx), \
+         patch("app.main.start_queue_depth_probe"), \
+         patch("app.main.register_celery_collector"):
+        from app.main import lifespan, app as fastapi_app
+        async with lifespan(fastapi_app):
+            pass
+
+    assert "scan:activity" in deleted_keys

--- a/backend/tests/test_api_activity.py
+++ b/backend/tests/test_api_activity.py
@@ -1,0 +1,120 @@
+import os, sys, uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+os.environ.setdefault("GALACTILOG_DATABASE_URL", "postgresql+asyncpg://test:test@localhost:5432/test_catalog")
+os.environ.setdefault("GALACTILOG_REDIS_URL", "redis://localhost:6379/1")
+os.environ.setdefault("GALACTILOG_FITS_DATA_PATH", "/tmp/test_fits")
+os.environ.setdefault("GALACTILOG_THUMBNAILS_PATH", "/tmp/test_thumbnails")
+os.environ.setdefault("GALACTILOG_JWT_SECRET", "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
+os.environ.setdefault("GALACTILOG_HTTPS", "false")
+for _mod in ("fitsio",):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+sys.modules.setdefault("app.worker.tasks", MagicMock())
+
+from app.main import app
+from app.database import get_session
+from app.api.deps import get_current_user, require_admin
+from app.models.user import User, UserRole
+
+
+def _user(role=UserRole.admin):
+    u = MagicMock(spec=User)
+    u.id = uuid.uuid4()
+    u.username = "admin"
+    u.role = role
+    u.is_active = True
+    return u
+
+
+def _session_with_events(events, total):
+    mock_session = AsyncMock()
+    count_result = MagicMock()
+    count_result.scalar_one.return_value = total
+    scalars_result = MagicMock()
+    scalars_result.all.return_value = events
+    call_count = [0]
+
+    async def _execute(stmt, *a, **kw):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return count_result
+        r = MagicMock()
+        r.scalars.return_value = scalars_result
+        return r
+
+    mock_session.execute = _execute
+
+    async def _gen():
+        yield mock_session
+
+    return _gen
+
+
+@pytest.mark.asyncio
+async def test_get_activity_returns_200():
+    from app.models.activity_event import ActivityEvent
+    ev = ActivityEvent(id=1, severity="info", category="scan",
+                       event_type="scan_complete", message="done",
+                       details=None, target_id=None, actor="system", duration_ms=None)
+    ev.timestamp = datetime(2026, 4, 15, 12, 0, 0, tzinfo=timezone.utc)
+    app.dependency_overrides[get_session] = _session_with_events([ev], 1)
+    app.dependency_overrides[get_current_user] = lambda: _user(UserRole.viewer)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        resp = await c.get("/api/activity")
+    app.dependency_overrides.clear()
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "items" in data and "total" in data and "next_cursor" in data
+
+
+@pytest.mark.asyncio
+async def test_get_activity_severity_filter():
+    app.dependency_overrides[get_session] = _session_with_events([], 0)
+    app.dependency_overrides[get_current_user] = lambda: _user(UserRole.viewer)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        resp = await c.get("/api/activity?severity=error")
+    app.dependency_overrides.clear()
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_get_activity_since_filter():
+    app.dependency_overrides[get_session] = _session_with_events([], 0)
+    app.dependency_overrides[get_current_user] = lambda: _user(UserRole.viewer)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        resp = await c.get("/api/activity?since=2026-04-15T12:00:00Z")
+    app.dependency_overrides.clear()
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_delete_activity_requires_admin():
+    from fastapi import HTTPException
+    async def _deny():
+        raise HTTPException(status_code=403, detail="Forbidden")
+    app.dependency_overrides[require_admin] = _deny
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        resp = await c.delete("/api/activity")
+    app.dependency_overrides.clear()
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_delete_activity_clears_all():
+    mock_session = AsyncMock()
+    mock_session.execute = AsyncMock()
+    mock_session.commit = AsyncMock()
+    async def _gen():
+        yield mock_session
+    app.dependency_overrides[get_session] = _gen
+    app.dependency_overrides[require_admin] = lambda: _user()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        resp = await c.delete("/api/activity")
+    app.dependency_overrides.clear()
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "cleared"

--- a/backend/tests/test_api_scan.py
+++ b/backend/tests/test_api_scan.py
@@ -143,53 +143,12 @@ async def test_scan_rejects_when_already_running():
 
 
 @pytest.mark.asyncio
-async def test_get_activity_empty():
-    with patch("app.api.scan.async_redis") as mock_redis_cm:
-        mock_redis = AsyncMock()
-        mock_redis.lrange = AsyncMock(return_value=[])
-        mock_redis_cm.side_effect = _mock_async_redis(mock_redis)
-
-        transport = ASGITransport(app=app)
-        async with AsyncClient(transport=transport, base_url="http://test") as client:
-            resp = await client.get("/api/scan/activity")
-
-    assert resp.status_code == 200
-    assert resp.json() == []
-
-
-@pytest.mark.asyncio
-async def test_get_activity_with_entries():
-    import json
-    entries = [
-        json.dumps({"type": "scan_complete", "message": "Scan complete: 10 ingested, 0 failed", "details": {}, "timestamp": 1711000000.0}),
-        json.dumps({"type": "rebuild_complete", "message": "Quick Fix: 3 linked", "details": {}, "timestamp": 1710999000.0}),
-    ]
-    with patch("app.api.scan.async_redis") as mock_redis_cm:
-        mock_redis = AsyncMock()
-        mock_redis.lrange = AsyncMock(return_value=entries)
-        mock_redis_cm.side_effect = _mock_async_redis(mock_redis)
-
-        transport = ASGITransport(app=app)
-        async with AsyncClient(transport=transport, base_url="http://test") as client:
-            resp = await client.get("/api/scan/activity")
-
-    assert resp.status_code == 200
-    data = resp.json()
-    assert len(data) == 2
-    assert data[0]["type"] == "scan_complete"
-
-
-@pytest.mark.asyncio
-async def test_clear_activity():
-    with patch("app.api.scan.async_redis") as mock_redis_cm:
-        mock_redis = AsyncMock()
-        mock_redis.delete = AsyncMock()
-        mock_redis_cm.side_effect = _mock_async_redis(mock_redis)
-
-        transport = ASGITransport(app=app)
-        async with AsyncClient(transport=transport, base_url="http://test") as client:
-            resp = await client.delete("/api/scan/activity")
-
-    assert resp.status_code == 200
-    assert resp.json()["status"] == "cleared"
-    mock_redis.delete.assert_called_once()
+async def test_old_scan_activity_routes_removed():
+    from app.main import app as _app
+    from httpx import AsyncClient, ASGITransport
+    transport = ASGITransport(app=_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r1 = await c.get("/api/scan/activity")
+        r2 = await c.delete("/api/scan/activity")
+    assert r1.status_code == 404
+    assert r2.status_code == 404

--- a/backend/tests/test_api_settings.py
+++ b/backend/tests/test_api_settings.py
@@ -720,3 +720,19 @@ async def test_discovered_invalid_section_returns_422():
         assert resp.status_code == 422
     finally:
         app.dependency_overrides.clear()
+
+
+def test_activity_retention_days_default():
+    from app.schemas.settings import GeneralSettings
+    assert GeneralSettings().activity_retention_days == 90
+
+
+def test_activity_retention_days_validation():
+    from pydantic import ValidationError
+    from app.schemas.settings import GeneralSettings
+    with pytest.raises(ValidationError):
+        GeneralSettings(activity_retention_days=0)
+    with pytest.raises(ValidationError):
+        GeneralSettings(activity_retention_days=3651)
+    assert GeneralSettings(activity_retention_days=1).activity_retention_days == 1
+    assert GeneralSettings(activity_retention_days=3650).activity_retention_days == 3650

--- a/backend/tests/test_container_permissions.py
+++ b/backend/tests/test_container_permissions.py
@@ -1,0 +1,253 @@
+"""
+Container permissions / PUID-PGID integration tests.
+
+These tests shell out to `docker compose exec` to introspect a running
+container. They are gated behind GALACTILOG_TEST_LIVE_CONTAINER=1 so the
+normal pytest run (which has no app container) skips them cleanly.
+
+Run with:
+    GALACTILOG_TEST_LIVE_CONTAINER=1 pytest backend/tests/test_container_permissions.py -v
+
+For scenarios that require container rebuild/restart (PUID/PGID remap),
+see backend/tests/container_perms.sh instead.
+"""
+import json
+import os
+import subprocess
+import time
+
+import pytest
+
+LIVE = os.environ.get("GALACTILOG_TEST_LIVE_CONTAINER") == "1"
+
+pytestmark = pytest.mark.skipif(
+    not LIVE,
+    reason="Set GALACTILOG_TEST_LIVE_CONTAINER=1 to run live-container tests",
+)
+
+
+def _exec(cmd: str, check: bool = False, timeout: int = 30) -> subprocess.CompletedProcess:
+    """Run a shell command inside the running app container."""
+    return subprocess.run(
+        ["docker", "compose", "exec", "-T", "app", "sh", "-c", cmd],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=check,
+    )
+
+
+def _host(cmd: list[str], timeout: int = 30) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+
+
+@pytest.fixture(scope="session")
+def live_container():
+    """Ensure the app container is up; skip the module if not."""
+    result = _host(["docker", "compose", "ps", "--format", "json", "app"])
+    if result.returncode != 0 or not result.stdout.strip():
+        pytest.skip("app container is not running (docker compose up first)")
+
+    # `docker compose ps --format json` emits either one JSON object or
+    # newline-delimited objects depending on version. Parse defensively.
+    raw = result.stdout.strip()
+    try:
+        if raw.startswith("["):
+            entries = json.loads(raw)
+        else:
+            entries = [json.loads(line) for line in raw.splitlines() if line.strip()]
+    except json.JSONDecodeError:
+        pytest.skip(f"could not parse docker compose ps output: {raw[:200]}")
+
+    state = (entries[0].get("State") or "").lower() if entries else ""
+    if "running" not in state:
+        pytest.skip(f"app container state is {state!r}, not running")
+
+    # Wait briefly for supervisord to fully spawn children.
+    # python:3.12-slim doesn't ship procps, so use /proc walker instead of ps.
+    proc_walk = r'''for pid in /proc/[0-9]*; do
+    comm=$(cat "$pid/comm" 2>/dev/null || continue)
+    echo "$comm"
+done'''
+    for _ in range(10):
+        ps = _exec(proc_walk)
+        if "supervisord" in ps.stdout and ("uvicorn" in ps.stdout or "nginx" in ps.stdout):
+            break
+        time.sleep(1)
+    return True
+
+
+def _proc_walk():
+    """Walk /proc inside the container. Returns list of (pid, ppid, uid, comm)."""
+    cmd = r'''for pid in /proc/[0-9]*; do
+    p=${pid##*/}
+    comm=$(cat "$pid/comm" 2>/dev/null || continue)
+    uid=$(awk "/^Uid:/ {print \$2; exit}" "$pid/status" 2>/dev/null || echo "")
+    ppid=$(awk "/^PPid:/ {print \$2; exit}" "$pid/status" 2>/dev/null || echo "")
+    echo "$p $ppid $uid $comm"
+done'''
+    result = _exec(cmd)
+    assert result.returncode == 0, result.stderr
+    entries = []
+    for line in result.stdout.splitlines():
+        parts = line.split(None, 3)
+        if len(parts) != 4:
+            continue
+        pid, ppid, uid, comm = parts
+        try:
+            entries.append((int(pid), int(ppid), int(uid), comm.strip()))
+        except ValueError:
+            continue
+    return entries
+
+
+def test_galactilog_user_exists_with_expected_default_uid(live_container):
+    """Default image should expose galactilog with uid/gid 1000 when PUID/PGID unset."""
+    if os.environ.get("PUID") or os.environ.get("PGID"):
+        pytest.skip("PUID/PGID overridden in environment; default-UID test not meaningful")
+
+    result = _exec("id galactilog")
+    assert result.returncode == 0, result.stderr
+    assert "uid=1000" in result.stdout
+    assert "gid=1000" in result.stdout
+
+
+def test_processes_run_as_galactilog_user(live_container):
+    """Service processes should run as galactilog (uid 1000 or PUID).
+
+    Exceptions permitted:
+      - supervisord master runs as root (needs to fork children with differing
+        `user=` directives, open log fds, bind privileged ports).
+      - nginx master runs as root per nginx.conf `user galactilog galactilog;`
+        (workers drop to galactilog). The assertion requires that at least one
+        nginx worker runs as galactilog.
+    """
+    expected_uid = int(os.environ.get("PUID") or "1000")
+
+    entries = _proc_walk()
+    assert entries, "no processes discovered via /proc walk"
+
+    offenders = []
+    nginx_uids: list[int] = []
+    saw_supervisord = False
+
+    for pid, ppid, uid, comm in entries:
+        c = comm
+        if c == "supervisord":
+            saw_supervisord = True
+            # supervisord may be root; that's fine.
+            continue
+        if c == "nginx":
+            nginx_uids.append(uid)
+            continue
+        if any(k in c for k in ("uvicorn", "celery")):
+            if uid != expected_uid:
+                offenders.append((pid, uid, comm))
+
+    assert not offenders, (
+        f"processes not running as uid={expected_uid}: {offenders}"
+    )
+
+    if nginx_uids:
+        assert any(u == expected_uid for u in nginx_uids), (
+            f"no nginx process runs as uid={expected_uid}; all nginx uids: {nginx_uids}"
+        )
+
+
+def test_nginx_binds_port_80(live_container):
+    """Nginx bound to :80 via setcap (no root). Hit it via the host."""
+    # Use the host-side port mapping. docker-compose.yml exposes app on 8080
+    # by default; try both.
+    for url in ("http://localhost:8080/api/health", "http://localhost/api/health"):
+        r = _host(["curl", "-sf", "-o", "/dev/null", "-w", "%{http_code}", url])
+        if r.stdout.strip() == "200":
+            return
+    pytest.fail("neither :8080 nor :80 returned 200 for /api/health")
+
+
+@pytest.mark.xfail(
+    reason="PUID/PGID remap requires container restart; see backend/tests/container_perms.sh",
+    strict=False,
+)
+def test_puid_pgid_remapping(live_container):
+    pytest.xfail("Tested by backend/tests/container_perms.sh (restart-based)")
+
+
+def test_run_dir_owned_by_galactilog(live_container):
+    """/app/run and its contents must be owned by galactilog.
+
+    Exception: artifacts owned by the supervisord master (which runs as root
+    by design) will be root-owned: supervisor.sock, supervisord.pid. Skip
+    any *.sock entries and the supervisord pidfile.
+    """
+    result = _exec(
+        "stat -c '%n %U:%G' /app/run /app/run/* 2>/dev/null || stat -c '%n %U:%G' /app/run"
+    )
+    assert result.returncode == 0, result.stderr
+    for line in result.stdout.strip().splitlines():
+        if not line.strip():
+            continue
+        name_part = line.rsplit(" ", 1)[0]
+        basename = name_part.rsplit("/", 1)[-1]
+        if basename.endswith(".sock") or basename == "supervisord.pid":
+            continue
+        owner = line.rsplit(" ", 1)[-1]
+        user = owner.split(":")[0]
+        assert user in ("galactilog", "galacti"), f"{line!r} not owned by galactilog"
+
+
+def test_thumbnail_write_readable_by_nginx(live_container):
+    """Regression test for issue #162: nginx must be able to serve thumbnails
+    written by the backend. Write a tiny JPEG via docker exec, then fetch it
+    through nginx from the host."""
+    fname = "test_perms.jpg"
+    # Smallest valid JPEG (1x1 pixel, ~125 bytes). Base64 decode in-container.
+    b64 = (
+        "/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/"
+        "2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAABAAEDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwDyyigUtf/Z"
+    )
+    _exec(f"rm -f /app/data/thumbnails/{fname}")
+    write = _exec(
+        f"echo '{b64}' | base64 -d > /app/data/thumbnails/{fname} && "
+        f"stat -c '%U:%G %a' /app/data/thumbnails/{fname}"
+    )
+    assert write.returncode == 0, write.stderr
+
+    try:
+        # nginx config maps /thumbnails/ -> /app/data/thumbnails/
+        for base in ("http://localhost:8080", "http://localhost"):
+            r = _host(
+                ["curl", "-sf", "-o", "/dev/null", "-w", "%{http_code}",
+                 f"{base}/thumbnails/{fname}"]
+            )
+            if r.stdout.strip() == "200":
+                return
+        pytest.fail("nginx returned non-200 for newly-written thumbnail")
+    finally:
+        _exec(f"rm -f /app/data/thumbnails/{fname}")
+
+
+def test_skip_chown_env_var_honored(live_container):
+    """Documentation test: marker. Full validation is in container_perms.sh
+    (scenario D) because it requires a restart with custom env.
+    """
+    pytest.skip("Requires container restart; covered by container_perms.sh scenario D")
+
+
+def test_celerybeat_schedule_writable(live_container):
+    """After startup, celery beat writes its schedule under /app/run.
+    File must exist and be owned by galactilog."""
+    # Give beat a moment to flush its schedule on fresh containers.
+    for _ in range(10):
+        r = _exec("ls /app/run/celerybeat-schedule* 2>/dev/null")
+        if r.stdout.strip():
+            break
+        time.sleep(1)
+
+    ls = _exec("ls /app/run/celerybeat-schedule* 2>/dev/null")
+    assert ls.stdout.strip(), "celerybeat schedule file not created under /app/run/"
+
+    stat = _exec("stat -c '%U:%G' /app/run/celerybeat-schedule* | head -1")
+    assert stat.returncode == 0, stat.stderr
+    owner = stat.stdout.strip().split(":")[0]
+    assert owner in ("galactilog", "galacti"), f"celerybeat schedule owned by {owner}"

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -63,3 +63,28 @@ def test_user_settings_has_dismissed_suggestions_default():
     from app.models.user_settings import UserSettings, SETTINGS_ROW_ID
     row = UserSettings(id=SETTINGS_ROW_ID)
     assert row.dismissed_suggestions == []
+
+
+def test_activity_event_columns():
+    from app.models.activity_event import ActivityEvent
+    cols = {c.name for c in ActivityEvent.__table__.columns}
+    assert cols == {
+        "id", "timestamp", "severity", "category", "event_type",
+        "message", "details", "target_id", "actor", "duration_ms",
+    }
+
+
+def test_activity_event_instantiation():
+    from app.models.activity_event import ActivityEvent
+    ev = ActivityEvent(
+        severity="warning",
+        category="scan",
+        event_type="scan_complete",
+        message="Scan complete: 5 new files added",
+        details={"completed": 5, "failed": 0},
+        actor="system",
+    )
+    assert ev.severity == "warning"
+    assert ev.details["completed"] == 5
+    assert ev.target_id is None
+    assert ev.duration_ms is None

--- a/backend/tests/test_mosaic_composite.py
+++ b/backend/tests/test_mosaic_composite.py
@@ -245,3 +245,26 @@ def test_parse_coord_negative_dec():
     assert result is not None
     assert result < 0
     assert abs(result - (-30.25)) < 0.01
+
+
+@pytest.mark.asyncio
+async def test_mosaic_composite_failed_emit_called_on_exception(mock_session):
+    from app.services import mosaic_composite as mc
+
+    emit_calls = []
+
+    async def fake_emit(db, *, category, severity, event_type, message, **kw):
+        emit_calls.append({
+            "category": category,
+            "severity": severity,
+            "event_type": event_type,
+            "message": message,
+        })
+
+    with patch.object(mc, "_emit_activity", fake_emit):
+        with pytest.raises(ValueError):
+            # Empty panels list -> raises ValueError "No panels have accessible FITS frames"
+            await mc.build_mosaic_composite("mosaic-x", [], mock_session)
+
+    assert any(c["event_type"] == "mosaic_composite_failed" for c in emit_calls)
+    assert any(c["severity"] == "error" for c in emit_calls)

--- a/backend/tests/test_prune_activity.py
+++ b/backend/tests/test_prune_activity.py
@@ -1,0 +1,81 @@
+import os, sys
+from unittest.mock import MagicMock, patch
+import pytest
+
+os.environ.setdefault("GALACTILOG_DATABASE_URL", "postgresql+asyncpg://test:test@localhost:5432/test_catalog")
+os.environ.setdefault("GALACTILOG_REDIS_URL", "redis://localhost:6379/1")
+os.environ.setdefault("GALACTILOG_FITS_DATA_PATH", "/tmp/test_fits")
+os.environ.setdefault("GALACTILOG_THUMBNAILS_PATH", "/tmp/test_thumbnails")
+os.environ.setdefault("GALACTILOG_JWT_SECRET", "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
+os.environ.setdefault("GALACTILOG_HTTPS", "false")
+for _mod in ("fitsio",):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+sys.modules.setdefault("app.worker.tasks", MagicMock())
+
+
+def _make_session(deleted_count, retention_days=90):
+    mock_result = MagicMock()
+    mock_result.rowcount = deleted_count
+    mock_settings = MagicMock()
+    mock_settings.general = {"activity_retention_days": retention_days}
+    settings_result = MagicMock()
+    settings_result.scalar_one_or_none.return_value = mock_settings
+    call_count = [0]
+
+    def _execute(stmt, *a, **kw):
+        call_count[0] += 1
+        return settings_result if call_count[0] == 1 else mock_result
+
+    session = MagicMock()
+    session.execute = _execute
+    session.commit = MagicMock()
+    return session
+
+
+def test_prune_deletes_old_rows_and_emits():
+    from app.worker.prune_activity import prune_activity_events
+    emit_calls = []
+
+    def fake_emit(session, *, redis, category, severity, event_type, message, **kw):
+        emit_calls.append({"event_type": event_type, "details": kw.get("details")})
+
+    with patch("app.worker.prune_activity.Session") as ms, \
+         patch("app.worker.prune_activity.emit_sync", fake_emit), \
+         patch("app.worker.prune_activity.get_sync_redis", return_value=MagicMock()):
+        session = _make_session(deleted_count=12)
+        ms.return_value.__enter__ = lambda s, *a: session
+        ms.return_value.__exit__ = lambda s, *a: None
+        result = prune_activity_events.run()
+
+    assert result["deleted"] == 12
+    evs = [e for e in emit_calls if e["event_type"] == "activity_pruned"]
+    assert len(evs) == 1
+    assert evs[0]["details"]["deleted_count"] == 12
+
+
+def test_prune_silent_when_zero_deleted():
+    from app.worker.prune_activity import prune_activity_events
+    emit_calls = []
+
+    def fake_emit(session, *, redis, category, severity, event_type, message, **kw):
+        emit_calls.append(event_type)
+
+    with patch("app.worker.prune_activity.Session") as ms, \
+         patch("app.worker.prune_activity.emit_sync", fake_emit), \
+         patch("app.worker.prune_activity.get_sync_redis", return_value=MagicMock()):
+        session = _make_session(deleted_count=0)
+        ms.return_value.__enter__ = lambda s, *a: session
+        ms.return_value.__exit__ = lambda s, *a: None
+        result = prune_activity_events.run()
+
+    assert result["deleted"] == 0
+    assert "activity_pruned" not in emit_calls
+
+
+def test_prune_task_in_beat_schedule():
+    from app.worker.celery_app import celery_app
+    schedule = celery_app.conf.beat_schedule
+    assert "prune-activity-events" in schedule
+    entry = schedule["prune-activity-events"]
+    assert entry["task"] == "app.worker.prune_activity.prune_activity_events"

--- a/backend/tests/test_scan_filters_api.py
+++ b/backend/tests/test_scan_filters_api.py
@@ -309,3 +309,16 @@ async def test_browse_rejects_escape(admin_user):
         assert r.status_code == 400
     finally:
         app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_apply_filters_now_calls_emit_not_append_activity():
+    import ast, pathlib
+    src = pathlib.Path("app/api/scan.py").read_text()
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name) and node.func.id == "append_activity":
+                raise AssertionError("append_activity() still called in scan.py")
+            if isinstance(node.func, ast.Attribute) and node.func.attr == "append_activity":
+                raise AssertionError("append_activity() still called in scan.py")

--- a/backend/tests/test_scan_state_emit.py
+++ b/backend/tests/test_scan_state_emit.py
@@ -88,3 +88,27 @@ def test_scan_files_failed_emitted_when_failures_occur():
     assert len(failure_evs) == 1
     assert failure_evs[0]["details"]["failed_files"][0]["path"] == "/fits/bad.fits"
     assert "truncated" in failure_evs[0]["details"]
+
+
+def test_thumbnail_regen_failed_emitted_for_thumbnail_failures():
+    import json
+    from app.services.scan_state import check_complete_sync
+    r = _redis(total=3, completed=2, failed=1, new_files=0)
+    r.lrange.return_value = [
+        json.dumps({"file": "/tmp/test_thumbnails/bad_abc123.jpg", "error": "stretch error"})
+    ]
+    emit_calls = []
+
+    def fake_emit(session, *, redis, category, severity, event_type, message, **kw):
+        emit_calls.append({"event_type": event_type, "category": category})
+
+    mock_session = MagicMock()
+    with patch("app.services.scan_state.emit_sync", fake_emit), \
+         patch("app.services.scan_state.create_engine"), \
+         patch("app.services.scan_state._SyncSession") as ms:
+        ms.return_value.__enter__ = lambda s, *a: mock_session
+        ms.return_value.__exit__ = lambda s, *a: None
+        check_complete_sync(r)
+
+    ev_types = [e["event_type"] for e in emit_calls]
+    assert "thumbnail_regen_failed" in ev_types

--- a/backend/tests/test_scan_state_emit.py
+++ b/backend/tests/test_scan_state_emit.py
@@ -1,0 +1,90 @@
+import os, sys, json
+from unittest.mock import MagicMock, patch
+import pytest
+
+os.environ.setdefault("GALACTILOG_DATABASE_URL", "postgresql+asyncpg://test:test@localhost:5432/test_catalog")
+os.environ.setdefault("GALACTILOG_REDIS_URL", "redis://localhost:6379/1")
+os.environ.setdefault("GALACTILOG_FITS_DATA_PATH", "/tmp/test_fits")
+os.environ.setdefault("GALACTILOG_THUMBNAILS_PATH", "/tmp/test_thumbnails")
+os.environ.setdefault("GALACTILOG_JWT_SECRET", "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
+os.environ.setdefault("GALACTILOG_HTTPS", "false")
+for _mod in ("fitsio",):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+sys.modules.setdefault("app.worker.tasks", MagicMock())
+
+
+def _redis(total=5, completed=5, failed=0, new_files=5):
+    r = MagicMock()
+    r.hgetall.return_value = {
+        "state": "ingesting", "total": str(total), "completed": str(completed),
+        "failed": str(failed), "started_at": "1700000000.0", "completed_at": "",
+        "new_files": str(new_files), "changed_files": "0", "removed": "0",
+        "csv_enriched": "0", "skipped_calibration": "0",
+    }
+    r.hset = MagicMock()
+    r.expire = MagicMock()
+    r.delete = MagicMock()
+    r.lrange.return_value = []
+    return r
+
+
+def test_check_complete_sync_calls_emit_sync_on_completion():
+    from app.services.scan_state import check_complete_sync
+    r = _redis()
+    emit_calls = []
+
+    def fake_emit(session, *, redis, category, severity, event_type, message, **kw):
+        emit_calls.append({"event_type": event_type, "category": category, "severity": severity})
+
+    mock_session = MagicMock()
+
+    with patch("app.services.scan_state.emit_sync", fake_emit), \
+         patch("app.services.scan_state.create_engine"), \
+         patch("app.services.scan_state._SyncSession") as ms:
+        ms.return_value.__enter__ = lambda s, *a: mock_session
+        ms.return_value.__exit__ = lambda s, *a: None
+        check_complete_sync(r)
+
+    assert any(e["event_type"] == "scan_complete" for e in emit_calls)
+    ev = next(e for e in emit_calls if e["event_type"] == "scan_complete")
+    assert ev["category"] == "scan"
+    assert ev["severity"] == "info"
+
+
+def test_check_complete_sync_no_emit_when_in_progress():
+    from app.services.scan_state import check_complete_sync
+    r = _redis(total=10, completed=5, failed=0)
+    emit_calls = []
+
+    def fake_emit(*a, **kw):
+        emit_calls.append(True)
+
+    with patch("app.services.scan_state.emit_sync", fake_emit):
+        check_complete_sync(r)
+
+    assert len(emit_calls) == 0
+
+
+def test_scan_files_failed_emitted_when_failures_occur():
+    from app.services.scan_state import check_complete_sync
+    r = _redis(total=3, completed=2, failed=1, new_files=3)
+    r.lrange.return_value = [json.dumps({"file": "/fits/bad.fits", "error": "parse error"})]
+    emit_calls = []
+
+    def fake_emit(session, *, redis, category, severity, event_type, message, **kw):
+        emit_calls.append({"event_type": event_type, "details": kw.get("details")})
+
+    mock_session = MagicMock()
+
+    with patch("app.services.scan_state.emit_sync", fake_emit), \
+         patch("app.services.scan_state.create_engine"), \
+         patch("app.services.scan_state._SyncSession") as ms:
+        ms.return_value.__enter__ = lambda s, *a: mock_session
+        ms.return_value.__exit__ = lambda s, *a: None
+        check_complete_sync(r)
+
+    failure_evs = [e for e in emit_calls if e["event_type"] == "scan_files_failed"]
+    assert len(failure_evs) == 1
+    assert failure_evs[0]["details"]["failed_files"][0]["path"] == "/fits/bad.fits"
+    assert "truncated" in failure_evs[0]["details"]

--- a/backend/tests/test_schemas_activity.py
+++ b/backend/tests/test_schemas_activity.py
@@ -1,0 +1,50 @@
+import pytest
+from datetime import datetime, timezone
+
+
+def test_activity_item_fields():
+    from app.schemas.activity import ActivityItem
+    fields = set(ActivityItem.model_fields.keys())
+    assert fields == {"id", "timestamp", "severity", "category", "event_type",
+                      "message", "details", "target_id", "actor", "duration_ms"}
+
+
+def test_activity_item_serializes():
+    from app.schemas.activity import ActivityItem
+    item = ActivityItem(
+        id=1,
+        timestamp=datetime(2026, 4, 15, 12, 0, 0, tzinfo=timezone.utc),
+        severity="info", category="scan", event_type="scan_complete",
+        message="done", details=None, target_id=None, actor="system", duration_ms=None,
+    )
+    assert item.model_dump()["severity"] == "info"
+
+
+def test_paginated_response():
+    from app.schemas.activity import PaginatedActivityResponse, ActivityItem
+    resp = PaginatedActivityResponse(
+        items=[ActivityItem(
+            id=1, timestamp=datetime(2026, 4, 15, 12, 0, 0, tzinfo=timezone.utc),
+            severity="info", category="scan", event_type="scan_complete",
+            message="done", details=None, target_id=None, actor=None, duration_ms=None,
+        )],
+        next_cursor=None,
+        total=1,
+    )
+    assert resp.total == 1
+
+
+def test_filter_params_defaults():
+    from app.schemas.activity import ActivityFilterParams
+    p = ActivityFilterParams()
+    assert p.limit == 50
+    assert p.severity == []
+    assert p.category == []
+    assert p.cursor is None
+    assert p.since is None
+
+
+def test_filter_params_limit_cap():
+    from app.schemas.activity import ActivityFilterParams
+    p = ActivityFilterParams(limit=999)
+    assert p.limit == 200

--- a/backend/tests/test_tasks_emit.py
+++ b/backend/tests/test_tasks_emit.py
@@ -1,6 +1,6 @@
 import ast, pathlib
 import os, sys
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 import pytest
 
 os.environ.setdefault("GALACTILOG_DATABASE_URL", "postgresql+asyncpg://test:test@localhost:5432/test_catalog")
@@ -62,3 +62,47 @@ def test_emit_sync_imported_in_tasks():
                 if "emit_sync" in names:
                     found = True
     assert found, "emit_sync not imported from app.services.activity in tasks.py"
+
+
+def _bootstrap_real_tasks():
+    """Replace the conftest MagicMock stub with the real app.worker.tasks module."""
+    import sys as _sys
+    mod = _sys.modules.get("app.worker.tasks")
+    if mod is not None and not isinstance(mod, MagicMock):
+        return mod
+    _sys.modules.pop("app.worker.tasks", None)
+    mock_engine = MagicMock()
+    mock_engine.connect.return_value.__enter__ = MagicMock(return_value=mock_engine)
+    mock_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    with patch("sqlalchemy.create_engine", return_value=mock_engine):
+        import app.worker.tasks as tasks_mod
+    return tasks_mod
+
+
+def test_mosaic_detection_complete_emits():
+    tasks_mod = _bootstrap_real_tasks()
+    detect_mosaic_panels_task = tasks_mod.detect_mosaic_panels_task
+    emit_calls = []
+
+    def fake_emit_sync(session, *, redis, category, severity, event_type, message, **kw):
+        emit_calls.append({"event_type": event_type, "details": kw.get("details")})
+
+    mock_redis = MagicMock()
+    mock_redis.set.return_value = True
+    mock_redis.delete = MagicMock()
+
+    with patch.object(tasks_mod, "_redis", mock_redis), \
+         patch.object(tasks_mod, "_emit_activity_sync", fake_emit_sync), \
+         patch.object(tasks_mod, "_activity_session") as mf, \
+         patch("asyncio.run", return_value=7):
+        mctx = MagicMock()
+        mctx.__enter__ = lambda s, *a: MagicMock()
+        mctx.__exit__ = lambda s, *a: None
+        mf.return_value = mctx
+
+        result = detect_mosaic_panels_task.run()
+
+    assert result["status"] == "complete"
+    evs = [e for e in emit_calls if e["event_type"] == "mosaic_detection_complete"]
+    assert len(evs) == 1
+    assert evs[0]["details"]["candidates"] == 7

--- a/backend/tests/test_tasks_emit.py
+++ b/backend/tests/test_tasks_emit.py
@@ -79,6 +79,18 @@ def _bootstrap_real_tasks():
     return tasks_mod
 
 
+def test_enrichment_query_failed_emits_after_rebuild():
+    import pathlib
+    src = pathlib.Path("app/worker/tasks.py").read_text()
+    assert "enrichment_query_failed" in src
+
+
+def test_filename_candidate_failed_event_type_present():
+    import pathlib
+    src = pathlib.Path("app/worker/tasks.py").read_text()
+    assert "filename_candidate_failed" in src
+
+
 def test_mosaic_detection_complete_emits():
     tasks_mod = _bootstrap_real_tasks()
     detect_mosaic_panels_task = tasks_mod.detect_mosaic_panels_task

--- a/backend/tests/test_tasks_emit.py
+++ b/backend/tests/test_tasks_emit.py
@@ -40,6 +40,17 @@ def test_run_scan_uses_emit_sync_not_append_activity_sync():
     )
 
 
+def test_append_activity_sync_not_imported_in_tasks():
+    src = TASKS_PATH.read_text()
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.module and "scan_state" in node.module:
+                names = [a.name for a in node.names]
+                assert "append_activity_sync" not in names, \
+                    "append_activity_sync still imported in tasks.py"
+
+
 def test_emit_sync_imported_in_tasks():
     src = TASKS_PATH.read_text()
     tree = ast.parse(src)

--- a/backend/tests/test_tasks_emit.py
+++ b/backend/tests/test_tasks_emit.py
@@ -1,0 +1,53 @@
+import ast, pathlib
+import os, sys
+from unittest.mock import MagicMock
+import pytest
+
+os.environ.setdefault("GALACTILOG_DATABASE_URL", "postgresql+asyncpg://test:test@localhost:5432/test_catalog")
+os.environ.setdefault("GALACTILOG_REDIS_URL", "redis://localhost:6379/1")
+os.environ.setdefault("GALACTILOG_FITS_DATA_PATH", "/tmp/test_fits")
+os.environ.setdefault("GALACTILOG_THUMBNAILS_PATH", "/tmp/test_thumbnails")
+os.environ.setdefault("GALACTILOG_JWT_SECRET", "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
+os.environ.setdefault("GALACTILOG_HTTPS", "false")
+for _mod in ("fitsio",):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+
+TASKS_PATH = pathlib.Path("app/worker/tasks.py")
+
+
+def _run_scan_source() -> str:
+    src = TASKS_PATH.read_text()
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "run_scan":
+            return ast.get_source_segment(src, node)
+    raise AssertionError("run_scan not found in tasks.py")
+
+
+def test_run_scan_uses_emit_sync_not_append_activity_sync():
+    """The 5 scan emit sites inside run_scan must use emit_sync, not append_activity_sync."""
+    run_scan_src = _run_scan_source()
+    assert "append_activity_sync(" not in run_scan_src, (
+        "run_scan still contains append_activity_sync() calls; "
+        "all 5 scan emit sites should use _emit_activity_sync()"
+    )
+    # All 5 sites should be migrated.
+    assert run_scan_src.count("_emit_activity_sync(") >= 5, (
+        "run_scan should contain at least 5 _emit_activity_sync() calls "
+        "(scan_stopped, delta_scan, orphan_cleanup, orphan_warning, scan_complete)"
+    )
+
+
+def test_emit_sync_imported_in_tasks():
+    src = TASKS_PATH.read_text()
+    tree = ast.parse(src)
+    found = False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.module == "app.services.activity":
+                names = [a.name for a in node.names]
+                if "emit_sync" in names:
+                    found = True
+    assert found, "emit_sync not imported from app.services.activity in tasks.py"

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -44,6 +44,14 @@ services:
     ports:
       - "8080:80"                                                # <-- CHANGE host port if needed
     environment:
+      # PUID/PGID: set these to match the host user that owns the bind-mounted
+      # directories. Find your UID/GID with `id -u` / `id -g`. Defaults to 1000:1000.
+      # On TrueNAS/Unraid/Synology, use the UID/GID of the user that owns the
+      # host directories you bind-mount below.
+      # PUID: "1000"
+      # PGID: "1000"
+      # GALACTILOG_SKIP_CHOWN: "1"   # Opt out of the automatic one-time chown on boot
+
       # Database - must match the postgres service credentials above
       GALACTILOG_DATABASE_URL: postgresql+asyncpg://galactilog:galactilog@postgres:5432/galactilog_catalog
       GALACTILOG_REDIS_URL: redis://redis:6379/0

--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -3,5 +3,13 @@
 # To skip in prod: docker compose -f docker-compose.yml up
 services:
   app:
+    # PUID/PGID: set to the UID/GID that owns the dev bind mount below.
+    # Find yours with `id -u` / `id -g`. Defaults to 1000:1000.
+    # Create bind-mounted dev directories with correct ownership up front to
+    # avoid the one-time chown on container boot.
+    # environment:
+    #   PUID: "1000"
+    #   PGID: "1000"
+    #   GALACTILOG_SKIP_CHOWN: "1"
     volumes:
       - ./backend:/app

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,26 @@
-import { type Component, type ParentProps, Show } from "solid-js";
+import { type Component, type ParentProps, Show, createEffect } from "solid-js";
 import { useLocation } from "@solidjs/router";
 import NavBar from "./components/NavBar";
 import { Toast } from "./components/Toast";
+import { useAuth } from "./components/AuthProvider";
+import {
+  startErrorToastPoller,
+  stopErrorToastPoller,
+} from "./store/errorToastPoller";
+
+const ErrorPollerMount: Component = () => {
+  const { user } = useAuth();
+
+  createEffect(() => {
+    if (user() !== null) {
+      startErrorToastPoller();
+    } else {
+      stopErrorToastPoller();
+    }
+  });
+
+  return null;
+};
 
 const App: Component<ParentProps> = (props) => {
   const location = useLocation();
@@ -10,6 +29,7 @@ const App: Component<ParentProps> = (props) => {
     <div class="min-h-screen bg-theme-base text-theme-text-primary relative z-10">
       <Show when={location.pathname !== "/login"}>
         <NavBar />
+        <ErrorPollerMount />
       </Show>
       {props.children}
       <Toast />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -301,7 +301,7 @@ export const api = {
 
   regenerateThumbnails: (opts: { purge?: boolean } = {}) => {
     const qs = opts.purge ? "?purge=true" : "";
-    return fetchJson<ScanResult>(`/scan/regenerate-thumbnails${qs}`, { method: "POST" });
+    return fetchJson<ScanResult & { task_id?: string }>(`/scan/regenerate-thumbnails${qs}`, { method: "POST" });
   },
 
   resetScan: () =>
@@ -349,13 +349,13 @@ export const api = {
     }),
 
   rebuildTargets: () =>
-    fetchJson<{ status: string; message: string }>("/scan/rebuild-targets", { method: "POST" }),
+    fetchJson<{ status: string; message: string; task_id?: string }>("/scan/rebuild-targets", { method: "POST" }),
 
   smartRebuildTargets: () =>
-    fetchJson<{ status: string; message: string }>("/scan/smart-rebuild-targets", { method: "POST" }),
+    fetchJson<{ status: string; message: string; task_id?: string }>("/scan/smart-rebuild-targets", { method: "POST" }),
 
   retryUnresolved: () =>
-    fetchJson<{ status: string; message: string }>("/scan/retry-unresolved", { method: "POST" }),
+    fetchJson<{ status: string; message: string; task_id?: string }>("/scan/retry-unresolved", { method: "POST" }),
 
   getRebuildStatus: () =>
     fetchJson<import("../types").RebuildStatus>("/scan/rebuild-status"),
@@ -756,10 +756,10 @@ export const api = {
 
   // Catalog enrichment tasks
   triggerXmatchEnrichment: () =>
-    fetchJson<{ status: string; message: string }>("/scan/xmatch-enrichment", { method: "POST" }),
+    fetchJson<{ status: string; message: string; task_id?: string }>("/scan/xmatch-enrichment", { method: "POST" }),
 
   triggerReferenceThumbnails: (force = false) =>
-    fetchJson<{ status: string; message: string }>(`/scan/generate-reference-thumbnails${force ? "?force=true" : ""}`, { method: "POST" }),
+    fetchJson<{ status: string; message: string; task_id?: string }>(`/scan/generate-reference-thumbnails${force ? "?force=true" : ""}`, { method: "POST" }),
 
   // Backup / Restore
   createBackup: async (): Promise<Blob> => {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -26,6 +26,9 @@ import type {
   CustomColumn,
   CustomColumnValue,
   ColumnVisibility,
+  ActivityEvent,
+  ActivityQueryParams,
+  ActivityPageResponse,
 } from "../types";
 
 const API_BASE = import.meta.env.VITE_API_URL || "/api";
@@ -307,11 +310,43 @@ export const api = {
   stopScan: () =>
     fetchJson<{ status: string; message?: string }>("/scan/stop", { method: "POST" }),
 
-  getActivity: () =>
-    fetchJson<import("../types").ActivityEntry[]>("/scan/activity"),
+  fetchActivity: (params: ActivityQueryParams = {}) => {
+    const qs = new URLSearchParams();
+    const severities = Array.isArray(params.severity)
+      ? params.severity
+      : params.severity
+      ? [params.severity]
+      : [];
+    severities.forEach((s) => qs.append("severity", s));
+    const categories = Array.isArray(params.category)
+      ? params.category
+      : params.category
+      ? [params.category]
+      : [];
+    categories.forEach((c) => qs.append("category", c));
+    if (params.limit !== undefined) qs.set("limit", String(params.limit));
+    if (params.cursor) qs.set("cursor", params.cursor);
+    if (params.since) qs.set("since", params.since);
+    const q = qs.toString();
+    return fetchJson<ActivityPageResponse>(`/activity${q ? `?${q}` : ""}`);
+  },
 
-  clearActivity: () =>
-    fetchJson<{ status: string }>("/scan/activity", { method: "DELETE" }),
+  fetchActivityErrorsSince: (since: string) => {
+    const qs = new URLSearchParams({ severity: "error", since });
+    return fetchJson<ActivityPageResponse>(`/activity?${qs}`);
+  },
+
+  clearActivityLog: () =>
+    fetchJson<{ status: string }>("/activity", { method: "DELETE" }),
+
+  getActivitySettings: () =>
+    fetchJson<{ activity_retention_days: number }>("/settings/activity"),
+
+  setActivitySettings: (body: { retention_days: number }) =>
+    fetchJson<{ activity_retention_days: number }>("/settings/activity", {
+      method: "PUT",
+      body: JSON.stringify(body),
+    }),
 
   rebuildTargets: () =>
     fetchJson<{ status: string; message: string }>("/scan/rebuild-targets", { method: "POST" }),

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -683,7 +683,7 @@ export const api = {
     fetchJson<import("../types").MosaicSuggestionResponse[]>("/mosaics/suggestions"),
 
   triggerMosaicDetection: () =>
-    fetchJson<{ status: string; new_suggestions: number }>("/mosaics/detect", { method: "POST" }),
+    fetchJson<{ status: string; new_suggestions?: number; task_id?: string }>("/mosaics/detect", { method: "POST" }),
 
   acceptMosaicSuggestion: (id: string, selectedPanels?: string[]) =>
     fetchJson<import("../types").MosaicSummary>(`/mosaics/suggestions/${id}/accept`, {

--- a/frontend/src/components/ActivityFeed.tsx
+++ b/frontend/src/components/ActivityFeed.tsx
@@ -1,248 +1,481 @@
-import { Component, Show, For, createSignal } from "solid-js";
-import type { ScanStatus, ActivityEntry, RebuildStatus } from "../types";
+import {
+  Component,
+  For,
+  Show,
+  createSignal,
+  createEffect,
+  onMount,
+  onCleanup,
+  batch,
+} from "solid-js";
+import { A } from "@solidjs/router";
+import { activeJobs, hasActiveJobs } from "../store/activeJobs";
+import { api } from "../api/client";
 import { useSettingsContext } from "./SettingsProvider";
-import { formatDateTime, timezoneLabel } from "../utils/dateTime";
+import type {
+  ActivityEvent,
+  ActivityCategory,
+  ActivitySeverity,
+  ActiveJob,
+} from "../types";
+import FailedFilesList from "./activity/FailedFilesList";
+import EnrichmentFailureList from "./activity/EnrichmentFailureList";
+import DetailsJsonFallback from "./activity/DetailsJsonFallback";
 
-const ActivityFeed: Component<{
-  scanStatus: ScanStatus;
-  rebuildStatus: RebuildStatus;
-  stopping: boolean;
-  scanError: string | null;
-  activity: ActivityEntry[];
-  onClearActivity: () => void;
-  onResetAndRescan: () => void;
-  onDismissStalled: () => void;
-}> = (props) => {
-  const settingsCtx = useSettingsContext();
+const SEVERITY_ICON: Record<ActivitySeverity, string> = {
+  info: "\u25CF", // filled circle
+  warning: "\u25B2", // filled triangle
+  error: "\u2715", // cross
+};
 
-  const clearLog = () => props.onClearActivity();
+const SEVERITY_CLASS: Record<ActivitySeverity, string> = {
+  info: "text-theme-text-secondary",
+  warning: "text-theme-warning",
+  error: "text-theme-error",
+};
 
-  const isActive = () => {
-    const s = props.scanStatus.state;
-    return s === "scanning" || s === "ingesting";
-  };
+const CATEGORY_LABELS: Record<ActivityCategory, string> = {
+  scan: "scan",
+  rebuild: "reb",
+  thumbnail: "thumb",
+  enrichment: "enrich",
+  mosaic: "mosaic",
+  migration: "migr",
+  user_action: "user",
+  system: "sys",
+};
 
-  const progressPct = () => {
-    const s = props.scanStatus;
-    if (s.total === 0) return 0;
-    return Math.min(100, Math.round(((s.completed + s.failed) / s.total) * 100));
-  };
+const ALL_CATEGORIES: ActivityCategory[] = [
+  "scan", "rebuild", "thumbnail", "enrichment",
+  "mosaic", "migration", "user_action", "system",
+];
 
-  const elapsed = () => {
-    const s = props.scanStatus;
-    if (!s.started_at) return null;
-    const end = s.completed_at || Date.now() / 1000;
-    return Math.round(end - s.started_at);
-  };
+const IndeterminateBar: Component = () => (
+  <div class="w-full h-1.5 rounded-full overflow-hidden bg-[var(--color-bg-subtle)]">
+    <div
+      class="h-full rounded-full"
+      style={{
+        background: "var(--color-accent)",
+        animation: "activityIndeterminate 1.6s ease-in-out infinite",
+        width: "40%",
+      }}
+    />
+    <style>{`
+      @keyframes activityIndeterminate {
+        0%   { transform: translateX(-150%); }
+        100% { transform: translateX(350%); }
+      }
+    `}</style>
+  </div>
+);
 
-  const formatDuration = (secs: number) => {
-    if (secs < 60) return `${secs}s`;
-    const m = Math.floor(secs / 60);
-    const s = secs % 60;
-    return `${m}m ${s}s`;
-  };
+function startedAgo(startedAt: number): string {
+  const secs = Math.floor((Date.now() - startedAt) / 1000);
+  if (secs < 60) return `${secs}s ago`;
+  const m = Math.floor(secs / 60);
+  const s = secs % 60;
+  return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")} ago`;
+}
 
-  const throughput = () => {
-    const el = elapsed();
-    if (!el || el === 0 || props.scanStatus.completed === 0) return null;
-    return (props.scanStatus.completed / el).toFixed(1);
-  };
+const ActiveJobRow: Component<{ job: ActiveJob }> = (props) => {
+  const [agoLabel, setAgoLabel] = createSignal(startedAgo(props.job.startedAt));
 
-  const stateLabel = () => {
-    if (props.stopping) return "Stopping...";
-    switch (props.scanStatus.state) {
-      case "scanning": return "Discovering files...";
-      case "ingesting": return "Ingesting";
-      default: return "";
-    }
-  };
-
-  const lostCount = () => {
-    const s = props.scanStatus;
-    return s.total - s.completed - s.failed;
-  };
-
-  const formatTime = (ts: number) =>
-    formatDateTime(new Date(ts * 1000), settingsCtx.timezone(), settingsCtx.use24hTime()) + " " + timezoneLabel(settingsCtx.timezone());
+  const timer = setInterval(() => {
+    setAgoLabel(startedAgo(props.job.startedAt));
+  }, 5000);
+  onCleanup(() => clearInterval(timer));
 
   return (
-    <div class="bg-theme-surface border border-theme-border rounded-[var(--radius-md)] shadow-[var(--shadow-sm)] p-4 flex flex-col h-full min-h-0">
-      <div class="flex justify-between items-center flex-wrap gap-2 mb-3">
-        <h3 class="text-theme-text-primary font-medium">Activity</h3>
-        <Show when={props.activity.length > 0 && !isActive()}>
-          <button
-            onClick={clearLog}
-            class="text-xs text-theme-text-secondary hover:text-theme-text-primary transition-colors"
-          >
-            Clear
-          </button>
-        </Show>
-      </div>
-
-      <div class="flex-1 min-h-0 overflow-y-auto space-y-3">
-      <Show when={props.scanError}>
-        <p class="text-xs text-theme-error">{props.scanError}</p>
-      </Show>
-
-      {/* Live scan progress */}
-      <Show when={isActive()}>
-        <div class="space-y-2 border border-theme-border-em rounded-[var(--radius-md)] p-3">
-          <div class="flex justify-between text-xs text-theme-text-secondary">
-            <span class="flex items-center gap-2">
-              <span class="w-2 h-2 bg-theme-accent rounded-full animate-pulse flex-shrink-0" />
-              {stateLabel()}
+    <div class="space-y-1.5 py-2">
+      <div class="flex items-center justify-between gap-2">
+        <div class="flex flex-col min-w-0">
+          <span class="text-xs font-medium text-theme-text-primary truncate">
+            {props.job.label}
+          </span>
+          <Show when={props.job.subLabel}>
+            <span class="text-xs text-theme-text-secondary truncate">
+              {props.job.subLabel}
             </span>
-            <Show when={props.scanStatus.state === "scanning"}>
-              <span>{props.scanStatus.discovered > 0 ? `${props.scanStatus.discovered.toLocaleString()} files found` : ""}</span>
-            </Show>
-            <Show when={props.scanStatus.state === "ingesting"}>
-              <span>{props.scanStatus.completed + props.scanStatus.failed} / {props.scanStatus.total}</span>
-            </Show>
-          </div>
-          <Show when={props.scanStatus.state === "scanning"}>
-            <div class="w-full bg-theme-base rounded-full h-2 overflow-hidden">
-              <div class="bg-theme-accent h-2 rounded-full animate-pulse w-full opacity-30" />
-            </div>
-          </Show>
-          <Show when={props.scanStatus.state === "ingesting"}>
-            <div class="w-full bg-theme-base rounded-full h-2">
-              <div class="bg-theme-accent h-2 rounded-full transition-all" style={{ width: `${progressPct()}%` }} />
-            </div>
-            <div class="flex justify-between text-xs text-theme-text-secondary">
-              <div class="flex gap-4">
-                <Show when={elapsed() != null}>
-                  <span>Elapsed: {formatDuration(elapsed()!)}</span>
-                </Show>
-                <Show when={throughput() != null}>
-                  <span>{throughput()} files/s</span>
-                </Show>
-              </div>
-              <div class="flex gap-3">
-                <Show when={props.scanStatus.new_files > 0}>
-                  <span>{props.scanStatus.new_files} new</span>
-                </Show>
-                <Show when={props.scanStatus.changed_files > 0}>
-                  <span>{props.scanStatus.changed_files} changed</span>
-                </Show>
-                <Show when={props.scanStatus.removed > 0}>
-                  <span>{props.scanStatus.removed} removed</span>
-                </Show>
-                <Show when={props.scanStatus.failed > 0}>
-                  <span class="text-theme-error">{props.scanStatus.failed} failed</span>
-                </Show>
-                <Show when={props.scanStatus.skipped_calibration > 0}>
-                  <span>{props.scanStatus.skipped_calibration} skipped</span>
-                </Show>
-              </div>
-            </div>
           </Show>
         </div>
-      </Show>
-
-      {/* Live rebuild progress */}
-      <Show when={props.rebuildStatus.state === "running"}>
-        <div class="flex items-center gap-2 border border-theme-border-em rounded-[var(--radius-md)] p-3">
-          <span class="w-2 h-2 bg-theme-accent rounded-full animate-pulse flex-shrink-0" />
-          <span class="text-xs text-theme-text-primary">{props.rebuildStatus.message || "Running..."}</span>
-        </div>
-      </Show>
-
-      {/* Rebuild completion summary */}
-      <Show when={props.rebuildStatus.state === "complete" && props.rebuildStatus.message}>
-        <div class="flex items-center gap-2 border border-theme-success/30 rounded-[var(--radius-md)] p-3">
-          <span class="w-2 h-2 bg-theme-success rounded-full flex-shrink-0" />
-          <span class="text-xs text-theme-text-primary">{props.rebuildStatus.message}</span>
-        </div>
-      </Show>
-
-      {/* Stalled warning */}
-      <Show when={props.scanStatus.state === "stalled"}>
-        <div class="bg-theme-warning/20 border border-theme-warning/50 rounded-[var(--radius-md)] p-3 space-y-2">
-          <span class="text-theme-warning text-sm font-medium">Scan stalled</span>
-          <p class="text-xs text-theme-warning/80">
-            {props.scanStatus.completed + props.scanStatus.failed} of {props.scanStatus.total} files were processed
-            ({props.scanStatus.completed} ingested, {props.scanStatus.failed} failed)
-            but {lostCount()} tasks stopped responding.
-          </p>
-          <p class="text-xs text-theme-warning/60">
-            Already-ingested files are safe. A rescan will pick up the {lostCount()} remaining files.
-          </p>
-          <div class="flex gap-2 pt-1">
+        <div class="flex items-center gap-2 flex-shrink-0">
+          <span class="text-xs text-theme-text-secondary">{agoLabel()}</span>
+          <Show when={props.job.cancelable && props.job.onCancel}>
             <button
-              onClick={props.onResetAndRescan}
-              class="px-3 py-1.5 bg-theme-accent/15 text-theme-accent border border-theme-accent/30 rounded text-xs font-medium hover:bg-theme-accent/25 transition-colors"
+              onClick={() => props.job.onCancel?.()}
+              class="px-2 py-1 text-xs border border-theme-border-em text-theme-text-secondary rounded hover:border-theme-error hover:text-theme-error transition-colors"
             >
-              Reset & Rescan
+              Stop
             </button>
-            <button
-              onClick={props.onDismissStalled}
-              class="px-3 py-1.5 border border-theme-border-em text-theme-text-secondary rounded text-xs hover:border-theme-accent hover:text-theme-text-primary transition-colors"
-            >
-              Dismiss
-            </button>
-          </div>
+          </Show>
         </div>
-      </Show>
-
-      {/* Failed files (expandable) */}
-      <Show when={(props.scanStatus.failed_files?.length ?? 0) > 0}>
-        <FailedFilesSection files={props.scanStatus.failed_files!} />
-      </Show>
-
-      {/* Historical activity log */}
-      <Show when={props.activity.length > 0}>
-        <div class="space-y-1">
-          <For each={props.activity}>
-            {(entry) => (
-              <div class="flex gap-3 text-xs py-1.5 border-t border-theme-border first:border-0">
-                <span class="text-theme-text-secondary flex-shrink-0 min-w-[4.5rem]">
-                  {formatTime(entry.timestamp)}
-                </span>
-                <span class={
-                  entry.type.includes("failed") ? "text-theme-error" :
-                  entry.type.includes("stopped") || entry.type.includes("stalled") || entry.type.includes("warning") ? "text-theme-warning" :
-                  entry.type.startsWith("migration_") ? "text-theme-text-secondary" :
-                  "text-theme-text-primary"
-                }>
-                  {entry.message}
-                </span>
-              </div>
-            )}
-          </For>
-        </div>
-      </Show>
-
-      {/* Empty state */}
-      <Show when={!isActive() && props.rebuildStatus.state !== "running" && props.scanStatus.state !== "stalled" && props.activity.length === 0 && !props.scanError}>
-        <p class="text-xs text-theme-text-secondary">No recent activity</p>
-      </Show>
       </div>
+      <Show
+        when={props.job.progress !== undefined}
+        fallback={<IndeterminateBar />}
+      >
+        {(_) => {
+          const pct = () => Math.round((props.job.progress ?? 0) * 100);
+          return (
+            <div class="w-full h-1.5 rounded-full overflow-hidden bg-[var(--color-bg-subtle)]">
+              <div
+                class="h-full rounded-full transition-all"
+                style={{
+                  background: "var(--color-accent)",
+                  width: `${pct()}%`,
+                }}
+              />
+            </div>
+          );
+        }}
+      </Show>
     </div>
   );
 };
 
-const FailedFilesSection: Component<{ files: { file: string; error: string }[] }> = (props) => {
+const RowDetails: Component<{ event: ActivityEvent }> = (props) => {
+  const d = props.event.details;
+  if (!d) return null;
+
+  if (
+    props.event.category === "scan" &&
+    Array.isArray((d as any).failed_files)
+  ) {
+    return (
+      <FailedFilesList
+        files={(d as any).failed_files}
+        truncated={(d as any).truncated ?? false}
+      />
+    );
+  }
+
+  if (
+    props.event.category === "enrichment" &&
+    Array.isArray((d as any).failed_targets)
+  ) {
+    return <EnrichmentFailureList targets={(d as any).failed_targets} />;
+  }
+
+  return <DetailsJsonFallback details={d} />;
+};
+
+const TargetLinkedMessage: Component<{ event: ActivityEvent }> = (props) => (
+  <span>
+    {props.event.message}
+    {" "}
+    <A
+      href={`/targets/${props.event.target_id}`}
+      class="text-theme-accent hover:underline"
+      onClick={(e) => e.stopPropagation()}
+    >
+      {"\u2197"}
+    </A>
+  </span>
+);
+
+const HistoryRow: Component<{ event: ActivityEvent }> = (props) => {
+  const settingsCtx = useSettingsContext();
   const [expanded, setExpanded] = createSignal(false);
+  const hasDetails = () => props.event.details !== null;
+
+  const hhmm = () => {
+    const d = new Date(props.event.timestamp);
+    const fmt = new Intl.DateTimeFormat("en-GB", {
+      hour: "2-digit",
+      minute: "2-digit",
+      timeZone: settingsCtx.timezone() || "UTC",
+      hour12: !settingsCtx.use24hTime(),
+    });
+    return fmt.format(d);
+  };
+
   return (
-    <div class="space-y-1">
-      <button
-        onClick={() => setExpanded((v) => !v)}
-        class="text-xs text-theme-error hover:underline"
+    <div
+      id={`activity-event-${props.event.id}`}
+      class="border-t border-theme-border first:border-0"
+    >
+      <div
+        class="flex items-start gap-2 py-1.5 text-xs cursor-default"
+        tabIndex={hasDetails() ? 0 : undefined}
+        role={hasDetails() ? "button" : undefined}
+        aria-expanded={hasDetails() ? expanded() : undefined}
+        onKeyDown={(e) => {
+          if (hasDetails() && (e.key === "Enter" || e.key === " ")) {
+            e.preventDefault();
+            setExpanded((v) => !v);
+          }
+        }}
+        onClick={() => {
+          if (hasDetails()) setExpanded((v) => !v);
+        }}
       >
-        {expanded() ? "Hide" : "Show"} {props.files.length} failed file{props.files.length > 1 ? "s" : ""}
-      </button>
-      <Show when={expanded()}>
-        <div class="max-h-40 overflow-y-auto space-y-1">
-          <For each={props.files}>
-            {(f) => (
-              <div class="border border-theme-border rounded px-2 py-1">
-                <div class="text-xs text-theme-text-secondary break-all">{f.file}</div>
-                <div class="text-xs text-theme-error/70 truncate" title={f.error}>{f.error}</div>
-              </div>
-            )}
+        <span class="text-theme-text-secondary flex-shrink-0 w-[3rem] tabular-nums">
+          {hhmm()}
+        </span>
+        <span
+          class={`flex-shrink-0 w-4 text-center ${SEVERITY_CLASS[props.event.severity]}`}
+          title={props.event.severity}
+        >
+          {SEVERITY_ICON[props.event.severity]}
+        </span>
+        <span class="flex-shrink-0 w-[3.5rem] text-theme-text-secondary truncate">
+          {CATEGORY_LABELS[props.event.category]}
+        </span>
+        <span class="flex-1 text-theme-text-primary min-w-0">
+          <Show
+            when={props.event.target_id !== null}
+            fallback={<span>{props.event.message}</span>}
+          >
+            <TargetLinkedMessage event={props.event} />
+          </Show>
+        </span>
+        <Show when={hasDetails()}>
+          <span
+            class={`flex-shrink-0 text-theme-text-secondary transition-transform ${
+              expanded() ? "rotate-90" : ""
+            }`}
+          >
+            {"\u203A"}
+          </span>
+        </Show>
+      </div>
+      <Show when={expanded() && hasDetails()}>
+        <div class="pb-2 pl-[7rem]">
+          <RowDetails event={props.event} />
+        </div>
+      </Show>
+    </div>
+  );
+};
+
+const FilterPill: Component<{
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}> = (props) => (
+  <button
+    onClick={props.onClick}
+    class={`px-2 py-0.5 text-xs rounded-full border transition-colors ${
+      props.active
+        ? "bg-[var(--color-accent)]/20 text-[var(--color-accent)] border-[var(--color-accent)]/40"
+        : "border-theme-border text-theme-text-secondary hover:text-theme-text-primary hover:border-theme-border-em"
+    }`}
+  >
+    {props.label}
+  </button>
+);
+
+const ActivityFeed: Component = () => {
+  const [severityFilter, setSeverityFilter] =
+    createSignal<ActivitySeverity | "all">("all");
+  const [categoryFilter, setCategoryFilter] =
+    createSignal<ActivityCategory | "all">("all");
+  const [items, setItems] = createSignal<ActivityEvent[]>([]);
+  const [nextCursor, setNextCursor] = createSignal<string | null>(null);
+  const [total, setTotal] = createSignal(0);
+  const [loading, setLoading] = createSignal(false);
+  const [loadingMore, setLoadingMore] = createSignal(false);
+  const [newCount, setNewCount] = createSignal(0);
+  const [latestId, setLatestId] = createSignal<number | null>(null);
+  const [isScrolledDown, setIsScrolledDown] = createSignal(false);
+  let listRef: HTMLDivElement | undefined;
+  let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+  const buildParams = (extra: Record<string, unknown> = {}) => {
+    const p: Record<string, unknown> = { limit: 50, ...extra };
+    const sv = severityFilter();
+    if (sv !== "all") p.severity = sv;
+    const cat = categoryFilter();
+    if (cat !== "all") p.category = cat;
+    return p;
+  };
+
+  const loadInitial = async () => {
+    setLoading(true);
+    try {
+      const res = await api.fetchActivity(buildParams());
+      batch(() => {
+        setItems(res.items);
+        setNextCursor(res.next_cursor);
+        setTotal(res.total);
+        setNewCount(0);
+        if (res.items.length > 0) setLatestId(res.items[0].id);
+      });
+    } catch { /* non-blocking */ } finally {
+      setLoading(false);
+    }
+  };
+
+  const loadMore = async () => {
+    const cursor = nextCursor();
+    if (!cursor || loadingMore()) return;
+    setLoadingMore(true);
+    try {
+      const res = await api.fetchActivity(buildParams({ cursor }));
+      batch(() => {
+        setItems((prev) => [...prev, ...res.items]);
+        setNextCursor(res.next_cursor);
+      });
+    } catch { /* ignore */ } finally {
+      setLoadingMore(false);
+    }
+  };
+
+  const pollNew = async () => {
+    const top = latestId();
+    if (top === null) { await loadInitial(); return; }
+    try {
+      const res = await api.fetchActivity(buildParams({ limit: 50 }));
+      if (res.items.length === 0) return;
+      const newItems = res.items.filter((e) => e.id > top);
+      if (newItems.length === 0) return;
+      if (isScrolledDown()) {
+        setNewCount((n) => n + newItems.length);
+      } else {
+        batch(() => {
+          setItems((prev) => [...newItems, ...prev]);
+          setLatestId(newItems[0].id);
+          setTotal(res.total);
+        });
+      }
+    } catch { /* ignore */ }
+  };
+
+  onMount(() => {
+    loadInitial();
+    pollTimer = setInterval(pollNew, 10_000);
+  });
+
+  onCleanup(() => {
+    if (pollTimer) clearInterval(pollTimer);
+  });
+
+  createEffect(() => {
+    severityFilter();
+    categoryFilter();
+    loadInitial();
+  });
+
+  const onScroll = () => {
+    if (!listRef) return;
+    setIsScrolledDown(listRef.scrollTop > 120);
+  };
+
+  const jumpToNew = () => {
+    listRef?.scrollTo({ top: 0, behavior: "smooth" });
+    setNewCount(0);
+    loadInitial();
+  };
+
+  const jobs = () => activeJobs();
+  const jobCount = () => jobs().length;
+
+  return (
+    <div class="bg-theme-surface border border-theme-border rounded-[var(--radius-md)] shadow-[var(--shadow-sm)] flex flex-col h-full min-h-0">
+      <div class="flex items-center justify-between px-4 py-3 flex-shrink-0">
+        <div class="flex items-center gap-2">
+          <h3 class="text-theme-text-primary font-medium text-sm">Activity</h3>
+          <Show when={jobCount() > 0}>
+            <span class="px-1.5 py-0.5 text-xs rounded-full bg-[var(--color-accent)]/20 text-[var(--color-accent)] border border-[var(--color-accent)]/30 tabular-nums">
+              {jobCount()} live
+            </span>
+          </Show>
+        </div>
+      </div>
+
+      <Show when={hasActiveJobs()}>
+        <div
+          role="status"
+          aria-live="polite"
+          class="px-4 pb-3 border-b border-theme-border space-y-0 divide-y divide-theme-border"
+          style={{ background: "var(--color-bg-subtle)" }}
+        >
+          <p class="text-[10px] font-semibold uppercase tracking-wider text-theme-text-secondary pb-1 pt-0.5">
+            Now Running
+          </p>
+          <For each={jobs()}>
+            {(job) => <ActiveJobRow job={job} />}
           </For>
         </div>
       </Show>
+
+      <div class="flex flex-col flex-1 min-h-0">
+        <div class="px-4 pt-3 pb-2 space-y-1.5 flex-shrink-0">
+          <p class="text-[10px] font-semibold uppercase tracking-wider text-theme-text-secondary">
+            History
+          </p>
+          <div class="flex flex-wrap gap-1">
+            {(["all", "info", "warning", "error"] as const).map((sv) => (
+              <FilterPill
+                label={sv === "all" ? "all" : sv === "warning" ? "warn" : sv}
+                active={severityFilter() === sv}
+                onClick={() => setSeverityFilter(sv)}
+              />
+            ))}
+          </div>
+          <div class="flex flex-wrap gap-1">
+            <FilterPill
+              label="all"
+              active={categoryFilter() === "all"}
+              onClick={() => setCategoryFilter("all")}
+            />
+            <For each={ALL_CATEGORIES}>
+              {(cat) => (
+                <FilterPill
+                  label={CATEGORY_LABELS[cat]}
+                  active={categoryFilter() === cat}
+                  onClick={() => setCategoryFilter(cat)}
+                />
+              )}
+            </For>
+          </div>
+        </div>
+
+        <div
+          ref={listRef}
+          class="flex-1 min-h-0 overflow-y-auto px-4 relative"
+          onScroll={onScroll}
+        >
+          <Show when={newCount() > 0}>
+            <div class="sticky top-2 flex justify-center z-10">
+              <button
+                onClick={jumpToNew}
+                class="px-3 py-1 text-xs rounded-full bg-[var(--color-accent)] text-white shadow-md"
+              >
+                {newCount()} new, click to view
+              </button>
+            </div>
+          </Show>
+
+          <Show when={loading()}>
+            <p class="text-xs text-theme-text-secondary py-4 text-center">Loading...</p>
+          </Show>
+
+          <Show when={!loading() && items().length === 0}>
+            <p class="text-xs text-theme-text-secondary py-4">No activity recorded yet.</p>
+          </Show>
+
+          <Show when={!loading()}>
+            <div class="space-y-0">
+              <For each={items()}>
+                {(event) => <HistoryRow event={event} />}
+              </For>
+            </div>
+
+            <Show when={nextCursor() !== null}>
+              <div class="py-3 text-center">
+                <button
+                  onClick={loadMore}
+                  disabled={loadingMore()}
+                  class="px-4 py-1.5 text-xs border border-theme-border text-theme-text-secondary rounded hover:text-theme-text-primary hover:border-theme-border-em transition-colors disabled:opacity-50"
+                >
+                  {loadingMore() ? "Loading..." : "Load older"}
+                </button>
+              </div>
+            </Show>
+          </Show>
+        </div>
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/MaintenanceActions.tsx
+++ b/frontend/src/components/MaintenanceActions.tsx
@@ -1,30 +1,83 @@
 import { Component, Show, createSignal } from "solid-js";
 import { api } from "../api/client";
+import { emitWithToast } from "../lib/emitWithToast";
 
-const MaintenanceActions: Component<{
-  disabled: boolean;
-  rebuildRunning: boolean;
-  rebuildMode: string;
-  onRegenThumbnails: (opts?: { purge?: boolean }) => void;
-  onStartedAction: () => void;
-}> = (props) => {
+const MaintenanceActions: Component = () => {
   const [showFullConfirm, setShowFullConfirm] = createSignal(false);
   const [showRefThumbChoice, setShowRefThumbChoice] = createSignal(false);
   const [showRegenChoice, setShowRegenChoice] = createSignal(false);
   const [confirmPurgeRegen, setConfirmPurgeRegen] = createSignal(false);
+  const [busy, setBusy] = createSignal(false);
 
-  const runAction = async (action: () => Promise<any>) => {
+  const run = async (fn: () => Promise<void>) => {
+    if (busy()) return;
+    setBusy(true);
     setShowFullConfirm(false);
     setShowRefThumbChoice(false);
     setShowRegenChoice(false);
     setConfirmPurgeRegen(false);
-    try {
-      await action();
-      props.onStartedAction();
-    } catch { /* ignore */ }
+    try { await fn(); } finally { setBusy(false); }
   };
 
-  const anyDisabled = () => props.disabled || props.rebuildRunning;
+  const fixOrphans = () => run(() => emitWithToast({
+    action: () => api.smartRebuildTargets() as Promise<{ task_id: string }>,
+    pendingLabel: "Starting Fix Orphans...",
+    successLabel: "Fix Orphans complete",
+    errorLabel: "Fix Orphans failed",
+    category: "rebuild",
+    taskLabel: "Fix Orphans",
+    timeout: 600_000,
+  }));
+
+  const reResolve = () => run(() => emitWithToast({
+    action: () => api.retryUnresolved() as Promise<{ task_id: string }>,
+    pendingLabel: "Starting Re-resolve...",
+    successLabel: "Re-resolve complete",
+    errorLabel: "Re-resolve failed",
+    category: "enrichment",
+    taskLabel: "Re-resolve targets",
+    timeout: 600_000,
+  }));
+
+  const catalogMatch = () => run(() => emitWithToast({
+    action: () => api.triggerXmatchEnrichment() as Promise<{ task_id: string }>,
+    pendingLabel: "Starting Catalog Match...",
+    successLabel: "Catalog Match complete",
+    errorLabel: "Catalog Match failed",
+    category: "enrichment",
+    taskLabel: "Catalog Match",
+    timeout: 600_000,
+  }));
+
+  const fetchDss = (forceAll: boolean) => run(() => emitWithToast({
+    action: () => api.triggerReferenceThumbnails(forceAll) as Promise<{ task_id: string }>,
+    pendingLabel: "Starting DSS fetch...",
+    successLabel: "DSS fetch complete",
+    errorLabel: "DSS fetch failed",
+    category: "thumbnail",
+    taskLabel: forceAll ? "Fetch DSS (all)" : "Fetch DSS (missing)",
+    timeout: 600_000,
+  }));
+
+  const regenThumbs = (purge: boolean) => run(() => emitWithToast({
+    action: () => api.regenerateThumbnails({ purge }) as Promise<{ task_id: string }>,
+    pendingLabel: purge ? "Deleting and regenerating thumbnails..." : "Regenerating thumbnails...",
+    successLabel: "Thumbnail regeneration complete",
+    errorLabel: "Thumbnail regeneration failed",
+    category: "thumbnail",
+    taskLabel: purge ? "Regen Thumbnails (purge)" : "Regen Thumbnails",
+    timeout: 1_800_000,
+  }));
+
+  const fullRebuild = () => run(() => emitWithToast({
+    action: () => api.rebuildTargets() as Promise<{ task_id: string }>,
+    pendingLabel: "Starting Full Rebuild...",
+    successLabel: "Full Rebuild complete",
+    errorLabel: "Full Rebuild failed",
+    category: "rebuild",
+    taskLabel: "Full Rebuild",
+    timeout: 3_600_000,
+  }));
 
   return (
     <div class="bg-theme-surface border border-theme-border rounded-[var(--radius-md)] shadow-[var(--shadow-sm)] p-4 space-y-3">
@@ -32,40 +85,40 @@ const MaintenanceActions: Component<{
         <h3 class="text-theme-text-primary font-medium">Maintenance</h3>
         <div class="flex gap-2 flex-shrink-0 flex-wrap">
           <button
-            onClick={() => runAction(api.smartRebuildTargets)}
-            disabled={anyDisabled()}
+            onClick={fixOrphans}
+            disabled={busy()}
             title="Re-matches orphaned images to existing targets using known aliases and cached SIMBAD results. Fast and offline - no network calls needed."
             class="px-3 py-1.5 border border-theme-border-em text-theme-text-secondary rounded text-sm disabled:opacity-50 hover:text-theme-text-primary hover:border-theme-accent transition-colors"
           >
-            {props.rebuildRunning && props.rebuildMode === "smart" ? "Running..." : "Fix Orphans"}
+            Fix Orphans
           </button>
           <button
-            onClick={() => runAction(api.retryUnresolved)}
-            disabled={anyDisabled()}
+            onClick={reResolve}
+            disabled={busy()}
             title="Clears SIMBAD negative cache and SESAME cache, then re-resolves unresolved targets through SIMBAD and SESAME (NED + VizieR). Existing targets are not affected."
             class="px-3 py-1.5 border border-theme-border-em text-theme-text-secondary rounded text-sm disabled:opacity-50 hover:text-theme-text-primary hover:border-theme-accent transition-colors"
           >
-            {props.rebuildRunning && props.rebuildMode === "retry" ? "Running..." : "Re-resolve"}
+            Re-resolve
           </button>
           <button
-            onClick={() => runAction(api.triggerXmatchEnrichment)}
-            disabled={anyDisabled()}
+            onClick={catalogMatch}
+            disabled={busy()}
             title="Runs bulk cross-match enrichment against external catalogs (Caldwell, Herschel 400, Arp, Abell) for all targets."
             class="px-3 py-1.5 border border-theme-border-em text-theme-text-secondary rounded text-sm disabled:opacity-50 hover:text-theme-text-primary hover:border-theme-accent transition-colors"
           >
-            {props.rebuildRunning && props.rebuildMode === "xmatch" ? "Running..." : "Catalog Match"}
+            Catalog Match
           </button>
           <button
             onClick={() => setShowRefThumbChoice(true)}
-            disabled={anyDisabled()}
+            disabled={busy()}
             title="Fetch DSS reference thumbnails from SkyView for targets with coordinates."
             class="px-3 py-1.5 border border-theme-border-em text-theme-text-secondary rounded text-sm disabled:opacity-50 hover:text-theme-text-primary hover:border-theme-accent transition-colors"
           >
-            {props.rebuildRunning && props.rebuildMode === "ref_thumbnails" ? "Running..." : "Fetch DSS"}
+            Fetch DSS
           </button>
           <button
             onClick={() => setShowRegenChoice(true)}
-            disabled={anyDisabled()}
+            disabled={busy()}
             title="Re-create all thumbnails using current stretch settings. Optionally delete existing thumbnails first."
             class="px-3 py-1.5 bg-theme-warning/15 text-theme-warning border border-theme-warning/30 rounded text-sm font-medium disabled:opacity-50 hover:bg-theme-warning/25 transition-colors"
           >
@@ -73,11 +126,11 @@ const MaintenanceActions: Component<{
           </button>
           <button
             onClick={() => setShowFullConfirm(true)}
-            disabled={anyDisabled()}
+            disabled={busy()}
             title="Deletes all targets and re-resolves from FITS headers via SIMBAD, SESAME (NED + VizieR), and VizieR enrichment. Cached results make repeat runs fast."
             class="px-3 py-1.5 border border-theme-error/50 text-theme-error rounded text-sm disabled:opacity-50 hover:bg-theme-error/20 hover:text-theme-error transition-colors"
           >
-            {props.rebuildRunning && props.rebuildMode === "full" ? "Running..." : "Full Rebuild"}
+            Full Rebuild
           </button>
         </div>
       </div>
@@ -90,13 +143,13 @@ const MaintenanceActions: Component<{
           </p>
           <div class="flex gap-2 pt-1">
             <button
-              onClick={() => runAction(() => api.triggerReferenceThumbnails(false))}
+              onClick={() => fetchDss(false)}
               class="px-3 py-1.5 border border-theme-accent text-theme-accent rounded text-xs font-medium hover:bg-theme-accent/20 transition-colors"
             >
               Missing only
             </button>
             <button
-              onClick={() => runAction(() => api.triggerReferenceThumbnails(true))}
+              onClick={() => fetchDss(true)}
               class="px-3 py-1.5 border border-theme-border-em text-theme-text-secondary rounded text-xs hover:border-theme-accent hover:text-theme-text-primary transition-colors"
             >
               Re-fetch all
@@ -119,7 +172,7 @@ const MaintenanceActions: Component<{
           </p>
           <div class="flex gap-2 pt-1">
             <button
-              onClick={() => { setShowRegenChoice(false); props.onRegenThumbnails(); }}
+              onClick={() => regenThumbs(false)}
               class="px-3 py-1.5 border border-theme-accent text-theme-accent rounded text-xs font-medium hover:bg-theme-accent/20 transition-colors"
             >
               Regenerate in place
@@ -150,7 +203,7 @@ const MaintenanceActions: Component<{
           </p>
           <div class="flex gap-2 pt-1">
             <button
-              onClick={() => { setConfirmPurgeRegen(false); setShowRegenChoice(false); props.onRegenThumbnails({ purge: true }); }}
+              onClick={() => regenThumbs(true)}
               class="px-3 py-1.5 bg-theme-error text-theme-text-primary rounded text-xs font-medium hover:opacity-90 transition-colors"
             >
               Yes, delete and regenerate
@@ -177,7 +230,7 @@ const MaintenanceActions: Component<{
           </p>
           <div class="flex gap-2 pt-1">
             <button
-              onClick={() => runAction(api.rebuildTargets)}
+              onClick={fullRebuild}
               class="px-3 py-1.5 bg-theme-error text-theme-text-primary rounded text-xs font-medium hover:opacity-90 transition-colors"
             >
               Yes, rebuild everything

--- a/frontend/src/components/ScanManager.tsx
+++ b/frontend/src/components/ScanManager.tsx
@@ -16,6 +16,7 @@ import ScanFiltersPanel from "./ScanFiltersPanel";
 import ScanFiltersOnboarding from "./ScanFiltersOnboarding";
 import { showToast } from "./Toast";
 import HelpPopover from "./HelpPopover";
+import { wireActiveJobSources } from "../store/activeJobs";
 
 type FrameFilter = "all" | "light_only";
 
@@ -45,6 +46,8 @@ const ScanManager: Component = () => {
   const [observerLongitude, setObserverLongitude] = createSignal<number | null>(null);
   const [scanFiltersData, setScanFiltersData] = createSignal<ScanFiltersResponse | null>(null);
   let rebuildPollTimer: ReturnType<typeof setInterval> | null = null;
+
+  wireActiveJobSources(scanStatus, rebuildState, stopScan);
 
   // --- Scan filters (shared between ScanFiltersPanel & ScanFiltersOnboarding) ---
   const loadScanFilters = async () => {

--- a/frontend/src/components/ScanManager.tsx
+++ b/frontend/src/components/ScanManager.tsx
@@ -5,7 +5,7 @@ import { useAuth } from "./AuthProvider";
 import { useStats } from "../store/stats";
 import { api } from "../api/client";
 import { scanFilters as scanFiltersApi } from "../api/scanFilters";
-import type { RebuildStatus, ActivityEntry } from "../types";
+import type { RebuildStatus } from "../types";
 import type { ScanFiltersResponse } from "../api/scanFilters";
 import DatabaseOverview from "./DatabaseOverview";
 import CaptureActivity from "./CaptureActivity";
@@ -30,7 +30,7 @@ const INTERVALS = [
 ];
 
 const ScanManager: Component = () => {
-  const { scanStatus, scanError, isActive, stopping, startScan, startRegeneration, resetScan, stopScan, stopPolling } = useScan();
+  const { scanStatus, isActive, stopping, startScan, startRegeneration, stopScan, stopPolling } = useScan();
   const { settings, saveGeneral } = useSettingsContext();
   const { isAdmin } = useAuth();
   const { stats } = useStats();
@@ -64,19 +64,9 @@ const ScanManager: Component = () => {
     try { setDbSummary(await api.getDbSummary()); } catch { /* ignore */ }
   };
 
-  // --- Activity ---
-  const [activity, setActivity] = createSignal<ActivityEntry[]>([]);
-  const refreshActivity = async () => {
-    try { setActivity(await api.getActivity()); } catch { /* ignore */ }
-  };
-
-  const clearActivity = async () => {
-    try { await api.clearActivity(); setActivity([]); } catch { /* ignore */ }
-  };
-
-  // Track previous composite state (scan + rebuild) to only fetch on real
-  // transitions. Starting with null ensures the first effect run triggers
-  // the initial fetch for both db-summary and activity.
+  // Track previous composite state (scan + rebuild) to only fetch db summary
+  // on real transitions. Starting with null ensures the first effect run
+  // triggers the initial fetch.
   let prevCompositeState: string | null = null;
   createEffect(() => {
     const scanState = scanStatus().state;
@@ -87,9 +77,6 @@ const ScanManager: Component = () => {
       prevCompositeState = current;
       if (wasPrev === null || scanState === "complete" || scanState === "idle") {
         refreshDbSummary();
-      }
-      if (wasPrev === null || scanState === "complete" || scanState === "idle" || rebuildSt === "complete" || rebuildSt === "error") {
-        refreshActivity();
       }
     }
   });
@@ -177,12 +164,6 @@ const ScanManager: Component = () => {
     stopPolling();
     if (rebuildPollTimer) clearInterval(rebuildPollTimer);
   });
-
-  // --- Stalled scan handling ---
-  const handleResetAndRescan = async () => {
-    await resetScan();
-    startScan({ includeCalibration: frameFilter() === "all" });
-  };
 
   return (
     <div class="space-y-4">
@@ -368,16 +349,7 @@ const ScanManager: Component = () => {
         {/* Right column: sticky activity feed */}
         <div class="lg:sticky lg:top-4 lg:self-start min-w-0">
           <div class="lg:max-h-[calc(100vh-2rem)] lg:overflow-hidden lg:flex lg:flex-col">
-            <ActivityFeed
-              scanStatus={scanStatus()}
-              rebuildStatus={rebuildState()}
-              stopping={stopping()}
-              scanError={scanError()}
-              activity={activity()}
-              onClearActivity={clearActivity}
-              onResetAndRescan={handleResetAndRescan}
-              onDismissStalled={resetScan}
-            />
+            <ActivityFeed />
           </div>
         </div>
       </div>

--- a/frontend/src/components/ScanManager.tsx
+++ b/frontend/src/components/ScanManager.tsx
@@ -336,13 +336,7 @@ const ScanManager: Component = () => {
           </div>
 
           <Show when={isAdmin()}>
-            <MaintenanceActions
-              disabled={isActive()}
-              rebuildRunning={rebuildState().state === "running"}
-              rebuildMode={rebuildState().mode}
-              onRegenThumbnails={startRegeneration}
-              onStartedAction={startRebuildPolling}
-            />
+            <MaintenanceActions />
           </Show>
         </div>
 

--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -1,56 +1,100 @@
-import { Show, type Component } from "solid-js";
+import { For, type Component } from "solid-js";
 import { createSignal } from "solid-js";
 
-interface ToastState {
+export type ToastSeverity = "success" | "error" | "info";
+
+export interface ToastEntry {
+  id: number;
   message: string;
-  type: "success" | "error" | "info";
+  type: ToastSeverity;
+  duration: number;
 }
 
-const [toast, setToast] = createSignal<ToastState | null>(null);
-let timeout: ReturnType<typeof setTimeout>;
+const [toasts, setToasts] = createSignal<ToastEntry[]>([]);
+const timers = new Map<number, ReturnType<typeof setTimeout>>();
+let nextId = 1;
 
-export function showToast(
-  message: string,
-  type: "success" | "error" | "info" = "success",
-  duration = 3000,
-) {
-  clearTimeout(timeout);
-  setToast({ message, type });
-  if (duration > 0) {
-    timeout = setTimeout(() => setToast(null), duration);
+function clearTimer(id: number): void {
+  const t = timers.get(id);
+  if (t !== undefined) {
+    clearTimeout(t);
+    timers.delete(id);
   }
 }
 
-export function dismissToast() {
-  clearTimeout(timeout);
-  setToast(null);
+function scheduleAutoDismiss(id: number, duration: number): void {
+  if (duration <= 0) return;
+  const t = setTimeout(() => {
+    timers.delete(id);
+    setToasts((list) => list.filter((x) => x.id !== id));
+  }, duration);
+  timers.set(id, t);
+}
+
+/**
+ * Show a toast. Returns the toast id, which can be passed to `dismissToast(id)`
+ * to dismiss that specific toast. Calling `dismissToast()` with no arguments
+ * dismisses all toasts (legacy behavior).
+ *
+ * Multiple toasts stack vertically; each has its own auto-dismiss timer.
+ */
+export function showToast(
+  message: string,
+  type: ToastSeverity = "success",
+  duration = 3000,
+): number {
+  const id = nextId++;
+  const entry: ToastEntry = { id, message, type, duration };
+  setToasts((list) => [...list, entry]);
+  scheduleAutoDismiss(id, duration);
+  return id;
+}
+
+/**
+ * Dismiss a toast. With no argument, dismisses all toasts (back-compat).
+ * With an id, dismisses just that toast.
+ */
+export function dismissToast(id?: number): void {
+  if (id === undefined) {
+    for (const t of timers.values()) clearTimeout(t);
+    timers.clear();
+    setToasts([]);
+    return;
+  }
+  clearTimer(id);
+  setToasts((list) => list.filter((x) => x.id !== id));
+}
+
+/** Returns the number of toasts currently visible. */
+export function toastCount(): number {
+  return toasts().length;
 }
 
 export const Toast: Component = () => {
   return (
-    <Show when={toast()}>
-      {(t) => (
-        <div class="fixed top-6 inset-x-0 flex justify-center z-50">
+    <div class="fixed top-6 inset-x-0 flex flex-col items-center gap-2 z-50 pointer-events-none">
+      <For each={toasts()}>
+        {(t) => (
           <div
-            class={`animate-toast-down px-5 py-2.5 rounded-[var(--radius-md)] text-sm font-medium backdrop-blur-xl shadow-lg border flex items-center gap-3 ${
-              t().type === "success"
+            class={`animate-toast-down pointer-events-auto px-5 py-2.5 rounded-[var(--radius-md)] text-sm font-medium backdrop-blur-xl shadow-lg border flex items-center gap-3 ${
+              t.type === "success"
                 ? "bg-theme-success/20 text-theme-success border-theme-success/30"
-                : t().type === "info"
+                : t.type === "info"
                 ? "bg-theme-accent/20 text-theme-accent border-theme-accent/30"
                 : "bg-theme-error/20 text-theme-error border-theme-error/30"
             }`}
           >
-            <span>{t().message}</span>
+            <span>{t.message}</span>
             <button
-              onClick={() => setToast(null)}
+              onClick={() => dismissToast(t.id)}
               class="opacity-60 hover:opacity-100 transition-opacity ml-1"
               aria-label="Dismiss"
             >
               ✕
             </button>
           </div>
-        </div>
-      )}
-    </Show>
+        )}
+      </For>
+    </div>
   );
 };

--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -1,4 +1,5 @@
-import { createSignal, Show, type Component } from "solid-js";
+import { Show, type Component } from "solid-js";
+import { createSignal } from "solid-js";
 
 interface ToastState {
   message: string;
@@ -8,19 +9,21 @@ interface ToastState {
 const [toast, setToast] = createSignal<ToastState | null>(null);
 let timeout: ReturnType<typeof setTimeout>;
 
-export function showToast(message: string, type: "success" | "error" | "info" = "success", duration = 3000) {
+export function showToast(
+  message: string,
+  type: "success" | "error" | "info" = "success",
+  duration = 3000,
+) {
   clearTimeout(timeout);
   setToast({ message, type });
-  timeout = setTimeout(() => setToast(null), duration);
+  if (duration > 0) {
+    timeout = setTimeout(() => setToast(null), duration);
+  }
 }
 
-export function dismissToast(delay = 0) {
+export function dismissToast() {
   clearTimeout(timeout);
-  if (delay > 0) {
-    timeout = setTimeout(() => setToast(null), delay);
-  } else {
-    setToast(null);
-  }
+  setToast(null);
 }
 
 export const Toast: Component = () => {
@@ -29,7 +32,7 @@ export const Toast: Component = () => {
       {(t) => (
         <div class="fixed top-6 inset-x-0 flex justify-center z-50">
           <div
-            class={`animate-toast-down px-5 py-2.5 rounded-[var(--radius-md)] text-sm font-medium backdrop-blur-xl shadow-lg border ${
+            class={`animate-toast-down px-5 py-2.5 rounded-[var(--radius-md)] text-sm font-medium backdrop-blur-xl shadow-lg border flex items-center gap-3 ${
               t().type === "success"
                 ? "bg-theme-success/20 text-theme-success border-theme-success/30"
                 : t().type === "info"
@@ -37,7 +40,14 @@ export const Toast: Component = () => {
                 : "bg-theme-error/20 text-theme-error border-theme-error/30"
             }`}
           >
-            {t().message}
+            <span>{t().message}</span>
+            <button
+              onClick={() => setToast(null)}
+              class="opacity-60 hover:opacity-100 transition-opacity ml-1"
+              aria-label="Dismiss"
+            >
+              ✕
+            </button>
           </div>
         </div>
       )}

--- a/frontend/src/components/activity/DetailsJsonFallback.tsx
+++ b/frontend/src/components/activity/DetailsJsonFallback.tsx
@@ -1,0 +1,19 @@
+import { Component } from "solid-js";
+
+const DetailsJsonFallback: Component<{ details: Record<string, unknown> }> = (props) => {
+  const formatted = () => {
+    try {
+      return JSON.stringify(props.details, null, 2);
+    } catch {
+      return String(props.details);
+    }
+  };
+
+  return (
+    <pre class="text-xs text-theme-text-secondary bg-theme-base/50 border border-theme-border rounded p-2 overflow-x-auto max-h-40 font-mono whitespace-pre-wrap break-all">
+      {formatted()}
+    </pre>
+  );
+};
+
+export default DetailsJsonFallback;

--- a/frontend/src/components/activity/EnrichmentFailureList.tsx
+++ b/frontend/src/components/activity/EnrichmentFailureList.tsx
@@ -1,0 +1,35 @@
+import { Component, For, Show } from "solid-js";
+
+interface FailedTarget {
+  name: string;
+  reason?: string;
+}
+
+const DISPLAY_LIMIT = 10;
+
+const EnrichmentFailureList: Component<{ targets: FailedTarget[] }> = (props) => {
+  const shown = () => props.targets.slice(0, DISPLAY_LIMIT);
+  const overflow = () => props.targets.length - DISPLAY_LIMIT;
+
+  return (
+    <div class="space-y-1 mt-1 max-h-48 overflow-y-auto">
+      <For each={shown()}>
+        {(t) => (
+          <div class="flex items-start gap-2 py-0.5">
+            <span class="text-xs text-theme-text-primary font-medium">{t.name}</span>
+            <Show when={t.reason}>
+              <span class="text-xs text-theme-text-secondary">{t.reason}</span>
+            </Show>
+          </div>
+        )}
+      </For>
+      <Show when={overflow() > 0}>
+        <p class="text-xs text-theme-text-secondary pl-1">
+          {overflow()} more target{overflow() > 1 ? "s" : ""}
+        </p>
+      </Show>
+    </div>
+  );
+};
+
+export default EnrichmentFailureList;

--- a/frontend/src/components/activity/FailedFilesList.tsx
+++ b/frontend/src/components/activity/FailedFilesList.tsx
@@ -1,0 +1,48 @@
+import { Component, For, Show } from "solid-js";
+
+interface FailedFile {
+  path: string;
+  reason: string;
+}
+
+const DISPLAY_LIMIT = 10;
+
+const FailedFilesList: Component<{
+  files: FailedFile[];
+  truncated: boolean;
+}> = (props) => {
+  const shown = () => props.files.slice(0, DISPLAY_LIMIT);
+  const overflow = () => props.files.length - DISPLAY_LIMIT;
+
+  return (
+    <div class="space-y-1 mt-1 max-h-48 overflow-y-auto">
+      <For each={shown()}>
+        {(f) => (
+          <div class="border border-theme-border rounded px-2 py-1">
+            <div class="text-xs text-theme-text-secondary break-all font-mono">
+              {f.path}
+            </div>
+            <div
+              class="text-xs text-[var(--color-warning)] truncate"
+              title={f.reason}
+            >
+              {f.reason}
+            </div>
+          </div>
+        )}
+      </For>
+      <Show when={overflow() > 0}>
+        <p class="text-xs text-theme-text-secondary pl-1">
+          {overflow()} more file{overflow() > 1 ? "s" : ""}
+        </p>
+      </Show>
+      <Show when={props.truncated}>
+        <p class="text-xs text-[var(--color-warning)] pl-1">
+          List truncated at 500 entries.
+        </p>
+      </Show>
+    </div>
+  );
+};
+
+export default FailedFilesList;

--- a/frontend/src/components/settings/ActivityLogTab.tsx
+++ b/frontend/src/components/settings/ActivityLogTab.tsx
@@ -1,0 +1,131 @@
+import { Component, createSignal, onMount, Show } from "solid-js";
+import { api } from "../../api/client";
+import { useAuth } from "../AuthProvider";
+import { showToast } from "../Toast";
+
+const ActivityLogTab: Component = () => {
+  const { isAdmin } = useAuth();
+  const [retentionDays, setRetentionDays] = createSignal(90);
+  const [saving, setSaving] = createSignal(false);
+  const [clearing, setClearing] = createSignal(false);
+  const [showClearConfirm, setShowClearConfirm] = createSignal(false);
+  const [loading, setLoading] = createSignal(true);
+
+  onMount(async () => {
+    try {
+      const s = await api.getActivitySettings();
+      setRetentionDays(s.activity_retention_days);
+    } catch { /* ignore */ } finally {
+      setLoading(false);
+    }
+  });
+
+  const handleSave = async () => {
+    if (saving()) return;
+    setSaving(true);
+    try {
+      const res = await api.setActivitySettings({ retention_days: retentionDays() });
+      setRetentionDays(res.activity_retention_days);
+      showToast("Retention setting saved", "success", 3000);
+    } catch {
+      showToast("Failed to save retention setting", "error", 0);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleClear = async () => {
+    if (clearing()) return;
+    setShowClearConfirm(false);
+    setClearing(true);
+    try {
+      await api.clearActivityLog();
+      showToast("Activity log cleared", "success", 3000);
+    } catch {
+      showToast("Failed to clear activity log", "error", 0);
+    } finally {
+      setClearing(false);
+    }
+  };
+
+  return (
+    <div class="space-y-4">
+      <div class="bg-theme-surface border border-theme-border rounded-[var(--radius-md)] shadow-[var(--shadow-sm)] p-4 space-y-4">
+        <h3 class="text-theme-text-primary font-medium">Activity Log</h3>
+
+        <Show when={loading()}>
+          <p class="text-xs text-theme-text-secondary">Loading...</p>
+        </Show>
+
+        <Show when={!loading()}>
+          <div class="space-y-3">
+            <div class="flex items-center gap-3">
+              <label class="text-sm text-theme-text-secondary w-40 flex-shrink-0">
+                Retention (days)
+              </label>
+              <input
+                type="number"
+                min={1}
+                max={3650}
+                value={retentionDays()}
+                onInput={(e) => {
+                  const v = parseInt(e.currentTarget.value, 10);
+                  if (!isNaN(v) && v >= 1 && v <= 3650) setRetentionDays(v);
+                }}
+                class="w-24 px-2 py-1 text-sm bg-theme-base border border-theme-border rounded text-theme-text-primary focus:outline-none focus:border-theme-accent tabular-nums"
+              />
+              <button
+                onClick={handleSave}
+                disabled={saving() || !isAdmin()}
+                class="px-3 py-1.5 bg-theme-accent/15 text-theme-accent border border-theme-accent/30 rounded text-sm disabled:opacity-50 hover:bg-theme-accent/25 transition-colors"
+              >
+                {saving() ? "Saving..." : "Save"}
+              </button>
+            </div>
+            <p class="text-xs text-theme-text-secondary">
+              Events older than this many days are deleted by the nightly pruner. Min 1, max 3650.
+            </p>
+          </div>
+
+          <Show when={isAdmin()}>
+            <div class="border-t border-theme-border pt-4 space-y-2">
+              <Show when={!showClearConfirm()}>
+                <button
+                  onClick={() => setShowClearConfirm(true)}
+                  disabled={clearing()}
+                  class="px-3 py-1.5 border border-theme-error/50 text-theme-error rounded text-sm disabled:opacity-50 hover:bg-theme-error/20 transition-colors"
+                >
+                  Clear activity log
+                </button>
+              </Show>
+              <Show when={showClearConfirm()}>
+                <div class="bg-theme-error/10 border border-theme-error/40 rounded-[var(--radius-md)] p-3 space-y-2">
+                  <p class="text-sm text-theme-error font-medium">Clear all activity?</p>
+                  <p class="text-xs text-theme-error/70">
+                    This permanently deletes all activity log entries. The action cannot be undone.
+                  </p>
+                  <div class="flex gap-2 pt-1">
+                    <button
+                      onClick={handleClear}
+                      class="px-3 py-1.5 bg-theme-error text-theme-text-primary rounded text-xs font-medium hover:opacity-90 transition-colors"
+                    >
+                      Yes, clear all
+                    </button>
+                    <button
+                      onClick={() => setShowClearConfirm(false)}
+                      class="px-3 py-1.5 border border-theme-border-em text-theme-text-secondary rounded text-xs hover:text-theme-text-primary transition-colors"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              </Show>
+            </div>
+          </Show>
+        </Show>
+      </div>
+    </div>
+  );
+};
+
+export default ActivityLogTab;

--- a/frontend/src/components/settings/MergesTab.tsx
+++ b/frontend/src/components/settings/MergesTab.tsx
@@ -1,10 +1,10 @@
-import { Component, For, Show, createSignal, onMount, onCleanup } from "solid-js";
+import { Component, For, Show, createSignal, onMount } from "solid-js";
 import { api } from "../../api/client";
-import { showToast, dismissToast } from "../Toast";
+import { showToast } from "../Toast";
 import { useAuth } from "../AuthProvider";
 import { UnresolvedFilesTab } from "./UnresolvedFilesTab";
 import HelpPopover from "../HelpPopover";
-import { pollTask } from "../../store/taskPoller";
+import { emitWithToast } from "../../lib/emitWithToast";
 import type { MergeCandidateResponse } from "../../types";
 
 export const MergesTab: Component = () => {
@@ -70,32 +70,20 @@ export const MergesTab: Component = () => {
     }
   };
 
-  let stopPolling: (() => void) | null = null;
-  onCleanup(() => stopPolling?.());
-
   const handleDetect = async () => {
+    if (detecting()) return;
     setDetecting(true);
-    try {
-      const { task_id } = await api.triggerDuplicateDetection();
-      showToast("Detecting duplicates...", "info", 60000);
-      stopPolling = pollTask(task_id, {
-        onSuccess: (result) => {
-          dismissToast();
-          const count = result?.candidates_found ?? 0;
-          showToast(`Detection complete - ${count} candidate(s) found`);
-          setDetecting(false);
-          refresh();
-        },
-        onFailure: (error) => {
-          dismissToast();
-          showToast(error, "error");
-          setDetecting(false);
-        },
-      });
-    } catch {
-      showToast("Failed to start detection", "error");
-      setDetecting(false);
-    }
+    await emitWithToast({
+      action: () => api.triggerDuplicateDetection(),
+      pendingLabel: "Detecting duplicates...",
+      successLabel: "Duplicate detection complete",
+      errorLabel: "Duplicate detection failed",
+      category: "scan",
+      taskLabel: "Duplicate detection",
+      timeout: 120_000,
+    });
+    setDetecting(false);
+    refresh();
   };
 
   return (

--- a/frontend/src/components/settings/MosaicsTab.tsx
+++ b/frontend/src/components/settings/MosaicsTab.tsx
@@ -4,6 +4,7 @@ import { showToast, dismissToast } from "../Toast";
 import { useAuth } from "../AuthProvider";
 import { useSettingsContext } from "../SettingsProvider";
 import HelpPopover from "../HelpPopover";
+import { emitWithToast } from "../../lib/emitWithToast";
 import type {
   MosaicSummary,
   MosaicDetailResponse,
@@ -133,16 +134,19 @@ export const MosaicsTab: Component = () => {
   };
 
   const handleDetect = async () => {
+    if (detecting()) return;
     setDetecting(true);
-    try {
-      const result = await api.triggerMosaicDetection();
-      showToast(`Detection complete - ${result.new_suggestions} new suggestion(s) found`);
-      await refresh();
-    } catch {
-      showToast("Failed to run detection", "error");
-    } finally {
-      setDetecting(false);
-    }
+    await emitWithToast({
+      action: () => api.triggerMosaicDetection() as Promise<{ task_id: string }>,
+      pendingLabel: "Running mosaic detection...",
+      successLabel: "Mosaic detection complete",
+      errorLabel: "Mosaic detection failed",
+      category: "mosaic",
+      taskLabel: "Mosaic detection",
+      timeout: 120_000,
+    });
+    setDetecting(false);
+    refresh(true);
   };
 
   // Initialize panel selection when expanding a suggestion (all selected by default)

--- a/frontend/src/lib/emitWithToast.ts
+++ b/frontend/src/lib/emitWithToast.ts
@@ -13,7 +13,19 @@ interface EmitWithToastOptions {
   timeout?: number;
 }
 
+// Monotonic counter identifying the most recently invoked emitWithToast call.
+// Each invocation captures its own id; only callbacks belonging to the most
+// recent invocation are allowed to mutate the global toast slot. This prevents
+// terminal callbacks from a previous (still-polling or just-completed) action
+// from stomping on the toast that a freshly clicked action just created. The
+// underlying Celery job tracking in `track()` is unaffected; only the toast
+// surface is gated.
+let latestEmitId = 0;
+
 export async function emitWithToast(opts: EmitWithToastOptions): Promise<void> {
+  const myId = ++latestEmitId;
+  const isCurrent = () => myId === latestEmitId;
+
   showToast(opts.pendingLabel, "info", 120_000);
 
   let taskId: string;
@@ -21,6 +33,7 @@ export async function emitWithToast(opts: EmitWithToastOptions): Promise<void> {
     const result = await opts.action();
     taskId = result.task_id;
   } catch {
+    if (!isCurrent()) return;
     dismissToast();
     showToast(opts.errorLabel, "error", 0);
     return;
@@ -31,6 +44,7 @@ export async function emitWithToast(opts: EmitWithToastOptions): Promise<void> {
   // just show a fire-and-forget toast rather than stranding an entry in
   // "Now Running" that never clears.
   if (!taskId) {
+    if (!isCurrent()) return;
     dismissToast();
     showToast(opts.successLabel, "info", 3000);
     return;
@@ -43,10 +57,12 @@ export async function emitWithToast(opts: EmitWithToastOptions): Promise<void> {
     subLabel: opts.taskSubLabel,
     timeout: opts.timeout ?? 300_000,
     onSuccess: () => {
+      if (!isCurrent()) return;
       dismissToast();
       showToast(opts.successLabel, "success", 3000);
     },
     onFailure: (error) => {
+      if (!isCurrent()) return;
       dismissToast();
       showToast(`${opts.errorLabel}: ${error}`, "error", 0);
     },

--- a/frontend/src/lib/emitWithToast.ts
+++ b/frontend/src/lib/emitWithToast.ts
@@ -1,0 +1,44 @@
+import { showToast, dismissToast } from "../components/Toast";
+import { track } from "../store/taskPoller";
+import type { ActiveJob } from "../types";
+
+interface EmitWithToastOptions {
+  action: () => Promise<{ task_id: string }>;
+  pendingLabel: string;
+  successLabel: string;
+  errorLabel: string;
+  category: ActiveJob["category"];
+  taskLabel: string;
+  taskSubLabel?: string;
+  timeout?: number;
+}
+
+export async function emitWithToast(opts: EmitWithToastOptions): Promise<void> {
+  showToast(opts.pendingLabel, "info", 120_000);
+
+  let taskId: string;
+  try {
+    const result = await opts.action();
+    taskId = result.task_id;
+  } catch {
+    dismissToast();
+    showToast(opts.errorLabel, "error", 0);
+    return;
+  }
+
+  track({
+    id: taskId,
+    category: opts.category,
+    label: opts.taskLabel,
+    subLabel: opts.taskSubLabel,
+    timeout: opts.timeout ?? 300_000,
+    onSuccess: () => {
+      dismissToast();
+      showToast(opts.successLabel, "success", 3000);
+    },
+    onFailure: (error) => {
+      dismissToast();
+      showToast(`${opts.errorLabel}: ${error}`, "error", 0);
+    },
+  });
+}

--- a/frontend/src/lib/emitWithToast.ts
+++ b/frontend/src/lib/emitWithToast.ts
@@ -26,6 +26,16 @@ export async function emitWithToast(opts: EmitWithToastOptions): Promise<void> {
     return;
   }
 
+  // Backend may not return a task_id (older endpoints). In that case we
+  // cannot poll for completion, so skip the activeJobs registration and
+  // just show a fire-and-forget toast rather than stranding an entry in
+  // "Now Running" that never clears.
+  if (!taskId) {
+    dismissToast();
+    showToast(opts.successLabel, "info", 3000);
+    return;
+  }
+
   track({
     id: taskId,
     category: opts.category,

--- a/frontend/src/lib/emitWithToast.ts
+++ b/frontend/src/lib/emitWithToast.ts
@@ -15,18 +15,27 @@ interface EmitWithToastOptions {
 
 // Monotonic counter identifying the most recently invoked emitWithToast call.
 // Each invocation captures its own id; only callbacks belonging to the most
-// recent invocation are allowed to mutate the global toast slot. This prevents
+// recent invocation are allowed to mutate the toast surface. This prevents
 // terminal callbacks from a previous (still-polling or just-completed) action
-// from stomping on the toast that a freshly clicked action just created. The
-// underlying Celery job tracking in `track()` is unaffected; only the toast
-// surface is gated.
+// from affecting the toast surface for a freshly clicked action.
 let latestEmitId = 0;
+
+// Cancel handle for the most recent in-flight `track()` call. When a newer
+// emitWithToast supersedes it, we cancel the older poller to stop wasted
+// network polling and remove the stale "Now Running" entry.
+let activeCancel: (() => void) | null = null;
 
 export async function emitWithToast(opts: EmitWithToastOptions): Promise<void> {
   const myId = ++latestEmitId;
   const isCurrent = () => myId === latestEmitId;
 
-  showToast(opts.pendingLabel, "info", 120_000);
+  // Supersede any previous in-flight tracker.
+  if (activeCancel) {
+    try { activeCancel(); } catch { /* ignore */ }
+    activeCancel = null;
+  }
+
+  const pendingToastId = showToast(opts.pendingLabel, "info", 120_000);
 
   let taskId: string;
   try {
@@ -34,7 +43,7 @@ export async function emitWithToast(opts: EmitWithToastOptions): Promise<void> {
     taskId = result.task_id;
   } catch {
     if (!isCurrent()) return;
-    dismissToast();
+    dismissToast(pendingToastId);
     showToast(opts.errorLabel, "error", 0);
     return;
   }
@@ -45,26 +54,36 @@ export async function emitWithToast(opts: EmitWithToastOptions): Promise<void> {
   // "Now Running" that never clears.
   if (!taskId) {
     if (!isCurrent()) return;
-    dismissToast();
+    dismissToast(pendingToastId);
     showToast(opts.successLabel, "info", 3000);
     return;
   }
 
-  track({
+  const cancel = track({
     id: taskId,
     category: opts.category,
     label: opts.taskLabel,
     subLabel: opts.taskSubLabel,
     timeout: opts.timeout ?? 300_000,
     onSuccess: () => {
+      if (activeCancel === cancel) activeCancel = null;
       if (!isCurrent()) return;
-      dismissToast();
+      dismissToast(pendingToastId);
       showToast(opts.successLabel, "success", 3000);
     },
     onFailure: (error) => {
+      if (activeCancel === cancel) activeCancel = null;
       if (!isCurrent()) return;
-      dismissToast();
+      dismissToast(pendingToastId);
       showToast(`${opts.errorLabel}: ${error}`, "error", 0);
     },
+    onTimeout: () => {
+      // Client poller gave up; the backend task may still finish. Silently
+      // dismiss the pending toast without surfacing a misleading failure.
+      if (activeCancel === cancel) activeCancel = null;
+      if (!isCurrent()) return;
+      dismissToast(pendingToastId);
+    },
   });
+  activeCancel = cancel;
 }

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -37,6 +37,7 @@ const ScanManager = lazy(() => import("../components/ScanManager"));
 const DisplayTab = lazy(() => import("../components/DisplayTab"));
 const AstroBinTab = lazy(() => import("../components/settings/AstroBinTab"));
 const CustomColumnsTab = lazy(() => import("../components/CustomColumnsTab"));
+const ActivityLogTab = lazy(() => import("../components/settings/ActivityLogTab"));
 
 const ALL_TABS = [
   { id: "scan", label: "Library" },
@@ -47,6 +48,7 @@ const ALL_TABS = [
   { id: "custom-columns", label: "Custom Columns" },
   { id: "backup", label: "Backup & Restore", adminOnly: true },
   { id: "users", label: "Users", adminOnly: true },
+  { id: "activity-log", label: "Activity Log", adminOnly: true },
 ] as const;
 
 type TabId = (typeof ALL_TABS)[number]["id"];
@@ -144,6 +146,9 @@ export const SettingsPage: Component = () => {
         </Show>
         <Show when={activeTab() === "users" && isAdmin()}>
           <UsersTab />
+        </Show>
+        <Show when={activeTab() === "activity-log" && isAdmin()}>
+          <ActivityLogTab />
         </Show>
       </Suspense>
     </div>

--- a/frontend/src/store/activeJobs.ts
+++ b/frontend/src/store/activeJobs.ts
@@ -1,0 +1,113 @@
+import { createSignal } from "solid-js";
+import type { ActiveJob, ScanStatus, RebuildStatus } from "../types";
+
+const [celeryJobs, setCeleryJobs] = createSignal<Map<string, ActiveJob>>(new Map());
+
+export function scanStatusToJob(
+  s: ScanStatus,
+  onStop: () => Promise<void>
+): ActiveJob | null {
+  if (s.state !== "scanning" && s.state !== "ingesting") return null;
+
+  const startedAt = s.started_at != null ? s.started_at * 1000 : Date.now();
+
+  const progress =
+    s.state === "ingesting" && s.total > 0
+      ? Math.min(1, (s.completed + s.failed) / s.total)
+      : undefined;
+
+  const subLabel =
+    s.state === "ingesting" && s.total > 0
+      ? `${(s.completed + s.failed).toLocaleString()} / ${s.total.toLocaleString()} files`
+      : s.discovered > 0
+      ? `${s.discovered.toLocaleString()} files found`
+      : undefined;
+
+  return {
+    id: "scan",
+    category: "scan",
+    label: s.state === "scanning" ? "Discovering files" : "Ingesting files",
+    subLabel,
+    progress,
+    startedAt,
+    cancelable: true,
+    onCancel: onStop,
+  };
+}
+
+export function rebuildStatusToJob(r: RebuildStatus): ActiveJob | null {
+  if (r.state !== "running") return null;
+
+  const startedAt = r.started_at != null ? r.started_at * 1000 : Date.now();
+
+  const modeLabel: Record<string, string> = {
+    smart: "Fix Orphans",
+    full: "Full Rebuild",
+    retry: "Re-resolve Targets",
+    xmatch: "Catalog Match",
+    ref_thumbnails: "Fetch DSS Thumbnails",
+    regen: "Regenerate Thumbnails",
+  };
+
+  return {
+    id: "rebuild",
+    category: "rebuild",
+    label: modeLabel[r.mode] ?? "Rebuild",
+    subLabel: r.message || undefined,
+    progress: undefined,
+    startedAt,
+    cancelable: false,
+  };
+}
+
+export function registerCeleryJob(job: ActiveJob): void {
+  setCeleryJobs((prev) => {
+    const next = new Map(prev);
+    next.set(job.id, job);
+    return next;
+  });
+}
+
+export function unregisterCeleryJob(id: string): void {
+  setCeleryJobs((prev) => {
+    const next = new Map(prev);
+    next.delete(id);
+    return next;
+  });
+}
+
+type Accessor<T> = () => T;
+
+let _scanStatusAccessor: Accessor<ScanStatus> | null = null;
+let _rebuildStatusAccessor: Accessor<RebuildStatus> | null = null;
+let _stopScanFn: (() => Promise<void>) | null = null;
+
+export function wireActiveJobSources(
+  scanStatus: Accessor<ScanStatus>,
+  rebuildStatus: Accessor<RebuildStatus>,
+  stopScan: () => Promise<void>
+): void {
+  _scanStatusAccessor = scanStatus;
+  _rebuildStatusAccessor = rebuildStatus;
+  _stopScanFn = stopScan;
+}
+
+export const activeJobs: Accessor<ActiveJob[]> = () => {
+  const jobs: ActiveJob[] = [];
+
+  if (_scanStatusAccessor && _stopScanFn) {
+    const scanJob = scanStatusToJob(_scanStatusAccessor(), _stopScanFn);
+    if (scanJob) jobs.push(scanJob);
+  }
+
+  if (_rebuildStatusAccessor) {
+    const rebuildJob = rebuildStatusToJob(_rebuildStatusAccessor());
+    if (rebuildJob) jobs.push(rebuildJob);
+  }
+
+  celeryJobs().forEach((job) => jobs.push(job));
+
+  return jobs;
+};
+
+export const hasActiveJobs: Accessor<boolean> = () => activeJobs().length > 0;

--- a/frontend/src/store/errorToastPoller.ts
+++ b/frontend/src/store/errorToastPoller.ts
@@ -1,0 +1,52 @@
+import { showToast } from "../components/Toast";
+import { api } from "../api/client";
+
+const LS_KEY = "galactilog_last_error_ts";
+
+function getLastSeenTs(): string {
+  try {
+    return localStorage.getItem(LS_KEY) ?? new Date(0).toISOString();
+  } catch {
+    return new Date(0).toISOString();
+  }
+}
+
+function setLastSeenTs(ts: string): void {
+  try {
+    localStorage.setItem(LS_KEY, ts);
+  } catch { /* ignore */ }
+}
+
+let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+async function checkErrors(): Promise<void> {
+  const since = getLastSeenTs();
+  try {
+    const res = await api.fetchActivityErrorsSince(since);
+    if (res.items.length === 0) return;
+
+    setLastSeenTs(res.items[0].timestamp);
+
+    const toShow = res.items.slice(0, 3);
+    for (const item of toShow) {
+      const msg = `[${item.category}] ${item.message} (ref #${item.id})`;
+      showToast(msg, "error", 0);
+    }
+    if (res.items.length > 3) {
+      showToast(`${res.items.length - 3} more errors, check the Activity log`, "error", 0);
+    }
+  } catch { /* non-blocking */ }
+}
+
+export function startErrorToastPoller(): void {
+  if (pollTimer) return;
+  checkErrors();
+  pollTimer = setInterval(checkErrors, 10_000);
+}
+
+export function stopErrorToastPoller(): void {
+  if (pollTimer) {
+    clearInterval(pollTimer);
+    pollTimer = null;
+  }
+}

--- a/frontend/src/store/taskPoller.ts
+++ b/frontend/src/store/taskPoller.ts
@@ -1,4 +1,6 @@
 import { api } from "../api/client";
+import { registerCeleryJob, unregisterCeleryJob } from "./activeJobs";
+import type { ActiveJob } from "../types";
 
 interface PollOptions {
   onSuccess?: (result: any) => void;
@@ -45,4 +47,47 @@ export function pollTask(taskId: string, options: PollOptions = {}): () => void 
   }, timeout);
 
   return stop;
+}
+
+interface TrackOptions {
+  id: string;
+  category: ActiveJob["category"];
+  label: string;
+  subLabel?: string;
+  cancelable?: boolean;
+  timeout?: number;
+  onSuccess?: (result: any) => void;
+  onFailure?: (error: string) => void;
+}
+
+export function track(opts: TrackOptions): () => void {
+  const jobId = `celery:${opts.id}`;
+
+  registerCeleryJob({
+    id: jobId,
+    category: opts.category,
+    label: opts.label,
+    subLabel: opts.subLabel,
+    progress: undefined,
+    startedAt: Date.now(),
+    cancelable: opts.cancelable ?? false,
+  });
+
+  const stop = pollTask(opts.id, {
+    interval: 2000,
+    timeout: opts.timeout ?? 300_000,
+    onSuccess: (result) => {
+      unregisterCeleryJob(jobId);
+      opts.onSuccess?.(result);
+    },
+    onFailure: (error) => {
+      unregisterCeleryJob(jobId);
+      opts.onFailure?.(error);
+    },
+  });
+
+  return () => {
+    unregisterCeleryJob(jobId);
+    stop();
+  };
 }

--- a/frontend/src/store/taskPoller.ts
+++ b/frontend/src/store/taskPoller.ts
@@ -5,12 +5,18 @@ import type { ActiveJob } from "../types";
 interface PollOptions {
   onSuccess?: (result: any) => void;
   onFailure?: (error: string) => void;
+  /**
+   * Called when the client-side poller times out. The backend task may still
+   * be running healthily; this is purely a client-side give-up signal. Callers
+   * should NOT treat this as a task failure.
+   */
+  onTimeout?: () => void;
   interval?: number;
   timeout?: number;
 }
 
 export function pollTask(taskId: string, options: PollOptions = {}): () => void {
-  const { onSuccess, onFailure, interval = 2000, timeout = 60000 } = options;
+  const { onSuccess, onFailure, onTimeout, interval = 2000, timeout = 60000 } = options;
   let timer: ReturnType<typeof setInterval> | null = null;
   let timeoutTimer: ReturnType<typeof setTimeout> | null = null;
   let stopped = false;
@@ -43,7 +49,9 @@ export function pollTask(taskId: string, options: PollOptions = {}): () => void 
   timer = setInterval(check, interval);
   timeoutTimer = setTimeout(() => {
     stop();
-    onFailure?.("Detection timed out");
+    // Client poller gave up; the backend task may still be running. Do NOT
+    // call onFailure -- that would falsely report failure for a healthy task.
+    onTimeout?.();
   }, timeout);
 
   return stop;
@@ -58,8 +66,18 @@ interface TrackOptions {
   timeout?: number;
   onSuccess?: (result: any) => void;
   onFailure?: (error: string) => void;
+  /**
+   * Called when the client poller stops watching due to timeout. The backend
+   * task may still be running; the activeJobs entry will already be removed.
+   */
+  onTimeout?: () => void;
 }
 
+/**
+ * Track a Celery task: register an activeJobs entry and poll for completion.
+ * Returns a cancel function that unregisters the activeJobs entry and stops
+ * the underlying poller. Safe to call multiple times.
+ */
 export function track(opts: TrackOptions): () => void {
   const jobId = `celery:${opts.id}`;
 
@@ -73,20 +91,33 @@ export function track(opts: TrackOptions): () => void {
     cancelable: opts.cancelable ?? false,
   });
 
+  let canceled = false;
   const stop = pollTask(opts.id, {
     interval: 2000,
     timeout: opts.timeout ?? 300_000,
     onSuccess: (result) => {
+      if (canceled) return;
       unregisterCeleryJob(jobId);
       opts.onSuccess?.(result);
     },
     onFailure: (error) => {
+      if (canceled) return;
       unregisterCeleryJob(jobId);
       opts.onFailure?.(error);
+    },
+    onTimeout: () => {
+      if (canceled) return;
+      // Silently detach the "Now Running" entry; the backend task may still
+      // complete, and downstream toast/UI surfaces should not surface this
+      // as a failure.
+      unregisterCeleryJob(jobId);
+      opts.onTimeout?.();
     },
   });
 
   return () => {
+    if (canceled) return;
+    canceled = true;
     unregisterCeleryJob(jobId);
     stop();
   };

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -288,15 +288,55 @@ export interface ScanStatus {
   failed_files?: FailedFile[];
 }
 
-export interface ActivityEntry {
-  type: "scan_complete" | "scan_stopped" | "scan_stalled"
-    | "rebuild_complete" | "rebuild_failed" | "regen_complete"
-    | "delta_scan" | "orphan_cleanup" | "orphan_warning"
-    | "migration_applied" | "migration_initialized" | "migration_ok" | "migration_failed"
-    | "data_upgrade_started" | "data_upgrade_complete" | "data_upgrade_failed";
+export type ActivitySeverity = "info" | "warning" | "error";
+
+export type ActivityCategory =
+  | "scan"
+  | "rebuild"
+  | "thumbnail"
+  | "enrichment"
+  | "mosaic"
+  | "migration"
+  | "user_action"
+  | "system";
+
+export interface ActivityEvent {
+  id: number;
+  timestamp: string;
+  severity: ActivitySeverity;
+  category: ActivityCategory;
+  event_type: string;
   message: string;
-  details: Record<string, any>;
-  timestamp: number;
+  details: Record<string, unknown> | null;
+  target_id: number | null;
+  actor: string | null;
+  duration_ms: number | null;
+}
+
+export interface ActiveJob {
+  id: string;
+  category: "scan" | "rebuild" | "thumbnail" | "enrichment" | "mosaic";
+  label: string;
+  subLabel?: string;
+  progress?: number;
+  startedAt: number;
+  detail?: string;
+  cancelable: boolean;
+  onCancel?: () => Promise<void>;
+}
+
+export interface ActivityQueryParams {
+  severity?: ActivitySeverity | ActivitySeverity[];
+  category?: ActivityCategory | ActivityCategory[];
+  limit?: number;
+  cursor?: string;
+  since?: string;
+}
+
+export interface ActivityPageResponse {
+  items: ActivityEvent[];
+  next_cursor: string | null;
+  total: number;
 }
 
 export interface RebuildStatus {

--- a/guides/CONFIGURATION.md
+++ b/guides/CONFIGURATION.md
@@ -24,6 +24,36 @@ Default uses Docker named volumes; host path alternatives are commented out in t
 | Thumbnails | `/app/data/thumbnails` | Generated JPEG thumbnails. Grows over time. |
 | PostgreSQL data | `/var/lib/postgresql/data` | Database storage. |
 
+### Permissions and ownership
+
+The container runs as a non-root `galactilog` user. Bind-mounted directories the container writes to must be owned by, or otherwise writable by, that user on the host.
+
+| Container path | Access | Notes |
+|---------------|--------|-------|
+| `/app/data/fits` | read-only | FITS source tree. Read permission for the container user is sufficient. |
+| `/app/data/thumbnails` | read-write | Generated JPEG thumbnails. Must be writable. |
+| `/app/data/thumbnails/previews` | read-write | Larger preview renders. Must be writable. |
+
+The `galactilog` user is remapped at entrypoint time to match the host ownership of these bind mounts. Use the following environment variables to control that behavior:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PUID` | `1000` | Host user ID the in-container `galactilog` user is remapped to. Set to match the host owner of the thumbnails directory. |
+| `PGID` | `1000` | Host group ID the in-container `galactilog` user is remapped to. |
+| `GALACTILOG_SKIP_CHOWN` | *(unset)* | Set to `1` to skip the first-boot recursive chown of `/app/data/thumbnails`. Use when ownership is already correct or when recursive chown is too slow. |
+
+See the [Install Guide](INSTALL.md#running-as-non-root) for discovery commands and platform-specific values.
+
+#### Troubleshooting 403 responses
+
+A 403 on `/preview/...` or `/thumbnails/...` paths indicates the container user cannot read the files. On the host, confirm ownership of the thumbnails directory matches `PUID:PGID`:
+
+```bash
+stat -c '%u %g' /path/to/thumbnails
+```
+
+If the values do not match, either adjust `PUID` and `PGID` to the existing owner, or `chown -R` the directory to the configured UID/GID.
+
 ### PostgreSQL Settings
 
 Set in the postgres service's `environment:` block. Must match `GALACTILOG_DATABASE_URL`.

--- a/guides/INSTALL.md
+++ b/guides/INSTALL.md
@@ -108,6 +108,72 @@ Docker Compose
         └── celery beat (periodic task scheduler)
 ```
 
+## Running as non-root
+
+The container runs as a non-root `galactilog` user (UID 1000, GID 1000 by default) for security. Any bind-mounted directory the container writes to must be accessible to that user. The FITS mount is read-only and only needs read access.
+
+### Discover the host user and group ID
+
+Run these on the host, as the user who owns the target directory:
+
+```bash
+id -u
+id -g
+```
+
+To inspect the current owner of a bind-mount source:
+
+```bash
+stat -c '%u %g' /path/to/thumbnails
+```
+
+### Set PUID and PGID
+
+Pass `PUID` and `PGID` to remap the in-container `galactilog` user to the host UID/GID at entrypoint time. Set them in the `environment:` block of the app service:
+
+```yaml
+services:
+  app:
+    environment:
+      - PUID=1000
+      - PGID=1000
+```
+
+Or via `.env` in the project root:
+
+```
+PUID=1000
+PGID=1000
+```
+
+and reference them in `docker-compose.yml`:
+
+```yaml
+environment:
+  - PUID=${PUID}
+  - PGID=${PGID}
+```
+
+### Platform notes
+
+- TrueNAS SCALE: the `apps` user is typically UID/GID 568. Set `PUID=568` and `PGID=568`, and ensure the dataset ACL grants that user write access to the thumbnails path.
+- Unraid: the `nobody` user is UID 99, GID 100. Set `PUID=99` and `PGID=100`.
+- Synology DSM: UIDs vary per user account. Check `id <username>` via SSH. For shared folders, use the UID/GID of the owning user.
+- Generic Linux host: `PUID=1000` and `PGID=1000` match the first regular user on most distributions and are the default if `PUID`/`PGID` are omitted.
+
+### First-boot chown
+
+On the first start after upgrading to a non-root image, the entrypoint runs `chown -R` on `/app/data/thumbnails` to match the effective `PUID:PGID` if the existing ownership differs. This runs once and may take time on large thumbnail directories.
+
+To skip the automatic chown (for example, if you have pre-set ownership yourself or run on a filesystem where recursive chown is expensive), set:
+
+```yaml
+environment:
+  - GALACTILOG_SKIP_CHOWN=1
+```
+
+With this flag set, you are responsible for ensuring the thumbnail directories are writable by the `PUID:PGID` user.
+
 ## Updating
 
 ```bash

--- a/guides/UPGRADE.md
+++ b/guides/UPGRADE.md
@@ -1,0 +1,65 @@
+# Upgrading GalactiLog
+
+## [version] Non-root container execution
+
+Starting with this release, the container runs as a non-root `galactilog` user (UID/GID 1000 by default) instead of root. The in-container user is remapped at entrypoint time to match `PUID` and `PGID` environment variables, following the LinuxServer.io convention. This resolves cases where nginx, previously running as `www-data`, could not read bind-mounted thumbnail directories owned by a different host user (see issue #162).
+
+Port 80 binding inside the container continues to work via file capabilities; no port change is required.
+
+### What to expect on first boot
+
+- The entrypoint checks ownership of `/app/data/thumbnails`. If it does not match the effective `PUID:PGID`, the entrypoint runs a recursive `chown` once.
+- For large thumbnail directories, this one-time chown may add a noticeable delay to the first startup after upgrade.
+- Subsequent restarts skip the chown when ownership already matches.
+- The FITS mount at `/app/data/fits` is read-only and is never chowned.
+
+### Action required
+
+Most users: none. The default `PUID=1000` and `PGID=1000` match a typical Docker host where the directory was previously created by the root-owned container and is now accessible to UID 1000, or where the host user running Docker is UID 1000.
+
+Verify after upgrade:
+
+```bash
+docker compose up -d
+docker compose logs app | head -n 40
+```
+
+Confirm the web UI loads and thumbnails display. A 403 on `/thumbnails/...` or `/preview/...` indicates the container user cannot read the files; see the [Install Guide](INSTALL.md#running-as-non-root) and the [Configuration Guide](CONFIGURATION.md#permissions-and-ownership) for remediation.
+
+### If you run on TrueNAS, Unraid, Synology, or Kubernetes
+
+Set `PUID` and `PGID` in the app service's `environment:` block to match the existing host owner of the thumbnails bind mount:
+
+- TrueNAS SCALE: `PUID=568`, `PGID=568` (the `apps` user).
+- Unraid: `PUID=99`, `PGID=100` (the `nobody` user).
+- Synology DSM: use `id <username>` via SSH to find the owner of the shared folder, then set `PUID` and `PGID` accordingly.
+- Kubernetes: set `securityContext.runAsUser` and `runAsGroup` on the pod, or pass `PUID`/`PGID` via `env`. Ensure the `PersistentVolume` permissions allow that UID to write to the thumbnails path.
+
+Alternative: pre-chown the thumbnails directory on the host to the desired UID/GID and set `GALACTILOG_SKIP_CHOWN=1` to opt out of the entrypoint chown:
+
+```bash
+sudo chown -R 568:568 /mnt/tank/apps/galactilog/thumbnails
+```
+
+```yaml
+environment:
+  - PUID=568
+  - PGID=568
+  - GALACTILOG_SKIP_CHOWN=1
+```
+
+### Rollback
+
+To revert to a previous image, pin the older tag in `docker-compose.yml`:
+
+```yaml
+image: chvvkumar/galactilog:<previous-version>
+```
+
+The older image runs as root and writes thumbnails as UID/GID 0. If the entrypoint chowned your host directory to 1000 (or to `PUID:PGID`) during the upgrade, the previous image will still function because root can read and write any ownership. However, if you later return to the non-root image or access the files from another host account, you may want to chown the directory back to its prior owner:
+
+```bash
+sudo chown -R <prior-uid>:<prior-gid> /path/to/thumbnails
+```
+
+Named Docker volumes are unaffected; ownership inside a Docker-managed volume is preserved across image changes.

--- a/guides/superpowers/plans/2026-04-15-activity-log-redesign-plan.md
+++ b/guides/superpowers/plans/2026-04-15-activity-log-redesign-plan.md
@@ -1,0 +1,3788 @@
+# Activity Log Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the scattered activity log and ad-hoc in-progress indicators with a single durable Postgres-backed event store, a unified active-jobs view, and a redesigned Dashboard card that clearly separates live status from history.
+
+**Architecture:** Backend adds an `activity_events` table, a single `emit()` helper, a filterable `/activity` API, and a nightly pruner. The 17 existing Redis-list call sites are refactored, and 7 previously-silent event sources are added with aggregation. Frontend adds an `activeJobs` adapter that merges scan status, rebuild status, and tracked Celery tasks into one shape, redesigns `ActivityFeed.tsx` into Now Running + History regions, and codifies toast firing rules via an `emitWithToast()` helper. Spec: `guides/superpowers/specs/2026-04-15-activity-log-redesign-design.md`.
+
+**Tech Stack:** FastAPI, SQLAlchemy 2.0 async, Alembic, asyncpg/psycopg2, Celery + Redis, pytest-asyncio, SolidJS + TypeScript strict, Tailwind CSS v4, Vite.
+
+**Numbering:** Tasks 1-17 are backend. Tasks 100-113 are frontend. Run the backend series first, then the frontend series.
+
+---
+
+## Backend
+
+### Task 1: Alembic migration creating `activity_events`
+
+**Files:**
+- Create: `backend/alembic/versions/0011_add_activity_events.py`
+
+- [ ] **Step 1: Create the migration file.**
+
+```python
+"""Add activity_events table.
+
+Creates the activity_events table with all columns and indexes defined in
+the activity log redesign spec. Uses defensive IF NOT EXISTS guards per
+project convention.
+"""
+from alembic import op
+from sqlalchemy import text
+
+revision = "0011"
+down_revision = "0010"
+branch_labels = None
+depends_on = None
+
+
+def _table_exists(name: str) -> bool:
+    conn = op.get_bind()
+    result = conn.execute(
+        text(
+            "SELECT 1 FROM information_schema.tables "
+            "WHERE table_schema = 'public' AND table_name = :name"
+        ),
+        {"name": name},
+    )
+    return result.fetchone() is not None
+
+
+def upgrade():
+    if not _table_exists("activity_events"):
+        op.execute("""
+            CREATE TABLE activity_events (
+                id          bigserial PRIMARY KEY,
+                timestamp   timestamptz NOT NULL DEFAULT now(),
+                severity    varchar(16) NOT NULL,
+                category    varchar(32) NOT NULL,
+                event_type  varchar(64) NOT NULL,
+                message     text NOT NULL,
+                details     jsonb,
+                target_id   integer REFERENCES targets(id) ON DELETE SET NULL,
+                actor       varchar(64),
+                duration_ms integer
+            )
+        """)
+
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_activity_timestamp_desc "
+        "ON activity_events (timestamp DESC)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_activity_severity_ts "
+        "ON activity_events (severity, timestamp DESC)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_activity_category_ts "
+        "ON activity_events (category, timestamp DESC)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_activity_target "
+        "ON activity_events (target_id) WHERE target_id IS NOT NULL"
+    )
+
+
+def downgrade():
+    op.execute("DROP INDEX IF EXISTS idx_activity_target")
+    op.execute("DROP INDEX IF EXISTS idx_activity_category_ts")
+    op.execute("DROP INDEX IF EXISTS idx_activity_severity_ts")
+    op.execute("DROP INDEX IF EXISTS idx_activity_timestamp_desc")
+    op.execute("DROP TABLE IF EXISTS activity_events")
+```
+
+Note: the migration revision number `0011` assumes current head is `0010`. Before committing, run `alembic current` and adjust `revision` and `down_revision` to match the actual head.
+
+- [ ] **Step 2: Apply migration and confirm.**
+
+```
+cd backend && alembic upgrade head
+```
+
+Expected output contains: `Running upgrade 0010 -> 0011`.
+
+- [ ] **Step 3: Verify columns.**
+
+```
+cd backend && python -c "
+from sqlalchemy import create_engine, text
+from app.config import settings
+url = settings.database_url.replace('+asyncpg', '+psycopg2')
+e = create_engine(url)
+with e.connect() as c:
+    r = c.execute(text(\"SELECT column_name FROM information_schema.columns WHERE table_name='activity_events' ORDER BY ordinal_position\"))
+    print([row[0] for row in r])
+"
+```
+
+Expected: `['id', 'timestamp', 'severity', 'category', 'event_type', 'message', 'details', 'target_id', 'actor', 'duration_ms']`
+
+- [ ] **Step 4: Commit.**
+
+```
+git add backend/alembic/versions/0011_add_activity_events.py
+git commit -m "Add activity_events table migration"
+```
+
+---
+
+### Task 2: SQLAlchemy model `ActivityEvent`
+
+**Files:**
+- Create: `backend/app/models/activity_event.py`
+- Modify: `backend/app/models/__init__.py`
+- Test: `backend/tests/test_models.py`
+
+- [ ] **Step 1: Write a failing test.**
+
+Add to `backend/tests/test_models.py`:
+
+```python
+def test_activity_event_columns():
+    from app.models.activity_event import ActivityEvent
+    cols = {c.name for c in ActivityEvent.__table__.columns}
+    assert cols == {
+        "id", "timestamp", "severity", "category", "event_type",
+        "message", "details", "target_id", "actor", "duration_ms",
+    }
+```
+
+Run: `cd backend && pytest tests/test_models.py::test_activity_event_columns -v`
+Expected: FAIL (ImportError).
+
+- [ ] **Step 2: Create `backend/app/models/activity_event.py`.**
+
+```python
+from datetime import datetime, timezone
+
+from sqlalchemy import BigInteger, DateTime, ForeignKey, Integer, String, Text, func
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import Base
+
+
+class ActivityEvent(Base):
+    __tablename__ = "activity_events"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    timestamp: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+    )
+    severity: Mapped[str] = mapped_column(String(16), nullable=False)
+    category: Mapped[str] = mapped_column(String(32), nullable=False)
+    event_type: Mapped[str] = mapped_column(String(64), nullable=False)
+    message: Mapped[str] = mapped_column(Text, nullable=False)
+    details: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    target_id: Mapped[int | None] = mapped_column(
+        Integer,
+        ForeignKey("targets.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    actor: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    duration_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+```
+
+- [ ] **Step 3: Update `backend/app/models/__init__.py`.**
+
+Add after the last import:
+```python
+from .activity_event import ActivityEvent
+```
+
+Append `"ActivityEvent"` to `__all__`.
+
+- [ ] **Step 4: Run tests.**
+
+Run: `cd backend && pytest tests/test_models.py::test_activity_event_columns -v`
+Expected: PASS.
+
+- [ ] **Step 5: Write a round-trip instantiation test.**
+
+Add to `backend/tests/test_models.py`:
+
+```python
+def test_activity_event_instantiation():
+    from app.models.activity_event import ActivityEvent
+    ev = ActivityEvent(
+        severity="warning",
+        category="scan",
+        event_type="scan_complete",
+        message="Scan complete: 5 new files added",
+        details={"completed": 5, "failed": 0},
+        actor="system",
+    )
+    assert ev.severity == "warning"
+    assert ev.details["completed"] == 5
+    assert ev.target_id is None
+    assert ev.duration_ms is None
+```
+
+Run: `cd backend && pytest tests/test_models.py::test_activity_event_instantiation -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit.**
+
+```
+git add backend/app/models/activity_event.py backend/app/models/__init__.py backend/tests/test_models.py
+git commit -m "Add ActivityEvent SQLAlchemy model"
+```
+
+---
+
+### Task 3: Pydantic schemas for activity
+
+**Files:**
+- Create: `backend/app/schemas/activity.py`
+- Create: `backend/tests/test_schemas_activity.py`
+
+- [ ] **Step 1: Write failing tests.**
+
+Create `backend/tests/test_schemas_activity.py`:
+
+```python
+import pytest
+from datetime import datetime, timezone
+
+
+def test_activity_item_fields():
+    from app.schemas.activity import ActivityItem
+    fields = set(ActivityItem.model_fields.keys())
+    assert fields == {"id", "timestamp", "severity", "category", "event_type",
+                      "message", "details", "target_id", "actor", "duration_ms"}
+
+
+def test_activity_item_serializes():
+    from app.schemas.activity import ActivityItem
+    item = ActivityItem(
+        id=1,
+        timestamp=datetime(2026, 4, 15, 12, 0, 0, tzinfo=timezone.utc),
+        severity="info", category="scan", event_type="scan_complete",
+        message="done", details=None, target_id=None, actor="system", duration_ms=None,
+    )
+    assert item.model_dump()["severity"] == "info"
+
+
+def test_paginated_response():
+    from app.schemas.activity import PaginatedActivityResponse, ActivityItem
+    resp = PaginatedActivityResponse(
+        items=[ActivityItem(
+            id=1, timestamp=datetime(2026, 4, 15, 12, 0, 0, tzinfo=timezone.utc),
+            severity="info", category="scan", event_type="scan_complete",
+            message="done", details=None, target_id=None, actor=None, duration_ms=None,
+        )],
+        next_cursor=None,
+        total=1,
+    )
+    assert resp.total == 1
+
+
+def test_filter_params_defaults():
+    from app.schemas.activity import ActivityFilterParams
+    p = ActivityFilterParams()
+    assert p.limit == 50
+    assert p.severity == []
+    assert p.category == []
+    assert p.cursor is None
+    assert p.since is None
+
+
+def test_filter_params_limit_cap():
+    from app.schemas.activity import ActivityFilterParams
+    p = ActivityFilterParams(limit=999)
+    assert p.limit == 200
+```
+
+Run: `cd backend && pytest tests/test_schemas_activity.py -v`
+Expected: all FAIL (ImportError).
+
+- [ ] **Step 2: Create `backend/app/schemas/activity.py`.**
+
+```python
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class ActivityItem(BaseModel):
+    id: int
+    timestamp: datetime
+    severity: str
+    category: str
+    event_type: str
+    message: str
+    details: dict[str, Any] | None
+    target_id: int | None
+    actor: str | None
+    duration_ms: int | None
+
+    model_config = {"from_attributes": True}
+
+
+class PaginatedActivityResponse(BaseModel):
+    items: list[ActivityItem]
+    next_cursor: str | None
+    total: int
+
+
+class ActivityFilterParams(BaseModel):
+    severity: list[str] = Field(default_factory=list)
+    category: list[str] = Field(default_factory=list)
+    limit: int = Field(default=50, ge=1, le=200)
+    cursor: str | None = None
+    since: datetime | None = None
+
+    @field_validator("limit", mode="before")
+    @classmethod
+    def cap_limit(cls, v: int) -> int:
+        return min(int(v), 200)
+```
+
+- [ ] **Step 3: Run tests.**
+
+Run: `cd backend && pytest tests/test_schemas_activity.py -v`
+Expected: all PASS.
+
+- [ ] **Step 4: Commit.**
+
+```
+git add backend/app/schemas/activity.py backend/tests/test_schemas_activity.py
+git commit -m "Add activity Pydantic schemas"
+```
+
+---
+
+### Task 4: `emit()` and `emit_sync()` helpers
+
+**Files:**
+- Create: `backend/app/services/activity.py`
+- Create: `backend/tests/test_activity_service.py`
+
+- [ ] **Step 1: Write failing tests.**
+
+Create `backend/tests/test_activity_service.py`:
+
+```python
+import os, sys
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+import pytest
+
+os.environ.setdefault("GALACTILOG_DATABASE_URL", "postgresql+asyncpg://test:test@localhost:5432/test_catalog")
+os.environ.setdefault("GALACTILOG_REDIS_URL", "redis://localhost:6379/1")
+os.environ.setdefault("GALACTILOG_FITS_DATA_PATH", "/tmp/test_fits")
+os.environ.setdefault("GALACTILOG_THUMBNAILS_PATH", "/tmp/test_thumbnails")
+os.environ.setdefault("GALACTILOG_JWT_SECRET", "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
+os.environ.setdefault("GALACTILOG_HTTPS", "false")
+for _mod in ("fitsio",):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+sys.modules.setdefault("app.worker.tasks", MagicMock())
+
+
+def _redis_ctx(mock_r):
+    @asynccontextmanager
+    async def _ctx():
+        yield mock_r
+    return _ctx
+
+
+@pytest.mark.asyncio
+async def test_emit_inserts_row():
+    from app.services.activity import emit
+    db = AsyncMock()
+    db.add = MagicMock()
+    db.commit = AsyncMock()
+    mock_r = AsyncMock()
+    mock_r.publish = AsyncMock()
+    with patch("app.services.activity.async_redis", side_effect=_redis_ctx(mock_r)):
+        await emit(db, category="scan", severity="info",
+                   event_type="scan_complete", message="done", details={"n": 3})
+    db.add.assert_called_once()
+    db.commit.assert_called_once()
+    added = db.add.call_args[0][0]
+    assert added.severity == "info"
+    assert added.category == "scan"
+    assert added.details == {"n": 3}
+
+
+@pytest.mark.asyncio
+async def test_emit_publishes_to_redis():
+    import json
+    from app.services.activity import emit
+    db = AsyncMock()
+    db.add = MagicMock()
+    db.commit = AsyncMock()
+    published = []
+    mock_r = AsyncMock()
+    async def capture(ch, data): published.append((ch, data))
+    mock_r.publish = capture
+    with patch("app.services.activity.async_redis", side_effect=_redis_ctx(mock_r)):
+        await emit(db, category="scan", severity="warning",
+                   event_type="scan_stalled", message="stalled")
+    assert len(published) == 1
+    ch, payload = published[0]
+    assert ch == "activity:new"
+    assert json.loads(payload)["event_type"] == "scan_stalled"
+
+
+@pytest.mark.asyncio
+async def test_emit_invalid_severity_raises_in_dev():
+    from app.services.activity import emit
+    db = AsyncMock()
+    with patch.dict(os.environ, {"GALACTILOG_ENV": "development"}):
+        with pytest.raises(ValueError, match="Invalid severity"):
+            await emit(db, category="scan", severity="critical",
+                       event_type="test", message="test")
+
+
+@pytest.mark.asyncio
+async def test_emit_invalid_severity_skips_in_prod():
+    from app.services.activity import emit
+    db = AsyncMock()
+    db.add = MagicMock()
+    with patch.dict(os.environ, {"GALACTILOG_ENV": "production"}):
+        await emit(db, category="scan", severity="critical",
+                   event_type="test", message="test")
+    db.add.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_emit_db_failure_does_not_propagate():
+    from app.services.activity import emit
+    db = AsyncMock()
+    db.add = MagicMock()
+    db.commit = AsyncMock(side_effect=RuntimeError("DB down"))
+    mock_r = AsyncMock()
+    mock_r.publish = AsyncMock()
+    with patch("app.services.activity.async_redis", side_effect=_redis_ctx(mock_r)):
+        await emit(db, category="system", severity="error",
+                   event_type="startup", message="test")
+    # Must not raise
+
+
+@pytest.mark.asyncio
+async def test_emit_invalid_category_skips_in_prod():
+    from app.services.activity import emit
+    db = AsyncMock()
+    db.add = MagicMock()
+    with patch.dict(os.environ, {"GALACTILOG_ENV": "production"}):
+        await emit(db, category="unknown_xyz", severity="info",
+                   event_type="test", message="test")
+    db.add.assert_not_called()
+
+
+def test_emit_sync_inserts_row():
+    from app.services.activity import emit_sync
+    db = MagicMock()
+    redis = MagicMock()
+    emit_sync(db, redis=redis, category="rebuild", severity="info",
+              event_type="rebuild_complete", message="done")
+    db.add.assert_called_once()
+    db.commit.assert_called_once()
+    assert db.add.call_args[0][0].event_type == "rebuild_complete"
+```
+
+Run: `cd backend && pytest tests/test_activity_service.py -v`
+Expected: all FAIL (ImportError).
+
+- [ ] **Step 2: Create `backend/app/services/activity.py`.**
+
+```python
+"""Activity event emit helpers.
+
+emit()      - async, for FastAPI route handlers.
+emit_sync() - sync, for Celery tasks.
+
+Neither function raises to the caller. Failures are logged only.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Session
+
+from app.config import async_redis
+from app.models.activity_event import ActivityEvent
+
+logger = logging.getLogger(__name__)
+
+VALID_SEVERITIES = frozenset({"info", "warning", "error"})
+VALID_CATEGORIES = frozenset({
+    "scan", "rebuild", "thumbnail", "enrichment",
+    "mosaic", "migration", "user_action", "system",
+})
+
+_ENV = os.environ.get("GALACTILOG_ENV", "production")
+
+
+def _validate(severity: str, category: str) -> bool:
+    ok = True
+    if severity not in VALID_SEVERITIES:
+        msg = f"Invalid severity '{severity}'. Must be one of {sorted(VALID_SEVERITIES)}"
+        if _ENV == "development":
+            raise ValueError(msg)
+        logger.warning("activity.emit: %s", msg)
+        ok = False
+    if category not in VALID_CATEGORIES:
+        msg = f"Invalid category '{category}'. Must be one of {sorted(VALID_CATEGORIES)}"
+        if _ENV == "development":
+            raise ValueError(msg)
+        logger.warning("activity.emit: %s", msg)
+        ok = False
+    return ok
+
+
+def _build_event(
+    *,
+    category: str,
+    severity: str,
+    event_type: str,
+    message: str,
+    details: dict[str, Any] | None = None,
+    target_id: int | None = None,
+    actor: str | None = None,
+    duration_ms: int | None = None,
+) -> ActivityEvent:
+    return ActivityEvent(
+        severity=severity,
+        category=category,
+        event_type=event_type,
+        message=message,
+        details=details,
+        target_id=target_id,
+        actor=actor,
+        duration_ms=duration_ms,
+    )
+
+
+def _pubsub_payload(event: ActivityEvent) -> str:
+    return json.dumps({
+        "event_type": event.event_type,
+        "severity": event.severity,
+        "category": event.category,
+        "message": event.message,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    })
+
+
+async def emit(
+    db: AsyncSession,
+    *,
+    category: str,
+    severity: str,
+    event_type: str,
+    message: str,
+    details: dict[str, Any] | None = None,
+    target_id: int | None = None,
+    actor: str | None = None,
+    duration_ms: int | None = None,
+) -> None:
+    """Insert one ActivityEvent row and publish to Redis pubsub activity:new."""
+    if not _validate(severity, category):
+        return
+    event = _build_event(
+        category=category, severity=severity, event_type=event_type,
+        message=message, details=details, target_id=target_id,
+        actor=actor, duration_ms=duration_ms,
+    )
+    try:
+        db.add(event)
+        await db.commit()
+    except Exception:
+        logger.exception("activity.emit: DB insert failed for event_type=%s", event_type)
+        return
+    try:
+        async with async_redis() as r:
+            await r.publish("activity:new", _pubsub_payload(event))
+    except Exception:
+        logger.warning("activity.emit: Redis publish failed for event_type=%s", event_type)
+
+
+def emit_sync(
+    db: Session,
+    *,
+    redis,
+    category: str,
+    severity: str,
+    event_type: str,
+    message: str,
+    details: dict[str, Any] | None = None,
+    target_id: int | None = None,
+    actor: str | None = None,
+    duration_ms: int | None = None,
+) -> None:
+    """Sync version of emit() for Celery tasks."""
+    if not _validate(severity, category):
+        return
+    event = _build_event(
+        category=category, severity=severity, event_type=event_type,
+        message=message, details=details, target_id=target_id,
+        actor=actor, duration_ms=duration_ms,
+    )
+    try:
+        db.add(event)
+        db.commit()
+    except Exception:
+        logger.exception("activity.emit_sync: DB insert failed for event_type=%s", event_type)
+        return
+    try:
+        redis.publish("activity:new", _pubsub_payload(event))
+    except Exception:
+        logger.warning("activity.emit_sync: Redis publish failed for event_type=%s", event_type)
+```
+
+- [ ] **Step 3: Run tests.**
+
+Run: `cd backend && pytest tests/test_activity_service.py -v`
+Expected: all PASS.
+
+- [ ] **Step 4: Commit.**
+
+```
+git add backend/app/services/activity.py backend/tests/test_activity_service.py
+git commit -m "Add activity emit() and emit_sync() service helpers"
+```
+
+---
+
+### Task 5: `GET /activity` and `DELETE /activity` API router
+
+**Files:**
+- Create: `backend/app/api/activity.py`
+- Modify: `backend/app/api/router.py`
+- Create: `backend/tests/test_api_activity.py`
+
+- [ ] **Step 1: Write failing tests.**
+
+Create `backend/tests/test_api_activity.py`:
+
+```python
+import os, sys, uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+os.environ.setdefault("GALACTILOG_DATABASE_URL", "postgresql+asyncpg://test:test@localhost:5432/test_catalog")
+os.environ.setdefault("GALACTILOG_REDIS_URL", "redis://localhost:6379/1")
+os.environ.setdefault("GALACTILOG_FITS_DATA_PATH", "/tmp/test_fits")
+os.environ.setdefault("GALACTILOG_THUMBNAILS_PATH", "/tmp/test_thumbnails")
+os.environ.setdefault("GALACTILOG_JWT_SECRET", "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
+os.environ.setdefault("GALACTILOG_HTTPS", "false")
+for _mod in ("fitsio",):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+sys.modules.setdefault("app.worker.tasks", MagicMock())
+
+from app.main import app
+from app.database import get_session
+from app.api.deps import get_current_user, require_admin
+from app.models.user import User, UserRole
+
+
+def _user(role=UserRole.admin):
+    u = MagicMock(spec=User)
+    u.id = uuid.uuid4()
+    u.username = "admin"
+    u.role = role
+    u.is_active = True
+    return u
+
+
+def _session_with_events(events, total):
+    mock_session = AsyncMock()
+    count_result = MagicMock()
+    count_result.scalar_one.return_value = total
+    scalars_result = MagicMock()
+    scalars_result.all.return_value = events
+    call_count = [0]
+
+    async def _execute(stmt, *a, **kw):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return count_result
+        r = MagicMock()
+        r.scalars.return_value = scalars_result
+        return r
+
+    mock_session.execute = _execute
+
+    async def _gen():
+        yield mock_session
+
+    return _gen
+
+
+@pytest.mark.asyncio
+async def test_get_activity_returns_200():
+    from app.models.activity_event import ActivityEvent
+    ev = ActivityEvent(id=1, severity="info", category="scan",
+                       event_type="scan_complete", message="done",
+                       details=None, target_id=None, actor="system", duration_ms=None)
+    ev.timestamp = datetime(2026, 4, 15, 12, 0, 0, tzinfo=timezone.utc)
+    app.dependency_overrides[get_session] = _session_with_events([ev], 1)
+    app.dependency_overrides[get_current_user] = lambda: _user(UserRole.viewer)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        resp = await c.get("/api/activity")
+    app.dependency_overrides.clear()
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "items" in data and "total" in data and "next_cursor" in data
+
+
+@pytest.mark.asyncio
+async def test_get_activity_severity_filter():
+    app.dependency_overrides[get_session] = _session_with_events([], 0)
+    app.dependency_overrides[get_current_user] = lambda: _user(UserRole.viewer)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        resp = await c.get("/api/activity?severity=error")
+    app.dependency_overrides.clear()
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_get_activity_since_filter():
+    app.dependency_overrides[get_session] = _session_with_events([], 0)
+    app.dependency_overrides[get_current_user] = lambda: _user(UserRole.viewer)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        resp = await c.get("/api/activity?since=2026-04-15T12:00:00Z")
+    app.dependency_overrides.clear()
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_delete_activity_requires_admin():
+    from fastapi import HTTPException
+    async def _deny():
+        raise HTTPException(status_code=403, detail="Forbidden")
+    app.dependency_overrides[require_admin] = _deny
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        resp = await c.delete("/api/activity")
+    app.dependency_overrides.clear()
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_delete_activity_clears_all():
+    mock_session = AsyncMock()
+    mock_session.execute = AsyncMock()
+    mock_session.commit = AsyncMock()
+    async def _gen():
+        yield mock_session
+    app.dependency_overrides[get_session] = _gen
+    app.dependency_overrides[require_admin] = lambda: _user()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        resp = await c.delete("/api/activity")
+    app.dependency_overrides.clear()
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "cleared"
+```
+
+Run: `cd backend && pytest tests/test_api_activity.py -v`
+Expected: all FAIL (route 404).
+
+- [ ] **Step 2: Create `backend/app/api/activity.py`.**
+
+```python
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_current_user, require_admin
+from app.database import get_session
+from app.models.activity_event import ActivityEvent
+from app.models.user import User
+from app.schemas.activity import ActivityItem, PaginatedActivityResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/activity", tags=["activity"])
+
+_VALID_SEVERITIES = {"info", "warning", "error"}
+_VALID_CATEGORIES = {
+    "scan", "rebuild", "thumbnail", "enrichment",
+    "mosaic", "migration", "user_action", "system",
+}
+
+
+def _encode_cursor(ts: datetime, row_id: int) -> str:
+    payload = json.dumps({"ts": ts.isoformat(), "id": row_id})
+    return base64.urlsafe_b64encode(payload.encode()).decode()
+
+
+def _decode_cursor(cursor: str) -> tuple[datetime, int] | None:
+    try:
+        payload = json.loads(base64.urlsafe_b64decode(cursor.encode()).decode())
+        return datetime.fromisoformat(payload["ts"]), int(payload["id"])
+    except Exception:
+        return None
+
+
+@router.get("", response_model=PaginatedActivityResponse)
+async def list_activity(
+    severity: list[str] = Query(default=[]),
+    category: list[str] = Query(default=[]),
+    limit: int = Query(default=50, ge=1, le=200),
+    cursor: str | None = Query(default=None),
+    since: datetime | None = Query(default=None),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(get_current_user),
+):
+    """Return paginated activity events, newest first.
+
+    Keyset pagination via `cursor` (encodes timestamp + id of last row from
+    previous page). `since` is used by the error toast poller.
+    """
+    count_q = select(func.count(ActivityEvent.id))
+    items_q = select(ActivityEvent)
+
+    valid_sev = [s for s in severity if s in _VALID_SEVERITIES]
+    if valid_sev:
+        count_q = count_q.where(ActivityEvent.severity.in_(valid_sev))
+        items_q = items_q.where(ActivityEvent.severity.in_(valid_sev))
+
+    valid_cat = [c for c in category if c in _VALID_CATEGORIES]
+    if valid_cat:
+        count_q = count_q.where(ActivityEvent.category.in_(valid_cat))
+        items_q = items_q.where(ActivityEvent.category.in_(valid_cat))
+
+    if since is not None:
+        count_q = count_q.where(ActivityEvent.timestamp > since)
+        items_q = items_q.where(ActivityEvent.timestamp > since)
+
+    total = (await session.execute(count_q)).scalar_one()
+
+    if cursor:
+        decoded = _decode_cursor(cursor)
+        if decoded:
+            cursor_ts, cursor_id = decoded
+            items_q = items_q.where(
+                (ActivityEvent.timestamp < cursor_ts)
+                | (
+                    (ActivityEvent.timestamp == cursor_ts)
+                    & (ActivityEvent.id < cursor_id)
+                )
+            )
+
+    items_q = (
+        items_q
+        .order_by(ActivityEvent.timestamp.desc(), ActivityEvent.id.desc())
+        .limit(limit)
+    )
+
+    result = await session.execute(items_q)
+    rows = result.scalars().all()
+
+    next_cursor = None
+    if len(rows) == limit:
+        last = rows[-1]
+        next_cursor = _encode_cursor(last.timestamp, last.id)
+
+    return PaginatedActivityResponse(
+        items=[ActivityItem.model_validate(r) for r in rows],
+        next_cursor=next_cursor,
+        total=total,
+    )
+
+
+@router.delete("")
+async def clear_activity(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_admin),
+):
+    """Delete all activity_events rows. Admin only."""
+    await session.execute(delete(ActivityEvent))
+    await session.commit()
+    return {"status": "cleared"}
+```
+
+- [ ] **Step 3: Wire into `backend/app/api/router.py`.**
+
+Add import:
+```python
+from .activity import router as activity_router
+```
+
+Add router include after the last existing `api_router.include_router(...)` line:
+```python
+api_router.include_router(activity_router)
+```
+
+- [ ] **Step 4: Run tests.**
+
+Run: `cd backend && pytest tests/test_api_activity.py -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit.**
+
+```
+git add backend/app/api/activity.py backend/app/api/router.py backend/tests/test_api_activity.py
+git commit -m "Add GET /activity and DELETE /activity API endpoints"
+```
+
+---
+
+### Task 6: Remove old `/scan/activity` endpoints
+
+**Files:**
+- Modify: `backend/app/api/scan.py`
+- Test: `backend/tests/test_api_scan.py`
+
+- [ ] **Step 1: Write a failing test.**
+
+Add to `backend/tests/test_api_scan.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_old_scan_activity_routes_removed():
+    from app.main import app as _app
+    from httpx import AsyncClient, ASGITransport
+    transport = ASGITransport(app=_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        r1 = await c.get("/api/scan/activity")
+        r2 = await c.delete("/api/scan/activity")
+    assert r1.status_code == 404
+    assert r2.status_code == 404
+```
+
+Run: `cd backend && pytest tests/test_api_scan.py::test_old_scan_activity_routes_removed -v`
+Expected: FAIL.
+
+- [ ] **Step 2: Delete the two endpoint functions from `backend/app/api/scan.py`.**
+
+Remove the entire `@router.get("/activity")` and `@router.delete("/activity")` endpoint functions.
+
+- [ ] **Step 3: Remove unused imports from `scan.py`.**
+
+In the `from app.services.scan_state import (...)` block, remove `get_activity`, `clear_activity`, and `append_activity`.
+
+- [ ] **Step 4: Run tests.**
+
+Run: `cd backend && pytest tests/test_api_scan.py -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit.**
+
+```
+git add backend/app/api/scan.py backend/tests/test_api_scan.py
+git commit -m "Remove old /scan/activity GET and DELETE endpoints"
+```
+
+---
+
+### Task 7: Startup hook to delete `scan:activity` Redis key
+
+**Files:**
+- Modify: `backend/app/main.py`
+- Create: `backend/tests/test_activity_startup.py`
+
+- [ ] **Step 1: Write a failing test.**
+
+Create `backend/tests/test_activity_startup.py`:
+
+```python
+import os, sys
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+import pytest
+
+os.environ.setdefault("GALACTILOG_DATABASE_URL", "postgresql+asyncpg://test:test@localhost:5432/test_catalog")
+os.environ.setdefault("GALACTILOG_REDIS_URL", "redis://localhost:6379/1")
+os.environ.setdefault("GALACTILOG_FITS_DATA_PATH", "/tmp/test_fits")
+os.environ.setdefault("GALACTILOG_THUMBNAILS_PATH", "/tmp/test_thumbnails")
+os.environ.setdefault("GALACTILOG_JWT_SECRET", "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
+os.environ.setdefault("GALACTILOG_HTTPS", "false")
+for _mod in ("fitsio",):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+sys.modules.setdefault("app.worker.tasks", MagicMock())
+
+
+@pytest.mark.asyncio
+async def test_startup_deletes_scan_activity_key():
+    deleted_keys = []
+
+    mock_r = AsyncMock()
+    async def capture_delete(*keys):
+        deleted_keys.extend(keys)
+    mock_r.delete = capture_delete
+
+    @asynccontextmanager
+    async def _ctx():
+        yield mock_r
+
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock()
+    mock_db.commit = AsyncMock()
+    mock_db.scalar = AsyncMock(return_value=0)
+
+    @asynccontextmanager
+    async def _session_ctx():
+        yield mock_db
+
+    with patch("app.main.async_redis", side_effect=_ctx), \
+         patch("app.main.async_session", side_effect=_session_ctx), \
+         patch("app.main.start_queue_depth_probe"), \
+         patch("app.main.register_celery_collector"):
+        from app.main import lifespan, app as fastapi_app
+        async with lifespan(fastapi_app):
+            pass
+
+    assert "scan:activity" in deleted_keys
+```
+
+Run: `cd backend && pytest tests/test_activity_startup.py -v`
+Expected: FAIL.
+
+- [ ] **Step 2: Add cleanup to lifespan in `backend/app/main.py`.**
+
+Inside the `lifespan` function, after the `pg_trgm` extension block, add:
+
+```python
+    # Delete legacy scan:activity Redis list replaced by activity_events table.
+    try:
+        async with async_redis() as r:
+            await r.delete("scan:activity")
+        logger.info("Deleted legacy scan:activity Redis key")
+    except Exception as e:
+        logger.warning("Failed to delete scan:activity key: %s", e)
+```
+
+- [ ] **Step 3: Run test.**
+
+Run: `cd backend && pytest tests/test_activity_startup.py -v`
+Expected: PASS.
+
+- [ ] **Step 4: Commit.**
+
+```
+git add backend/app/main.py backend/tests/test_activity_startup.py
+git commit -m "Delete scan:activity Redis key on startup"
+```
+
+---
+
+### Task 8: Refactor `scan_state.py` emit site with `scan_files_failed` aggregation
+
+**Files:**
+- Modify: `backend/app/services/scan_state.py`
+- Create: `backend/tests/test_scan_state_emit.py`
+
+- [ ] **Step 1: Write failing tests.**
+
+Create `backend/tests/test_scan_state_emit.py`:
+
+```python
+import os, sys, json
+from unittest.mock import MagicMock, patch
+import pytest
+
+os.environ.setdefault("GALACTILOG_DATABASE_URL", "postgresql+asyncpg://test:test@localhost:5432/test_catalog")
+os.environ.setdefault("GALACTILOG_REDIS_URL", "redis://localhost:6379/1")
+os.environ.setdefault("GALACTILOG_FITS_DATA_PATH", "/tmp/test_fits")
+os.environ.setdefault("GALACTILOG_THUMBNAILS_PATH", "/tmp/test_thumbnails")
+os.environ.setdefault("GALACTILOG_JWT_SECRET", "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
+os.environ.setdefault("GALACTILOG_HTTPS", "false")
+for _mod in ("fitsio",):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+sys.modules.setdefault("app.worker.tasks", MagicMock())
+
+
+def _redis(total=5, completed=5, failed=0, new_files=5):
+    r = MagicMock()
+    r.hgetall.return_value = {
+        "state": "ingesting", "total": str(total), "completed": str(completed),
+        "failed": str(failed), "started_at": "1700000000.0", "completed_at": "",
+        "new_files": str(new_files), "changed_files": "0", "removed": "0",
+        "csv_enriched": "0", "skipped_calibration": "0",
+    }
+    r.hset = MagicMock()
+    r.expire = MagicMock()
+    r.delete = MagicMock()
+    r.lrange.return_value = []
+    return r
+
+
+def test_check_complete_sync_calls_emit_sync_on_completion():
+    from app.services.scan_state import check_complete_sync
+    r = _redis()
+    emit_calls = []
+
+    def fake_emit(session, *, redis, category, severity, event_type, message, **kw):
+        emit_calls.append({"event_type": event_type, "category": category, "severity": severity})
+
+    mock_session = MagicMock()
+
+    with patch("app.services.scan_state.emit_sync", fake_emit), \
+         patch("app.services.scan_state.create_engine"), \
+         patch("app.services.scan_state._SyncSession") as ms:
+        ms.return_value.__enter__ = lambda s, *a: mock_session
+        ms.return_value.__exit__ = lambda s, *a: None
+        check_complete_sync(r)
+
+    assert any(e["event_type"] == "scan_complete" for e in emit_calls)
+    ev = next(e for e in emit_calls if e["event_type"] == "scan_complete")
+    assert ev["category"] == "scan"
+    assert ev["severity"] == "info"
+
+
+def test_check_complete_sync_no_emit_when_in_progress():
+    from app.services.scan_state import check_complete_sync
+    r = _redis(total=10, completed=5, failed=0)
+    emit_calls = []
+
+    def fake_emit(*a, **kw):
+        emit_calls.append(True)
+
+    with patch("app.services.scan_state.emit_sync", fake_emit):
+        check_complete_sync(r)
+
+    assert len(emit_calls) == 0
+
+
+def test_scan_files_failed_emitted_when_failures_occur():
+    from app.services.scan_state import check_complete_sync
+    r = _redis(total=3, completed=2, failed=1, new_files=3)
+    r.lrange.return_value = [json.dumps({"file": "/fits/bad.fits", "error": "parse error"})]
+    emit_calls = []
+
+    def fake_emit(session, *, redis, category, severity, event_type, message, **kw):
+        emit_calls.append({"event_type": event_type, "details": kw.get("details")})
+
+    mock_session = MagicMock()
+
+    with patch("app.services.scan_state.emit_sync", fake_emit), \
+         patch("app.services.scan_state.create_engine"), \
+         patch("app.services.scan_state._SyncSession") as ms:
+        ms.return_value.__enter__ = lambda s, *a: mock_session
+        ms.return_value.__exit__ = lambda s, *a: None
+        check_complete_sync(r)
+
+    failure_evs = [e for e in emit_calls if e["event_type"] == "scan_files_failed"]
+    assert len(failure_evs) == 1
+    assert failure_evs[0]["details"]["failed_files"][0]["path"] == "/fits/bad.fits"
+    assert "truncated" in failure_evs[0]["details"]
+```
+
+Run: `cd backend && pytest tests/test_scan_state_emit.py -v`
+Expected: all FAIL.
+
+- [ ] **Step 2: Refactor `backend/app/services/scan_state.py`.**
+
+Add these imports near the top, after the existing `import redis as sync_redis` line:
+
+```python
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session as _SyncSession
+```
+
+In `check_complete_sync`, replace the `append_activity_sync(r, {...})` block with:
+
+```python
+        try:
+            from app.config import settings as _cfg
+            from app.services.activity import emit_sync
+            _engine = create_engine(
+                _cfg.database_url.replace("+asyncpg", "+psycopg2"),
+                pool_pre_ping=True,
+            )
+            with _SyncSession(_engine) as _db:
+                emit_sync(
+                    _db, redis=r, category="scan", severity="info",
+                    event_type="scan_complete", message=msg,
+                    details={
+                        "completed": snap.completed, "failed": snap.failed,
+                        "skipped_calibration": snap.skipped_calibration,
+                        "csv_enriched": snap.csv_enriched, "total": snap.total,
+                        "removed": snap.removed, "new_files": snap.new_files,
+                        "changed_files": snap.changed_files,
+                    },
+                    actor="system",
+                )
+                if snap.failed > 0:
+                    import json as _json
+                    raw = r.lrange(SCAN_FAILED_KEY, 0, -1)
+                    failed_files = []
+                    for item in raw[:500]:
+                        try:
+                            entry = _json.loads(item)
+                            failed_files.append({
+                                "path": entry.get("file", ""),
+                                "reason": entry.get("error", ""),
+                            })
+                        except Exception:
+                            pass
+                    emit_sync(
+                        _db, redis=r, category="scan", severity="warning",
+                        event_type="scan_files_failed",
+                        message=f"Scan completed with {snap.failed} file failure{'s' if snap.failed != 1 else ''}",
+                        details={"failed_files": failed_files, "truncated": len(raw) > 500},
+                        actor="system",
+                    )
+        except Exception:
+            logger.exception("scan_state: failed to emit scan_complete activity")
+```
+
+Delete the `append_activity_sync` function definition.
+
+- [ ] **Step 3: Run tests.**
+
+Run: `cd backend && pytest tests/test_scan_state_emit.py -v`
+Expected: all PASS.
+
+- [ ] **Step 4: Commit.**
+
+```
+git add backend/app/services/scan_state.py backend/tests/test_scan_state_emit.py
+git commit -m "Refactor scan_state check_complete_sync to use emit_sync with scan_files_failed aggregation"
+```
+
+---
+
+### Task 9: Refactor `scan.py` `scan_filters_applied` emit site
+
+**Files:**
+- Modify: `backend/app/api/scan.py`
+- Test: `backend/tests/test_scan_filters_api.py`
+
+- [ ] **Step 1: Write a failing test.**
+
+Add to `backend/tests/test_scan_filters_api.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_apply_filters_now_calls_emit_not_append_activity():
+    import ast, pathlib
+    src = pathlib.Path("app/api/scan.py").read_text()
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name) and node.func.id == "append_activity":
+                raise AssertionError("append_activity() still called in scan.py")
+            if isinstance(node.func, ast.Attribute) and node.func.attr == "append_activity":
+                raise AssertionError("append_activity() still called in scan.py")
+```
+
+Run: `cd backend && pytest tests/test_scan_filters_api.py::test_apply_filters_now_calls_emit_not_append_activity -v`
+Expected: FAIL.
+
+- [ ] **Step 2: Refactor `backend/app/api/scan.py`.**
+
+Add import at the top:
+```python
+from app.services.activity import emit as _emit_activity
+```
+
+Replace the `append_activity` block in `apply_filters_now`:
+
+```python
+        await _emit_activity(
+            session,
+            category="scan",
+            severity="info",
+            event_type="scan_filters_applied",
+            message=(
+                f"Scan filters applied: {len(matched_ids)} image row"
+                f"{'s' if len(matched_ids) != 1 else ''} removed "
+                f"(by {user.username})"
+            ),
+            details={"removed": len(matched_ids), "by_user": user.username},
+            actor=user.username,
+        )
+```
+
+- [ ] **Step 3: Run tests.**
+
+Run: `cd backend && pytest tests/test_scan_filters_api.py -v`
+Expected: all PASS.
+
+- [ ] **Step 4: Commit.**
+
+```
+git add backend/app/api/scan.py backend/tests/test_scan_filters_api.py
+git commit -m "Refactor scan_filters_applied emit site in scan.py to use emit()"
+```
+
+---
+
+### Task 10: Refactor `tasks.py` scan emit sites (5 sites in `run_scan`)
+
+**Files:**
+- Modify: `backend/app/worker/tasks.py`
+- Create: `backend/tests/test_tasks_emit.py`
+
+Covers lines 133 (`scan_stopped`), 143 (`delta_scan`), 186 (`orphan_cleanup`), 198 (`orphan_warning`), 212 (`scan_complete` no-files path).
+
+- [ ] **Step 1: Write a failing test.**
+
+Create `backend/tests/test_tasks_emit.py`:
+
+```python
+import ast, pathlib
+import os, sys
+from unittest.mock import MagicMock, patch
+import pytest
+
+os.environ.setdefault("GALACTILOG_DATABASE_URL", "postgresql+asyncpg://test:test@localhost:5432/test_catalog")
+os.environ.setdefault("GALACTILOG_REDIS_URL", "redis://localhost:6379/1")
+os.environ.setdefault("GALACTILOG_FITS_DATA_PATH", "/tmp/test_fits")
+os.environ.setdefault("GALACTILOG_THUMBNAILS_PATH", "/tmp/test_thumbnails")
+os.environ.setdefault("GALACTILOG_JWT_SECRET", "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
+os.environ.setdefault("GALACTILOG_HTTPS", "false")
+for _mod in ("fitsio",):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+
+def test_append_activity_sync_not_imported_in_tasks():
+    src = pathlib.Path("app/worker/tasks.py").read_text()
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.module and "scan_state" in node.module:
+                names = [a.name for a in node.names]
+                assert "append_activity_sync" not in names, \
+                    "append_activity_sync still imported in tasks.py"
+```
+
+Run: `cd backend && pytest tests/test_tasks_emit.py::test_append_activity_sync_not_imported_in_tasks -v`
+Expected: FAIL.
+
+- [ ] **Step 2: Add `emit_sync` import and session factory to `backend/app/worker/tasks.py`.**
+
+Add after the `from app.services.scan_state import (...)` block:
+
+```python
+from app.services.activity import emit_sync as _emit_activity_sync
+
+
+def _activity_session():
+    """Return a context-managed sync Session for activity writes in Celery tasks."""
+    return Session(_sync_engine)
+```
+
+Remove `append_activity_sync` from the `from app.services.scan_state import (...)` import.
+
+- [ ] **Step 3: Replace 5 `append_activity_sync` calls in `run_scan()`.**
+
+**scan_stopped:**
+```python
+with _activity_session() as _db:
+    _emit_activity_sync(
+        _db, redis=_redis, category="scan", severity="info",
+        event_type="scan_stopped",
+        message=f"Scan stopped by user ({len(new_files)} files discovered before stop)",
+        details={"discovered": len(new_files)}, actor="system",
+    )
+```
+
+**delta_scan:**
+```python
+with _activity_session() as _db:
+    _emit_activity_sync(
+        _db, redis=_redis, category="scan", severity="info",
+        event_type="delta_scan",
+        message=f"Delta scan: {len(changed_files)} changed file{'s' if len(changed_files) != 1 else ''} detected and re-queued",
+        details={"changed_files": len(changed_files)}, actor="system",
+    )
+```
+
+**orphan_cleanup:**
+```python
+with _activity_session() as _db:
+    _emit_activity_sync(
+        _db, redis=_redis, category="scan", severity="info",
+        event_type="orphan_cleanup",
+        message=f"Removed {removed} deleted file{'s' if removed != 1 else ''} from catalog",
+        details={"removed": removed}, actor="system",
+    )
+```
+
+**orphan_warning:**
+```python
+with _activity_session() as _db:
+    _emit_activity_sync(
+        _db, redis=_redis, category="scan", severity="warning",
+        event_type="orphan_warning",
+        message=f"Orphan cleanup skipped: {len(orphaned_paths)} of {len(in_scope_known_paths)} in-scope files missing (>50%) - possible unmounted share",
+        details={"missing": len(orphaned_paths), "total_known": len(in_scope_known_paths)},
+        actor="system",
+    )
+```
+
+**scan_complete no-files path:**
+```python
+with _activity_session() as _db:
+    _emit_activity_sync(
+        _db, redis=_redis, category="scan", severity="info",
+        event_type="scan_complete", message=msg,
+        details={"completed": 0, "failed": 0, "already_known": cataloged, "removed": removed},
+        actor="system",
+    )
+```
+
+- [ ] **Step 4: Commit partial progress.**
+
+```
+git add backend/app/worker/tasks.py backend/tests/test_tasks_emit.py
+git commit -m "Refactor run_scan emit sites in tasks.py to emit_sync"
+```
+
+---
+
+### Task 11: Refactor `tasks.py` rebuild, thumbnail, and migration emit sites
+
+**Files:**
+- Modify: `backend/app/worker/tasks.py`
+
+Covers all remaining `append_activity_sync` calls.
+
+- [ ] **Step 1: Replace each remaining call.** Each replacement follows the pattern `with _activity_session() as _db: _emit_activity_sync(_db, redis=_redis, ...)`. Category/severity/event_type mapping:
+
+| Original `type` | category | severity | event_type |
+|---|---|---|---|
+| `thumb_purge_complete` (empty) | `thumbnail` | `info` | `thumb_purge_complete` |
+| `rebuild_cancelled` (purge before start) | `thumbnail` | `info` | `rebuild_cancelled` |
+| `thumb_purge_start` | `thumbnail` | `info` | `thumb_purge_start` |
+| `thumb_purge_progress` | DELETE this call entirely | n/a | n/a |
+| `thumb_purge_complete` (final) | `thumbnail` | `info` | `thumb_purge_complete` |
+| `rebuild_cancelled` (post-delete) | `thumbnail` | `info` | `rebuild_cancelled` |
+| `rebuild_cancelled` (full) | `rebuild` | `info` | `rebuild_cancelled` |
+| `rebuild_complete` (full) | `rebuild` | `info` | `rebuild_complete` |
+| `rebuild_cancelled` (retry) | `rebuild` | `info` | `rebuild_cancelled` |
+| `rebuild_complete` (retry) | `rebuild` | `info` | `rebuild_complete` |
+| `rebuild_cancelled` (smart manual) | `rebuild` | `info` | `rebuild_cancelled` |
+| `rebuild_complete` (smart manual) | `rebuild` | `info` | `rebuild_complete` |
+| `data_upgrade_failed` | `migration` | `error` | `data_upgrade_failed` |
+| `data_upgrade_complete` | `migration` | `info` | `data_upgrade_complete` |
+| `rebuild_cancelled` (ref thumbnails) | `thumbnail` | `info` | `rebuild_cancelled` |
+| `ref_thumbnails_complete` | `thumbnail` | `info` | `ref_thumbnails_complete` |
+| `rebuild_cancelled` (xmatch) | `rebuild` | `info` | `rebuild_cancelled` |
+| `xmatch_complete` | `enrichment` | `info` | `xmatch_complete` |
+
+Retain `message` and `details` values verbatim; only replace the transport.
+
+- [ ] **Step 2: Run the import-check test.**
+
+Run: `cd backend && pytest tests/test_tasks_emit.py::test_append_activity_sync_not_imported_in_tasks -v`
+Expected: PASS.
+
+- [ ] **Step 3: Run full test suite.**
+
+Run: `cd backend && pytest tests/ --ignore=tests/test_container_permissions.py -x -q`
+Expected: all PASS.
+
+- [ ] **Step 4: Commit.**
+
+```
+git add backend/app/worker/tasks.py
+git commit -m "Refactor all remaining tasks.py append_activity_sync calls to emit_sync"
+```
+
+---
+
+### Task 12: New emit site - `mosaic_detection_complete`
+
+**Files:**
+- Modify: `backend/app/worker/tasks.py`
+- Test: `backend/tests/test_tasks_emit.py`
+
+- [ ] **Step 1: Write a failing test.**
+
+Add to `backend/tests/test_tasks_emit.py`:
+
+```python
+def test_mosaic_detection_complete_emits():
+    from app.worker.tasks import detect_mosaic_panels_task
+    emit_calls = []
+
+    def fake_emit_sync(session, *, redis, category, severity, event_type, message, **kw):
+        emit_calls.append({"event_type": event_type, "details": kw.get("details")})
+
+    mock_redis = MagicMock()
+    mock_redis.set.return_value = True
+    mock_redis.delete = MagicMock()
+
+    with patch("app.worker.tasks._redis", mock_redis), \
+         patch("app.worker.tasks._emit_activity_sync", fake_emit_sync), \
+         patch("app.worker.tasks._activity_session") as mf, \
+         patch("app.worker.tasks.asyncio") as mock_aio:
+        mctx = MagicMock()
+        mctx.__enter__ = lambda s, *a: MagicMock()
+        mctx.__exit__ = lambda s, *a: None
+        mf.return_value = mctx
+        mock_aio.run.return_value = 7
+
+        result = detect_mosaic_panels_task.run()
+
+    assert result["status"] == "complete"
+    evs = [e for e in emit_calls if e["event_type"] == "mosaic_detection_complete"]
+    assert len(evs) == 1
+    assert evs[0]["details"]["candidates"] == 7
+```
+
+Run: `cd backend && pytest tests/test_tasks_emit.py::test_mosaic_detection_complete_emits -v`
+Expected: FAIL.
+
+- [ ] **Step 2: Add emit to `detect_mosaic_panels_task` in `tasks.py`.**
+
+After `count = asyncio.run(_run())` and before `return {"status": "complete", ...}`:
+
+```python
+        try:
+            with _activity_session() as _db:
+                _emit_activity_sync(
+                    _db, redis=_redis, category="mosaic", severity="info",
+                    event_type="mosaic_detection_complete",
+                    message=f"Mosaic detection complete: {count} new suggestion{'s' if count != 1 else ''} found",
+                    details={"candidates": count}, actor="system",
+                )
+        except Exception:
+            logger.warning("detect_mosaic_panels_task: failed to emit mosaic_detection_complete")
+```
+
+- [ ] **Step 3: Run test.**
+
+Run: `cd backend && pytest tests/test_tasks_emit.py::test_mosaic_detection_complete_emits -v`
+Expected: PASS.
+
+- [ ] **Step 4: Commit.**
+
+```
+git add backend/app/worker/tasks.py backend/tests/test_tasks_emit.py
+git commit -m "Add mosaic_detection_complete emit site"
+```
+
+---
+
+### Task 13: New emit site - `mosaic_composite_failed`
+
+**Files:**
+- Modify: `backend/app/services/mosaic_composite.py`
+- Test: `backend/tests/test_mosaic_composite.py`
+
+- [ ] **Step 1: Identify the public entry point.**
+
+```
+cd backend && grep -n "^async def\|^def " app/services/mosaic_composite.py | head -20
+```
+
+- [ ] **Step 2: Write a failing test.**
+
+Add to `backend/tests/test_mosaic_composite.py`:
+
+```python
+def test_mosaic_composite_failed_emit_called_on_exception():
+    from unittest.mock import AsyncMock, MagicMock, patch
+    import pytest
+
+    emit_calls = []
+
+    async def fake_emit(db, *, category, severity, event_type, message, **kw):
+        emit_calls.append({"event_type": event_type, "severity": severity})
+
+    with patch("app.services.mosaic_composite.emit", fake_emit):
+        from app.services import mosaic_composite as mc
+        assert hasattr(mc, "emit") or True
+```
+
+Run: `cd backend && pytest tests/test_mosaic_composite.py::test_mosaic_composite_failed_emit_called_on_exception -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Add `emit` import and failure emit to `backend/app/services/mosaic_composite.py`.**
+
+```python
+from app.services.activity import emit as _emit_activity
+```
+
+In the primary public async composite function's outer try/except:
+
+```python
+    except Exception as exc:
+        logger.error("mosaic_composite: failed - %s", exc, exc_info=True)
+        try:
+            await _emit_activity(
+                session,
+                category="mosaic",
+                severity="error",
+                event_type="mosaic_composite_failed",
+                message=f"Mosaic composite generation failed: {exc}",
+                details={"error": str(exc)},
+                actor="system",
+            )
+        except Exception:
+            pass
+        raise
+```
+
+- [ ] **Step 4: Run tests.**
+
+Run: `cd backend && pytest tests/test_mosaic_composite.py -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit.**
+
+```
+git add backend/app/services/mosaic_composite.py backend/tests/test_mosaic_composite.py
+git commit -m "Add mosaic_composite_failed emit site"
+```
+
+---
+
+### Task 14: New emit sites - `enrichment_query_failed` and `filename_candidate_failed`
+
+**Files:**
+- Modify: `backend/app/worker/tasks.py`
+- Test: `backend/tests/test_tasks_emit.py`
+
+- [ ] **Step 1: Write failing tests.**
+
+Add to `backend/tests/test_tasks_emit.py`:
+
+```python
+def test_enrichment_query_failed_emits_after_rebuild():
+    import pathlib
+    src = pathlib.Path("app/worker/tasks.py").read_text()
+    assert "enrichment_query_failed" in src
+
+
+def test_filename_candidate_failed_event_type_present():
+    import pathlib
+    src = pathlib.Path("app/worker/tasks.py").read_text()
+    assert "filename_candidate_failed" in src
+```
+
+Run: `cd backend && pytest tests/test_tasks_emit.py::test_enrichment_query_failed_emits_after_rebuild tests/test_tasks_emit.py::test_filename_candidate_failed_event_type_present -v`
+Expected: both FAIL.
+
+- [ ] **Step 2: Add `enrichment_query_failed` to `rebuild_targets` and `retry_unresolved`.**
+
+After the final `_emit_activity_sync(..., event_type="rebuild_complete", ...)`:
+
+```python
+    if failed > 0:
+        with _activity_session() as _db:
+            _emit_activity_sync(
+                _db, redis=_redis, category="enrichment", severity="warning",
+                event_type="enrichment_query_failed",
+                message=f"Full Rebuild: enrichment failed for {failed} of {total} object names",
+                details={"failed_targets": failed, "total": total}, actor="system",
+            )
+```
+
+Apply the identical pattern in `retry_unresolved`.
+
+- [ ] **Step 3: Add `filename_candidate_failed` to `_do_ingest`.**
+
+Replace the filename candidate `except` block:
+
+```python
+        except Exception:
+            logger.warning("Failed to create filename candidate for %s", path.name, exc_info=True)
+            try:
+                with _activity_session() as _db:
+                    _emit_activity_sync(
+                        _db, redis=_redis, category="scan", severity="warning",
+                        event_type="filename_candidate_failed",
+                        message=f"Filename candidate resolution failed for {path.name}",
+                        details={"path": str(path)}, actor="system",
+                    )
+            except Exception:
+                pass
+```
+
+- [ ] **Step 4: Run tests.**
+
+Run: `cd backend && pytest tests/test_tasks_emit.py -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit.**
+
+```
+git add backend/app/worker/tasks.py backend/tests/test_tasks_emit.py
+git commit -m "Add enrichment_query_failed and filename_candidate_failed emit sites"
+```
+
+---
+
+### Task 15: New emit site - `thumbnail_regen_failed` aggregation
+
+**Files:**
+- Modify: `backend/app/services/scan_state.py`
+- Test: `backend/tests/test_scan_state_emit.py`
+
+- [ ] **Step 1: Write a failing test.**
+
+Add to `backend/tests/test_scan_state_emit.py`:
+
+```python
+def test_thumbnail_regen_failed_emitted_for_thumbnail_failures():
+    import json
+    from app.services.scan_state import check_complete_sync
+    r = _redis(total=3, completed=2, failed=1, new_files=0)
+    r.lrange.return_value = [
+        json.dumps({"file": "/app/data/thumbnails/bad_abc123.jpg", "error": "stretch error"})
+    ]
+    emit_calls = []
+
+    def fake_emit(session, *, redis, category, severity, event_type, message, **kw):
+        emit_calls.append({"event_type": event_type, "category": category})
+
+    mock_session = MagicMock()
+    with patch("app.services.scan_state.emit_sync", fake_emit), \
+         patch("app.services.scan_state.create_engine"), \
+         patch("app.services.scan_state._SyncSession") as ms:
+        ms.return_value.__enter__ = lambda s, *a: mock_session
+        ms.return_value.__exit__ = lambda s, *a: None
+        check_complete_sync(r)
+
+    ev_types = [e["event_type"] for e in emit_calls]
+    assert "thumbnail_regen_failed" in ev_types
+```
+
+Run: `cd backend && pytest tests/test_scan_state_emit.py::test_thumbnail_regen_failed_emitted_for_thumbnail_failures -v`
+Expected: FAIL.
+
+- [ ] **Step 2: Extend failure aggregation in `check_complete_sync`.**
+
+In the failure aggregation block (from Task 8), split by path:
+
+```python
+                from app.config import settings as _cfg2
+                thumb_root = _cfg2.thumbnails_path
+                thumb_failures = [f for f in failed_files if f["path"].startswith(thumb_root)]
+                fits_failures = [f for f in failed_files if not f["path"].startswith(thumb_root)]
+
+                if thumb_failures:
+                    emit_sync(
+                        _db, redis=r, category="thumbnail", severity="warning",
+                        event_type="thumbnail_regen_failed",
+                        message=f"Thumbnail regen: {len(thumb_failures)} failure{'s' if len(thumb_failures) != 1 else ''}",
+                        details={"failed_files": thumb_failures, "truncated": len(raw) > 500},
+                        actor="system",
+                    )
+                if fits_failures:
+                    emit_sync(
+                        _db, redis=r, category="scan", severity="warning",
+                        event_type="scan_files_failed",
+                        message=f"Scan completed with {len(fits_failures)} file failure{'s' if len(fits_failures) != 1 else ''}",
+                        details={"failed_files": fits_failures, "truncated": len(raw) > 500},
+                        actor="system",
+                    )
+```
+
+Replace the single `scan_files_failed` emit from Task 8 with this split.
+
+- [ ] **Step 3: Run tests.**
+
+Run: `cd backend && pytest tests/test_scan_state_emit.py -v`
+Expected: all PASS.
+
+- [ ] **Step 4: Commit.**
+
+```
+git add backend/app/services/scan_state.py backend/tests/test_scan_state_emit.py
+git commit -m "Add thumbnail_regen_failed aggregation emit in check_complete_sync"
+```
+
+---
+
+### Task 16: Settings endpoint for `activity_retention_days`
+
+**Files:**
+- Modify: `backend/app/schemas/settings.py`
+- Test: `backend/tests/test_api_settings.py`
+
+- [ ] **Step 1: Write failing tests.**
+
+Add to `backend/tests/test_api_settings.py`:
+
+```python
+def test_activity_retention_days_default():
+    from app.schemas.settings import GeneralSettings
+    assert GeneralSettings().activity_retention_days == 90
+
+
+def test_activity_retention_days_validation():
+    from pydantic import ValidationError
+    from app.schemas.settings import GeneralSettings
+    with pytest.raises(ValidationError):
+        GeneralSettings(activity_retention_days=0)
+    with pytest.raises(ValidationError):
+        GeneralSettings(activity_retention_days=3651)
+    assert GeneralSettings(activity_retention_days=1).activity_retention_days == 1
+    assert GeneralSettings(activity_retention_days=3650).activity_retention_days == 3650
+```
+
+Run: `cd backend && pytest tests/test_api_settings.py::test_activity_retention_days_default tests/test_api_settings.py::test_activity_retention_days_validation -v`
+Expected: both FAIL.
+
+- [ ] **Step 2: Add field to `GeneralSettings` in `backend/app/schemas/settings.py`.**
+
+Update import to include `Field`:
+```python
+from pydantic import BaseModel, Field
+```
+
+Add to the `GeneralSettings` class body:
+```python
+activity_retention_days: int = Field(default=90, ge=1, le=3650)
+```
+
+- [ ] **Step 3: Run tests.**
+
+Run: `cd backend && pytest tests/test_api_settings.py::test_activity_retention_days_default tests/test_api_settings.py::test_activity_retention_days_validation -v`
+Expected: both PASS.
+
+- [ ] **Step 4: Commit.**
+
+```
+git add backend/app/schemas/settings.py backend/tests/test_api_settings.py
+git commit -m "Add activity_retention_days to GeneralSettings (default 90, min 1, max 3650)"
+```
+
+---
+
+### Task 17: Celery beat task `prune_activity_events`
+
+**Files:**
+- Create: `backend/app/worker/prune_activity.py`
+- Modify: `backend/app/worker/celery_app.py`
+- Create: `backend/tests/test_prune_activity.py`
+
+- [ ] **Step 1: Write failing tests.**
+
+Create `backend/tests/test_prune_activity.py`:
+
+```python
+import os, sys
+from unittest.mock import MagicMock, patch
+import pytest
+
+os.environ.setdefault("GALACTILOG_DATABASE_URL", "postgresql+asyncpg://test:test@localhost:5432/test_catalog")
+os.environ.setdefault("GALACTILOG_REDIS_URL", "redis://localhost:6379/1")
+os.environ.setdefault("GALACTILOG_FITS_DATA_PATH", "/tmp/test_fits")
+os.environ.setdefault("GALACTILOG_THUMBNAILS_PATH", "/tmp/test_thumbnails")
+os.environ.setdefault("GALACTILOG_JWT_SECRET", "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
+os.environ.setdefault("GALACTILOG_HTTPS", "false")
+for _mod in ("fitsio",):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+sys.modules.setdefault("app.worker.tasks", MagicMock())
+
+
+def _make_session(deleted_count, retention_days=90):
+    mock_result = MagicMock()
+    mock_result.rowcount = deleted_count
+    mock_settings = MagicMock()
+    mock_settings.general = {"activity_retention_days": retention_days}
+    settings_result = MagicMock()
+    settings_result.scalar_one_or_none.return_value = mock_settings
+    call_count = [0]
+
+    def _execute(stmt, *a, **kw):
+        call_count[0] += 1
+        return settings_result if call_count[0] == 1 else mock_result
+
+    session = MagicMock()
+    session.execute = _execute
+    session.commit = MagicMock()
+    return session
+
+
+def test_prune_deletes_old_rows_and_emits():
+    from app.worker.prune_activity import prune_activity_events
+    emit_calls = []
+
+    def fake_emit(session, *, redis, category, severity, event_type, message, **kw):
+        emit_calls.append({"event_type": event_type, "details": kw.get("details")})
+
+    with patch("app.worker.prune_activity.Session") as ms, \
+         patch("app.worker.prune_activity.emit_sync", fake_emit), \
+         patch("app.worker.prune_activity.get_sync_redis", return_value=MagicMock()):
+        session = _make_session(deleted_count=12)
+        ms.return_value.__enter__ = lambda s, *a: session
+        ms.return_value.__exit__ = lambda s, *a: None
+        result = prune_activity_events.run()
+
+    assert result["deleted"] == 12
+    evs = [e for e in emit_calls if e["event_type"] == "activity_pruned"]
+    assert len(evs) == 1
+    assert evs[0]["details"]["deleted_count"] == 12
+
+
+def test_prune_silent_when_zero_deleted():
+    from app.worker.prune_activity import prune_activity_events
+    emit_calls = []
+
+    def fake_emit(session, *, redis, category, severity, event_type, message, **kw):
+        emit_calls.append(event_type)
+
+    with patch("app.worker.prune_activity.Session") as ms, \
+         patch("app.worker.prune_activity.emit_sync", fake_emit), \
+         patch("app.worker.prune_activity.get_sync_redis", return_value=MagicMock()):
+        session = _make_session(deleted_count=0)
+        ms.return_value.__enter__ = lambda s, *a: session
+        ms.return_value.__exit__ = lambda s, *a: None
+        result = prune_activity_events.run()
+
+    assert result["deleted"] == 0
+    assert "activity_pruned" not in emit_calls
+
+
+def test_prune_task_in_beat_schedule():
+    from app.worker.celery_app import celery_app
+    schedule = celery_app.conf.beat_schedule
+    assert "prune-activity-events" in schedule
+    entry = schedule["prune-activity-events"]
+    assert entry["task"] == "app.worker.prune_activity.prune_activity_events"
+```
+
+Run: `cd backend && pytest tests/test_prune_activity.py -v`
+Expected: all FAIL.
+
+- [ ] **Step 2: Create `backend/app/worker/prune_activity.py`.**
+
+```python
+"""Nightly Celery beat task: prune activity_events rows older than retention window."""
+import logging
+
+from celery.schedules import crontab
+from sqlalchemy import create_engine, select, text
+from sqlalchemy.orm import Session
+
+from app.config import settings, get_sync_redis
+from app.models.user_settings import UserSettings, SETTINGS_ROW_ID
+from app.services.activity import emit_sync
+from app.worker.celery_app import celery_app
+
+logger = logging.getLogger(__name__)
+
+_sync_url = settings.database_url.replace("+asyncpg", "+psycopg2")
+_sync_engine = create_engine(_sync_url, pool_pre_ping=True)
+
+_DEFAULT_RETENTION_DAYS = 90
+
+
+@celery_app.task(name="app.worker.prune_activity.prune_activity_events")
+def prune_activity_events() -> dict:
+    """Delete activity_events rows older than activity_retention_days.
+
+    Reads retention from GeneralSettings. Emits activity_pruned only when
+    deleted_count > 0.
+    """
+    redis = get_sync_redis()
+
+    try:
+        with Session(_sync_engine) as session:
+            row = session.execute(
+                select(UserSettings).where(UserSettings.id == SETTINGS_ROW_ID)
+            ).scalar_one_or_none()
+
+            general = (row.general or {}) if row else {}
+            retention_days = int(general.get("activity_retention_days", _DEFAULT_RETENTION_DAYS))
+            retention_days = max(1, min(3650, retention_days))
+
+            result = session.execute(
+                text(
+                    f"DELETE FROM activity_events "
+                    f"WHERE timestamp < now() - interval '{retention_days} days'"
+                )
+            )
+            deleted = result.rowcount
+            session.commit()
+
+        logger.info(
+            "prune_activity_events: deleted %d rows (retention=%d days)",
+            deleted, retention_days,
+        )
+
+        if deleted > 0:
+            with Session(_sync_engine) as emit_session:
+                emit_sync(
+                    emit_session,
+                    redis=redis,
+                    category="system",
+                    severity="info",
+                    event_type="activity_pruned",
+                    message=(
+                        f"Activity log pruned: {deleted} "
+                        f"entr{'ies' if deleted != 1 else 'y'} older than "
+                        f"{retention_days} days removed"
+                    ),
+                    details={"deleted_count": deleted, "retention_days": retention_days},
+                    actor="system",
+                )
+
+        return {"status": "complete", "deleted": deleted, "retention_days": retention_days}
+
+    except Exception as exc:
+        logger.exception("prune_activity_events: failed - %s", exc)
+        return {"status": "error", "error": str(exc)}
+    finally:
+        try:
+            redis.close()
+        except Exception:
+            pass
+```
+
+- [ ] **Step 3: Register in `backend/app/worker/celery_app.py`.**
+
+Add import:
+```python
+from celery.schedules import crontab
+```
+
+Add entry to the `beat_schedule` dict:
+```python
+        "prune-activity-events": {
+            "task": "app.worker.prune_activity.prune_activity_events",
+            "schedule": crontab(hour=3, minute=0),
+        },
+```
+
+- [ ] **Step 4: Run tests.**
+
+Run: `cd backend && pytest tests/test_prune_activity.py -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Run full backend suite.**
+
+Run: `cd backend && pytest tests/ --ignore=tests/test_container_permissions.py -q`
+Expected: all PASS.
+
+- [ ] **Step 6: Commit.**
+
+```
+git add backend/app/worker/prune_activity.py backend/app/worker/celery_app.py backend/tests/test_prune_activity.py
+git commit -m "Add prune_activity_events Celery beat task scheduled daily at 03:00"
+```
+
+---
+
+## Frontend
+
+The frontend has no test framework configured (per CLAUDE.md). Each frontend task ends with a manual verification step (browser interactions) plus `npx tsc --noEmit` or `npm run build` compile check.
+
+Several frontend tasks assume backend endpoints have been updated to return `{ task_id: string }` from the various trigger endpoints (`triggerMosaicDetection`, `smartRebuildTargets`, `rebuildTargets`, `retryUnresolved`, `triggerXmatchEnrichment`, `triggerReferenceThumbnails`, `regenerateThumbnails`). If any still return only `{ status, message }`, update the API client return types locally when refactoring the caller, or add a small backend follow-up task to ensure all trigger endpoints return `{ task_id }`.
+
+### Task 100: Update activity types in `frontend/src/types/index.ts`
+
+**Files:**
+- Modify: `frontend/src/types/index.ts`
+
+- [ ] **Step 1: Replace the `ActivityEntry` interface block.**
+
+Locate the existing `ActivityEntry` interface and replace with:
+
+```ts
+export type ActivitySeverity = "info" | "warning" | "error";
+
+export type ActivityCategory =
+  | "scan"
+  | "rebuild"
+  | "thumbnail"
+  | "enrichment"
+  | "mosaic"
+  | "migration"
+  | "user_action"
+  | "system";
+
+export interface ActivityEvent {
+  id: number;
+  timestamp: string;
+  severity: ActivitySeverity;
+  category: ActivityCategory;
+  event_type: string;
+  message: string;
+  details: Record<string, unknown> | null;
+  target_id: number | null;
+  actor: string | null;
+  duration_ms: number | null;
+}
+
+export interface ActiveJob {
+  id: string;
+  category: "scan" | "rebuild" | "thumbnail" | "enrichment" | "mosaic";
+  label: string;
+  subLabel?: string;
+  progress?: number;
+  startedAt: number;
+  detail?: string;
+  cancelable: boolean;
+  onCancel?: () => Promise<void>;
+}
+
+export interface ActivityQueryParams {
+  severity?: ActivitySeverity | ActivitySeverity[];
+  category?: ActivityCategory | ActivityCategory[];
+  limit?: number;
+  cursor?: string;
+  since?: string;
+}
+
+export interface ActivityPageResponse {
+  items: ActivityEvent[];
+  next_cursor: string | null;
+  total: number;
+}
+```
+
+- [ ] **Step 2: Verify compilation.**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: zero errors from this file. `ActivityEntry` reference errors in other files are expected and will be resolved in Task 113.
+
+**Manual verification:** Compilation-only. No browser step.
+
+---
+
+### Task 101: Add activity API client functions
+
+**Files:**
+- Modify: `frontend/src/api/client.ts`
+
+- [ ] **Step 1: Add type imports.**
+
+At the top of `frontend/src/api/client.ts`, extend the existing `from "../types"` import block:
+
+```ts
+import type {
+  // existing imports unchanged,
+  ActivityEvent,
+  ActivityQueryParams,
+  ActivityPageResponse,
+} from "../types";
+```
+
+- [ ] **Step 2: Replace old activity methods.**
+
+Remove the existing `getActivity` and `clearActivity` methods. Add:
+
+```ts
+  fetchActivity: (params: ActivityQueryParams = {}) => {
+    const qs = new URLSearchParams();
+    const severities = Array.isArray(params.severity)
+      ? params.severity
+      : params.severity
+      ? [params.severity]
+      : [];
+    severities.forEach((s) => qs.append("severity", s));
+    const categories = Array.isArray(params.category)
+      ? params.category
+      : params.category
+      ? [params.category]
+      : [];
+    categories.forEach((c) => qs.append("category", c));
+    if (params.limit !== undefined) qs.set("limit", String(params.limit));
+    if (params.cursor) qs.set("cursor", params.cursor);
+    if (params.since) qs.set("since", params.since);
+    const q = qs.toString();
+    return fetchJson<ActivityPageResponse>(`/activity${q ? `?${q}` : ""}`);
+  },
+
+  fetchActivityErrorsSince: (since: string) => {
+    const qs = new URLSearchParams({ severity: "error", since });
+    return fetchJson<ActivityPageResponse>(`/activity?${qs}`);
+  },
+
+  clearActivityLog: () =>
+    fetchJson<{ status: string }>("/activity", { method: "DELETE" }),
+
+  getActivitySettings: () =>
+    fetchJson<{ activity_retention_days: number }>("/settings/activity"),
+
+  setActivitySettings: (body: { retention_days: number }) =>
+    fetchJson<{ activity_retention_days: number }>("/settings/activity", {
+      method: "PUT",
+      body: JSON.stringify(body),
+    }),
+```
+
+Note: the `/settings/activity` GET/PUT endpoints are added as part of the settings UI wiring. If not yet present on the backend, add a thin FastAPI endpoint in a backend follow-up that reads/writes `activity_retention_days` in `GeneralSettings`.
+
+- [ ] **Step 3: Verify compilation.**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: zero new errors.
+
+**Manual verification:** No requests to `/activity` should appear in DevTools Network tab yet (not called by any component).
+
+---
+
+### Task 102: Create `frontend/src/store/activeJobs.ts`
+
+**Files:**
+- Create: `frontend/src/store/activeJobs.ts`
+- Modify: `frontend/src/components/ScanManager.tsx`
+
+- [ ] **Step 1: Write the full store module.**
+
+```ts
+import { createSignal } from "solid-js";
+import type { ActiveJob, ScanStatus, RebuildStatus } from "../types";
+
+const [celeryJobs, setCeleryJobs] = createSignal<Map<string, ActiveJob>>(new Map());
+
+export function scanStatusToJob(
+  s: ScanStatus,
+  onStop: () => Promise<void>
+): ActiveJob | null {
+  if (s.state !== "scanning" && s.state !== "ingesting") return null;
+
+  const startedAt = s.started_at != null ? s.started_at * 1000 : Date.now();
+
+  const progress =
+    s.state === "ingesting" && s.total > 0
+      ? Math.min(1, (s.completed + s.failed) / s.total)
+      : undefined;
+
+  const subLabel =
+    s.state === "ingesting" && s.total > 0
+      ? `${(s.completed + s.failed).toLocaleString()} / ${s.total.toLocaleString()} files`
+      : s.discovered > 0
+      ? `${s.discovered.toLocaleString()} files found`
+      : undefined;
+
+  return {
+    id: "scan",
+    category: "scan",
+    label: s.state === "scanning" ? "Discovering files" : "Ingesting files",
+    subLabel,
+    progress,
+    startedAt,
+    cancelable: true,
+    onCancel: onStop,
+  };
+}
+
+export function rebuildStatusToJob(r: RebuildStatus): ActiveJob | null {
+  if (r.state !== "running") return null;
+
+  const startedAt = r.started_at != null ? r.started_at * 1000 : Date.now();
+
+  const modeLabel: Record<string, string> = {
+    smart: "Fix Orphans",
+    full: "Full Rebuild",
+    retry: "Re-resolve Targets",
+    xmatch: "Catalog Match",
+    ref_thumbnails: "Fetch DSS Thumbnails",
+    regen: "Regenerate Thumbnails",
+  };
+
+  return {
+    id: "rebuild",
+    category: "rebuild",
+    label: modeLabel[r.mode] ?? "Rebuild",
+    subLabel: r.message || undefined,
+    progress: undefined,
+    startedAt,
+    cancelable: false,
+  };
+}
+
+export function registerCeleryJob(job: ActiveJob): void {
+  setCeleryJobs((prev) => {
+    const next = new Map(prev);
+    next.set(job.id, job);
+    return next;
+  });
+}
+
+export function unregisterCeleryJob(id: string): void {
+  setCeleryJobs((prev) => {
+    const next = new Map(prev);
+    next.delete(id);
+    return next;
+  });
+}
+
+type Accessor<T> = () => T;
+
+let _scanStatusAccessor: Accessor<ScanStatus> | null = null;
+let _rebuildStatusAccessor: Accessor<RebuildStatus> | null = null;
+let _stopScanFn: (() => Promise<void>) | null = null;
+
+export function wireActiveJobSources(
+  scanStatus: Accessor<ScanStatus>,
+  rebuildStatus: Accessor<RebuildStatus>,
+  stopScan: () => Promise<void>
+): void {
+  _scanStatusAccessor = scanStatus;
+  _rebuildStatusAccessor = rebuildStatus;
+  _stopScanFn = stopScan;
+}
+
+export const activeJobs: Accessor<ActiveJob[]> = () => {
+  const jobs: ActiveJob[] = [];
+
+  if (_scanStatusAccessor && _stopScanFn) {
+    const scanJob = scanStatusToJob(_scanStatusAccessor(), _stopScanFn);
+    if (scanJob) jobs.push(scanJob);
+  }
+
+  if (_rebuildStatusAccessor) {
+    const rebuildJob = rebuildStatusToJob(_rebuildStatusAccessor());
+    if (rebuildJob) jobs.push(rebuildJob);
+  }
+
+  celeryJobs().forEach((job) => jobs.push(job));
+
+  return jobs;
+};
+
+export const hasActiveJobs: Accessor<boolean> = () => activeJobs().length > 0;
+```
+
+- [ ] **Step 2: Wire the sources from ScanManager.**
+
+In `frontend/src/components/ScanManager.tsx`, add import:
+```ts
+import { wireActiveJobSources } from "../store/activeJobs";
+```
+
+Inside the `ScanManager` component body, after both `scanStatus` and `rebuildState` signals are declared and `stopScan` is defined:
+
+```ts
+wireActiveJobSources(scanStatus, rebuildState, stopScan);
+```
+
+- [ ] **Step 3: Verify compilation.**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: zero errors.
+
+**Manual verification:** No visible change yet.
+
+---
+
+### Task 103: Extend `taskPoller.ts` with `track()` method
+
+**Files:**
+- Modify: `frontend/src/store/taskPoller.ts`
+
+- [ ] **Step 1: Rewrite the file preserving `pollTask()` signature.**
+
+```ts
+import { api } from "../api/client";
+import { registerCeleryJob, unregisterCeleryJob } from "./activeJobs";
+import type { ActiveJob } from "../types";
+
+interface PollOptions {
+  onSuccess?: (result: any) => void;
+  onFailure?: (error: string) => void;
+  interval?: number;
+  timeout?: number;
+}
+
+export function pollTask(taskId: string, options: PollOptions = {}): () => void {
+  const { onSuccess, onFailure, interval = 2000, timeout = 60000 } = options;
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let timeoutTimer: ReturnType<typeof setTimeout> | null = null;
+  let stopped = false;
+
+  const stop = () => {
+    stopped = true;
+    if (timer) clearInterval(timer);
+    if (timeoutTimer) clearTimeout(timeoutTimer);
+    timer = null;
+    timeoutTimer = null;
+  };
+
+  const check = async () => {
+    if (stopped) return;
+    try {
+      const status = await api.getTaskStatus(taskId);
+      if (stopped) return;
+      if (status.state === "SUCCESS") {
+        stop();
+        onSuccess?.(status.result);
+      } else if (status.state === "FAILURE") {
+        stop();
+        onFailure?.(status.result?.error ?? "Task failed");
+      }
+    } catch {
+      // Network error, keep polling
+    }
+  };
+
+  timer = setInterval(check, interval);
+  timeoutTimer = setTimeout(() => {
+    stop();
+    onFailure?.("Detection timed out");
+  }, timeout);
+
+  return stop;
+}
+
+interface TrackOptions {
+  id: string;
+  category: ActiveJob["category"];
+  label: string;
+  subLabel?: string;
+  cancelable?: boolean;
+  timeout?: number;
+  onSuccess?: (result: any) => void;
+  onFailure?: (error: string) => void;
+}
+
+export function track(opts: TrackOptions): () => void {
+  const jobId = `celery:${opts.id}`;
+
+  registerCeleryJob({
+    id: jobId,
+    category: opts.category,
+    label: opts.label,
+    subLabel: opts.subLabel,
+    progress: undefined,
+    startedAt: Date.now(),
+    cancelable: opts.cancelable ?? false,
+  });
+
+  const stop = pollTask(opts.id, {
+    interval: 2000,
+    timeout: opts.timeout ?? 300_000,
+    onSuccess: (result) => {
+      unregisterCeleryJob(jobId);
+      opts.onSuccess?.(result);
+    },
+    onFailure: (error) => {
+      unregisterCeleryJob(jobId);
+      opts.onFailure?.(error);
+    },
+  });
+
+  return () => {
+    unregisterCeleryJob(jobId);
+    stop();
+  };
+}
+```
+
+- [ ] **Step 2: Verify compilation.**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: zero errors.
+
+**Manual verification:** No visible change yet.
+
+---
+
+### Task 104: Redesign `ActivityFeed.tsx`
+
+**Files:**
+- Modify: `frontend/src/components/ActivityFeed.tsx` (full rewrite)
+- Modify: `frontend/src/components/ScanManager.tsx`
+
+- [ ] **Step 1: Replace the entire `ActivityFeed.tsx` file.**
+
+```tsx
+import {
+  Component,
+  For,
+  Show,
+  createSignal,
+  createEffect,
+  onMount,
+  onCleanup,
+  batch,
+} from "solid-js";
+import { A } from "@solidjs/router";
+import { activeJobs, hasActiveJobs } from "../store/activeJobs";
+import { api } from "../api/client";
+import { useSettingsContext } from "./SettingsProvider";
+import type {
+  ActivityEvent,
+  ActivityCategory,
+  ActivitySeverity,
+  ActiveJob,
+} from "../types";
+import FailedFilesList from "./activity/FailedFilesList";
+import EnrichmentFailureList from "./activity/EnrichmentFailureList";
+import DetailsJsonFallback from "./activity/DetailsJsonFallback";
+
+const SEVERITY_ICON: Record<ActivitySeverity, string> = {
+  info: "●",
+  warning: "▲",
+  error: "✕",
+};
+
+const SEVERITY_CLASS: Record<ActivitySeverity, string> = {
+  info: "text-theme-text-secondary",
+  warning: "text-theme-warning",
+  error: "text-theme-error",
+};
+
+const CATEGORY_LABELS: Record<ActivityCategory, string> = {
+  scan: "scan",
+  rebuild: "reb",
+  thumbnail: "thumb",
+  enrichment: "enrich",
+  mosaic: "mosaic",
+  migration: "migr",
+  user_action: "user",
+  system: "sys",
+};
+
+const ALL_CATEGORIES: ActivityCategory[] = [
+  "scan", "rebuild", "thumbnail", "enrichment",
+  "mosaic", "migration", "user_action", "system",
+];
+
+const IndeterminateBar: Component = () => (
+  <div class="w-full h-1.5 rounded-full overflow-hidden bg-[var(--color-bg-subtle)]">
+    <div
+      class="h-full rounded-full"
+      style={{
+        background: "var(--color-accent)",
+        animation: "activityIndeterminate 1.6s ease-in-out infinite",
+        width: "40%",
+      }}
+    />
+    <style>{`
+      @keyframes activityIndeterminate {
+        0%   { transform: translateX(-150%); }
+        100% { transform: translateX(350%); }
+      }
+    `}</style>
+  </div>
+);
+
+function startedAgo(startedAt: number): string {
+  const secs = Math.floor((Date.now() - startedAt) / 1000);
+  if (secs < 60) return `${secs}s ago`;
+  const m = Math.floor(secs / 60);
+  const s = secs % 60;
+  return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")} ago`;
+}
+
+const ActiveJobRow: Component<{ job: ActiveJob }> = (props) => {
+  const [agoLabel, setAgoLabel] = createSignal(startedAgo(props.job.startedAt));
+
+  const timer = setInterval(() => {
+    setAgoLabel(startedAgo(props.job.startedAt));
+  }, 5000);
+  onCleanup(() => clearInterval(timer));
+
+  return (
+    <div class="space-y-1.5 py-2">
+      <div class="flex items-center justify-between gap-2">
+        <div class="flex flex-col min-w-0">
+          <span class="text-xs font-medium text-theme-text-primary truncate">
+            {props.job.label}
+          </span>
+          <Show when={props.job.subLabel}>
+            <span class="text-xs text-theme-text-secondary truncate">
+              {props.job.subLabel}
+            </span>
+          </Show>
+        </div>
+        <div class="flex items-center gap-2 flex-shrink-0">
+          <span class="text-xs text-theme-text-secondary">{agoLabel()}</span>
+          <Show when={props.job.cancelable && props.job.onCancel}>
+            <button
+              onClick={() => props.job.onCancel?.()}
+              class="px-2 py-1 text-xs border border-theme-border-em text-theme-text-secondary rounded hover:border-theme-error hover:text-theme-error transition-colors"
+            >
+              Stop
+            </button>
+          </Show>
+        </div>
+      </div>
+      <Show
+        when={props.job.progress !== undefined}
+        fallback={<IndeterminateBar />}
+      >
+        {(_) => {
+          const pct = () => Math.round((props.job.progress ?? 0) * 100);
+          return (
+            <div class="w-full h-1.5 rounded-full overflow-hidden bg-[var(--color-bg-subtle)]">
+              <div
+                class="h-full rounded-full transition-all"
+                style={{
+                  background: "var(--color-accent)",
+                  width: `${pct()}%`,
+                }}
+              />
+            </div>
+          );
+        }}
+      </Show>
+    </div>
+  );
+};
+
+const RowDetails: Component<{ event: ActivityEvent }> = (props) => {
+  const d = props.event.details;
+  if (!d) return null;
+
+  if (
+    props.event.category === "scan" &&
+    Array.isArray((d as any).failed_files)
+  ) {
+    return (
+      <FailedFilesList
+        files={(d as any).failed_files}
+        truncated={(d as any).truncated ?? false}
+      />
+    );
+  }
+
+  if (
+    props.event.category === "enrichment" &&
+    Array.isArray((d as any).failed_targets)
+  ) {
+    return <EnrichmentFailureList targets={(d as any).failed_targets} />;
+  }
+
+  return <DetailsJsonFallback details={d} />;
+};
+
+const TargetLinkedMessage: Component<{ event: ActivityEvent }> = (props) => (
+  <span>
+    {props.event.message}
+    {" "}
+    <A
+      href={`/targets/${props.event.target_id}`}
+      class="text-theme-accent hover:underline"
+      onClick={(e) => e.stopPropagation()}
+    >
+      ↗
+    </A>
+  </span>
+);
+
+const HistoryRow: Component<{ event: ActivityEvent }> = (props) => {
+  const settingsCtx = useSettingsContext();
+  const [expanded, setExpanded] = createSignal(false);
+  const hasDetails = () => props.event.details !== null;
+
+  const hhmm = () => {
+    const d = new Date(props.event.timestamp);
+    const fmt = new Intl.DateTimeFormat("en-GB", {
+      hour: "2-digit",
+      minute: "2-digit",
+      timeZone: settingsCtx.timezone() || "UTC",
+      hour12: !settingsCtx.use24hTime(),
+    });
+    return fmt.format(d);
+  };
+
+  return (
+    <div
+      id={`activity-event-${props.event.id}`}
+      class="border-t border-theme-border first:border-0"
+    >
+      <div
+        class="flex items-start gap-2 py-1.5 text-xs cursor-default"
+        tabIndex={hasDetails() ? 0 : undefined}
+        role={hasDetails() ? "button" : undefined}
+        aria-expanded={hasDetails() ? expanded() : undefined}
+        onKeyDown={(e) => {
+          if (hasDetails() && (e.key === "Enter" || e.key === " ")) {
+            e.preventDefault();
+            setExpanded((v) => !v);
+          }
+        }}
+        onClick={() => {
+          if (hasDetails()) setExpanded((v) => !v);
+        }}
+      >
+        <span class="text-theme-text-secondary flex-shrink-0 w-[3rem] tabular-nums">
+          {hhmm()}
+        </span>
+        <span
+          class={`flex-shrink-0 w-4 text-center ${SEVERITY_CLASS[props.event.severity]}`}
+          title={props.event.severity}
+        >
+          {SEVERITY_ICON[props.event.severity]}
+        </span>
+        <span class="flex-shrink-0 w-[3.5rem] text-theme-text-secondary truncate">
+          {CATEGORY_LABELS[props.event.category]}
+        </span>
+        <span class="flex-1 text-theme-text-primary min-w-0">
+          <Show
+            when={props.event.target_id !== null}
+            fallback={<span>{props.event.message}</span>}
+          >
+            <TargetLinkedMessage event={props.event} />
+          </Show>
+        </span>
+        <Show when={hasDetails()}>
+          <span
+            class={`flex-shrink-0 text-theme-text-secondary transition-transform ${
+              expanded() ? "rotate-90" : ""
+            }`}
+          >
+            ›
+          </span>
+        </Show>
+      </div>
+      <Show when={expanded() && hasDetails()}>
+        <div class="pb-2 pl-[7rem]">
+          <RowDetails event={props.event} />
+        </div>
+      </Show>
+    </div>
+  );
+};
+
+const FilterPill: Component<{
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}> = (props) => (
+  <button
+    onClick={props.onClick}
+    class={`px-2 py-0.5 text-xs rounded-full border transition-colors ${
+      props.active
+        ? "bg-[var(--color-accent)]/20 text-[var(--color-accent)] border-[var(--color-accent)]/40"
+        : "border-theme-border text-theme-text-secondary hover:text-theme-text-primary hover:border-theme-border-em"
+    }`}
+  >
+    {props.label}
+  </button>
+);
+
+const ActivityFeed: Component = () => {
+  const [severityFilter, setSeverityFilter] =
+    createSignal<ActivitySeverity | "all">("all");
+  const [categoryFilter, setCategoryFilter] =
+    createSignal<ActivityCategory | "all">("all");
+  const [items, setItems] = createSignal<ActivityEvent[]>([]);
+  const [nextCursor, setNextCursor] = createSignal<string | null>(null);
+  const [total, setTotal] = createSignal(0);
+  const [loading, setLoading] = createSignal(false);
+  const [loadingMore, setLoadingMore] = createSignal(false);
+  const [newCount, setNewCount] = createSignal(0);
+  const [latestId, setLatestId] = createSignal<number | null>(null);
+  const [isScrolledDown, setIsScrolledDown] = createSignal(false);
+  let listRef: HTMLDivElement | undefined;
+  let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+  const buildParams = (extra: Record<string, unknown> = {}) => {
+    const p: Record<string, unknown> = { limit: 50, ...extra };
+    const sv = severityFilter();
+    if (sv !== "all") p.severity = sv;
+    const cat = categoryFilter();
+    if (cat !== "all") p.category = cat;
+    return p;
+  };
+
+  const loadInitial = async () => {
+    setLoading(true);
+    try {
+      const res = await api.fetchActivity(buildParams());
+      batch(() => {
+        setItems(res.items);
+        setNextCursor(res.next_cursor);
+        setTotal(res.total);
+        setNewCount(0);
+        if (res.items.length > 0) setLatestId(res.items[0].id);
+      });
+    } catch { /* non-blocking */ } finally {
+      setLoading(false);
+    }
+  };
+
+  const loadMore = async () => {
+    const cursor = nextCursor();
+    if (!cursor || loadingMore()) return;
+    setLoadingMore(true);
+    try {
+      const res = await api.fetchActivity(buildParams({ cursor }));
+      batch(() => {
+        setItems((prev) => [...prev, ...res.items]);
+        setNextCursor(res.next_cursor);
+      });
+    } catch { /* ignore */ } finally {
+      setLoadingMore(false);
+    }
+  };
+
+  const pollNew = async () => {
+    const top = latestId();
+    if (top === null) { await loadInitial(); return; }
+    try {
+      const res = await api.fetchActivity(buildParams({ limit: 50 }));
+      if (res.items.length === 0) return;
+      const newItems = res.items.filter((e) => e.id > top);
+      if (newItems.length === 0) return;
+      if (isScrolledDown()) {
+        setNewCount((n) => n + newItems.length);
+      } else {
+        batch(() => {
+          setItems((prev) => [...newItems, ...prev]);
+          setLatestId(newItems[0].id);
+          setTotal(res.total);
+        });
+      }
+    } catch { /* ignore */ }
+  };
+
+  onMount(() => {
+    loadInitial();
+    pollTimer = setInterval(pollNew, 10_000);
+  });
+
+  onCleanup(() => {
+    if (pollTimer) clearInterval(pollTimer);
+  });
+
+  createEffect(() => {
+    severityFilter();
+    categoryFilter();
+    loadInitial();
+  });
+
+  const onScroll = () => {
+    if (!listRef) return;
+    setIsScrolledDown(listRef.scrollTop > 120);
+  };
+
+  const jumpToNew = () => {
+    listRef?.scrollTo({ top: 0, behavior: "smooth" });
+    setNewCount(0);
+    loadInitial();
+  };
+
+  const jobs = () => activeJobs();
+  const jobCount = () => jobs().length;
+
+  return (
+    <div class="bg-theme-surface border border-theme-border rounded-[var(--radius-md)] shadow-[var(--shadow-sm)] flex flex-col h-full min-h-0">
+      <div class="flex items-center justify-between px-4 py-3 flex-shrink-0">
+        <div class="flex items-center gap-2">
+          <h3 class="text-theme-text-primary font-medium text-sm">Activity</h3>
+          <Show when={jobCount() > 0}>
+            <span class="px-1.5 py-0.5 text-xs rounded-full bg-[var(--color-accent)]/20 text-[var(--color-accent)] border border-[var(--color-accent)]/30 tabular-nums">
+              {jobCount()} live
+            </span>
+          </Show>
+        </div>
+      </div>
+
+      <Show when={hasActiveJobs()}>
+        <div
+          role="status"
+          aria-live="polite"
+          class="px-4 pb-3 border-b border-theme-border space-y-0 divide-y divide-theme-border"
+          style={{ background: "var(--color-bg-subtle)" }}
+        >
+          <p class="text-[10px] font-semibold uppercase tracking-wider text-theme-text-secondary pb-1 pt-0.5">
+            Now Running
+          </p>
+          <For each={jobs()}>
+            {(job) => <ActiveJobRow job={job} />}
+          </For>
+        </div>
+      </Show>
+
+      <div class="flex flex-col flex-1 min-h-0">
+        <div class="px-4 pt-3 pb-2 space-y-1.5 flex-shrink-0">
+          <p class="text-[10px] font-semibold uppercase tracking-wider text-theme-text-secondary">
+            History
+          </p>
+          <div class="flex flex-wrap gap-1">
+            {(["all", "info", "warning", "error"] as const).map((sv) => (
+              <FilterPill
+                label={sv === "all" ? "all" : sv === "warning" ? "warn" : sv}
+                active={severityFilter() === sv}
+                onClick={() => setSeverityFilter(sv)}
+              />
+            ))}
+          </div>
+          <div class="flex flex-wrap gap-1">
+            <FilterPill
+              label="all"
+              active={categoryFilter() === "all"}
+              onClick={() => setCategoryFilter("all")}
+            />
+            <For each={ALL_CATEGORIES}>
+              {(cat) => (
+                <FilterPill
+                  label={CATEGORY_LABELS[cat]}
+                  active={categoryFilter() === cat}
+                  onClick={() => setCategoryFilter(cat)}
+                />
+              )}
+            </For>
+          </div>
+        </div>
+
+        <div
+          ref={listRef}
+          class="flex-1 min-h-0 overflow-y-auto px-4 relative"
+          onScroll={onScroll}
+        >
+          <Show when={newCount() > 0}>
+            <div class="sticky top-2 flex justify-center z-10">
+              <button
+                onClick={jumpToNew}
+                class="px-3 py-1 text-xs rounded-full bg-[var(--color-accent)] text-white shadow-md"
+              >
+                {newCount()} new, click to view
+              </button>
+            </div>
+          </Show>
+
+          <Show when={loading()}>
+            <p class="text-xs text-theme-text-secondary py-4 text-center">Loading...</p>
+          </Show>
+
+          <Show when={!loading() && items().length === 0}>
+            <p class="text-xs text-theme-text-secondary py-4">No activity recorded yet.</p>
+          </Show>
+
+          <Show when={!loading()}>
+            <div class="space-y-0">
+              <For each={items()}>
+                {(event) => <HistoryRow event={event} />}
+              </For>
+            </div>
+
+            <Show when={nextCursor() !== null}>
+              <div class="py-3 text-center">
+                <button
+                  onClick={loadMore}
+                  disabled={loadingMore()}
+                  class="px-4 py-1.5 text-xs border border-theme-border text-theme-text-secondary rounded hover:text-theme-text-primary hover:border-theme-border-em transition-colors disabled:opacity-50"
+                >
+                  {loadingMore() ? "Loading..." : "Load older"}
+                </button>
+              </div>
+            </Show>
+          </Show>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ActivityFeed;
+```
+
+- [ ] **Step 2: Mount the redesigned component in ScanManager.**
+
+In `ScanManager.tsx`, replace the existing `<ActivityFeed ...props />` with the prop-less version:
+
+```tsx
+<ActivityFeed />
+```
+
+Remove the old `activity` signal, `refreshActivity`, `clearActivity`, and the `createEffect` that drove them.
+
+- [ ] **Step 3: Verify compilation.**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: zero errors.
+
+**Manual verification:** Navigate to `http://localhost:3000` Settings > Library. Confirm the Activity card shows a header, empty Now Running (hidden), History region with severity and category filter pills. Trigger a scan via Scan Now and verify the scan appears in Now Running with a progress bar and the header badge shows "1 live". After the scan completes the region collapses to 0h.
+
+---
+
+### Task 105: Create detail renderer components
+
+**Files:**
+- Create: `frontend/src/components/activity/FailedFilesList.tsx`
+- Create: `frontend/src/components/activity/EnrichmentFailureList.tsx`
+- Create: `frontend/src/components/activity/DetailsJsonFallback.tsx`
+
+- [ ] **Step 1: Create `FailedFilesList.tsx`.**
+
+```tsx
+import { Component, For, Show } from "solid-js";
+
+interface FailedFile {
+  path: string;
+  reason: string;
+}
+
+const DISPLAY_LIMIT = 10;
+
+const FailedFilesList: Component<{
+  files: FailedFile[];
+  truncated: boolean;
+}> = (props) => {
+  const shown = () => props.files.slice(0, DISPLAY_LIMIT);
+  const overflow = () => props.files.length - DISPLAY_LIMIT;
+
+  return (
+    <div class="space-y-1 mt-1 max-h-48 overflow-y-auto">
+      <For each={shown()}>
+        {(f) => (
+          <div class="border border-theme-border rounded px-2 py-1">
+            <div class="text-xs text-theme-text-secondary break-all font-mono">
+              {f.path}
+            </div>
+            <div
+              class="text-xs text-[var(--color-warning)] truncate"
+              title={f.reason}
+            >
+              {f.reason}
+            </div>
+          </div>
+        )}
+      </For>
+      <Show when={overflow() > 0}>
+        <p class="text-xs text-theme-text-secondary pl-1">
+          {overflow()} more file{overflow() > 1 ? "s" : ""}
+        </p>
+      </Show>
+      <Show when={props.truncated}>
+        <p class="text-xs text-[var(--color-warning)] pl-1">
+          List truncated at 500 entries.
+        </p>
+      </Show>
+    </div>
+  );
+};
+
+export default FailedFilesList;
+```
+
+- [ ] **Step 2: Create `EnrichmentFailureList.tsx`.**
+
+```tsx
+import { Component, For, Show } from "solid-js";
+
+interface FailedTarget {
+  name: string;
+  reason?: string;
+}
+
+const DISPLAY_LIMIT = 10;
+
+const EnrichmentFailureList: Component<{ targets: FailedTarget[] }> = (props) => {
+  const shown = () => props.targets.slice(0, DISPLAY_LIMIT);
+  const overflow = () => props.targets.length - DISPLAY_LIMIT;
+
+  return (
+    <div class="space-y-1 mt-1 max-h-48 overflow-y-auto">
+      <For each={shown()}>
+        {(t) => (
+          <div class="flex items-start gap-2 py-0.5">
+            <span class="text-xs text-theme-text-primary font-medium">{t.name}</span>
+            <Show when={t.reason}>
+              <span class="text-xs text-theme-text-secondary">{t.reason}</span>
+            </Show>
+          </div>
+        )}
+      </For>
+      <Show when={overflow() > 0}>
+        <p class="text-xs text-theme-text-secondary pl-1">
+          {overflow()} more target{overflow() > 1 ? "s" : ""}
+        </p>
+      </Show>
+    </div>
+  );
+};
+
+export default EnrichmentFailureList;
+```
+
+- [ ] **Step 3: Create `DetailsJsonFallback.tsx`.**
+
+```tsx
+import { Component } from "solid-js";
+
+const DetailsJsonFallback: Component<{ details: Record<string, unknown> }> = (props) => {
+  const formatted = () => {
+    try {
+      return JSON.stringify(props.details, null, 2);
+    } catch {
+      return String(props.details);
+    }
+  };
+
+  return (
+    <pre class="text-xs text-theme-text-secondary bg-theme-base/50 border border-theme-border rounded p-2 overflow-x-auto max-h-40 font-mono whitespace-pre-wrap break-all">
+      {formatted()}
+    </pre>
+  );
+};
+
+export default DetailsJsonFallback;
+```
+
+- [ ] **Step 4: Verify compilation.**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: zero errors.
+
+**Manual verification:** If any history row has details (chevron shown), click the row. Expect a file list or JSON block to appear inline.
+
+---
+
+### Task 106: Create `emitWithToast()` helper and update Toast for persist mode
+
+**Files:**
+- Create: `frontend/src/lib/emitWithToast.ts`
+- Modify: `frontend/src/components/Toast.tsx`
+
+- [ ] **Step 1: Write the helper.**
+
+```ts
+import { showToast, dismissToast } from "../components/Toast";
+import { track } from "../store/taskPoller";
+import type { ActiveJob } from "../types";
+
+interface EmitWithToastOptions {
+  action: () => Promise<{ task_id: string }>;
+  pendingLabel: string;
+  successLabel: string;
+  errorLabel: string;
+  category: ActiveJob["category"];
+  taskLabel: string;
+  taskSubLabel?: string;
+  timeout?: number;
+}
+
+export async function emitWithToast(opts: EmitWithToastOptions): Promise<void> {
+  showToast(opts.pendingLabel, "info", 120_000);
+
+  let taskId: string;
+  try {
+    const result = await opts.action();
+    taskId = result.task_id;
+  } catch {
+    dismissToast();
+    showToast(opts.errorLabel, "error", 0);
+    return;
+  }
+
+  track({
+    id: taskId,
+    category: opts.category,
+    label: opts.taskLabel,
+    subLabel: opts.taskSubLabel,
+    timeout: opts.timeout ?? 300_000,
+    onSuccess: () => {
+      dismissToast();
+      showToast(opts.successLabel, "success", 3000);
+    },
+    onFailure: (error) => {
+      dismissToast();
+      showToast(`${opts.errorLabel}: ${error}`, "error", 0);
+    },
+  });
+}
+```
+
+- [ ] **Step 2: Update `Toast.tsx` for persist mode + dismiss button.**
+
+Support `duration = 0` meaning persist until `dismissToast()` is called. Add a dismiss button to the toast markup.
+
+```ts
+export function showToast(
+  message: string,
+  type: "success" | "error" | "info" = "success",
+  duration = 3000,
+) {
+  clearTimeout(timeout);
+  setToast({ message, type });
+  if (duration > 0) {
+    timeout = setTimeout(() => setToast(null), duration);
+  }
+}
+
+export function dismissToast() {
+  clearTimeout(timeout);
+  setToast(null);
+}
+```
+
+In the toast component JSX, after the message span, add:
+
+```tsx
+<button
+  onClick={() => setToast(null)}
+  class="opacity-60 hover:opacity-100 transition-opacity ml-1"
+  aria-label="Dismiss"
+>
+  ✕
+</button>
+```
+
+- [ ] **Step 3: Verify compilation.**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: zero errors.
+
+**Manual verification:** Exercised in Tasks 107-109.
+
+---
+
+### Task 107: Refactor `MergesTab.tsx` to use `emitWithToast()`
+
+**Files:**
+- Modify: `frontend/src/components/settings/MergesTab.tsx`
+
+- [ ] **Step 1: Add import.**
+
+```ts
+import { emitWithToast } from "../../lib/emitWithToast";
+```
+
+Remove any now-unused imports of `pollTask` from the old inline polling code.
+
+- [ ] **Step 2: Replace `handleDetect`.**
+
+```ts
+const handleDetect = async () => {
+  if (detecting()) return;
+  setDetecting(true);
+  await emitWithToast({
+    action: () => api.triggerDuplicateDetection(),
+    pendingLabel: "Detecting duplicates...",
+    successLabel: "Duplicate detection complete",
+    errorLabel: "Duplicate detection failed",
+    category: "scan",
+    taskLabel: "Duplicate detection",
+    timeout: 120_000,
+  });
+  setDetecting(false);
+  refresh();
+};
+```
+
+Remove the old `stopPolling` ref and its `onCleanup`.
+
+- [ ] **Step 3: Verify compilation.**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: zero errors.
+
+**Manual verification:** Navigate to Settings > Target Management. Click Run Detection. Expect info toast "Detecting duplicates...", job appears in Now Running. On completion, success toast replaces the info toast and auto-dismisses after 3 seconds.
+
+---
+
+### Task 108: Refactor `MosaicsTab.tsx` for mosaic detection
+
+**Files:**
+- Modify: `frontend/src/components/settings/MosaicsTab.tsx`
+
+- [ ] **Step 1: Add import.**
+
+```ts
+import { emitWithToast } from "../../lib/emitWithToast";
+```
+
+- [ ] **Step 2: Replace `handleDetect`.**
+
+```ts
+const handleDetect = async () => {
+  if (detecting()) return;
+  setDetecting(true);
+  await emitWithToast({
+    action: () => api.triggerMosaicDetection() as Promise<{ task_id: string }>,
+    pendingLabel: "Running mosaic detection...",
+    successLabel: "Mosaic detection complete",
+    errorLabel: "Mosaic detection failed",
+    category: "mosaic",
+    taskLabel: "Mosaic detection",
+    timeout: 120_000,
+  });
+  setDetecting(false);
+  refresh(true);
+};
+```
+
+- [ ] **Step 3: Verify compilation.**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: zero errors.
+
+**Manual verification:** Navigate to Settings > Mosaics. Click Run Detection. Info toast + Now Running entry + success toast on completion.
+
+---
+
+### Task 109: Refactor `MaintenanceActions.tsx` for all six triggers
+
+**Files:**
+- Modify: `frontend/src/components/MaintenanceActions.tsx`
+- Modify: `frontend/src/components/ScanManager.tsx`
+
+- [ ] **Step 1: Rewrite `MaintenanceActions.tsx` with no props.**
+
+Each maintenance handler calls `emitWithToast()`. Preserve all the existing confirm dialogs and button styles. Full component structure per spec mockup retained. Key handlers:
+
+```tsx
+const fixOrphans = () => run(() => emitWithToast({
+  action: () => api.smartRebuildTargets() as Promise<{ task_id: string }>,
+  pendingLabel: "Starting Fix Orphans...",
+  successLabel: "Fix Orphans complete",
+  errorLabel: "Fix Orphans failed",
+  category: "rebuild",
+  taskLabel: "Fix Orphans",
+  timeout: 600_000,
+}));
+
+const reResolve = () => run(() => emitWithToast({
+  action: () => api.retryUnresolved() as Promise<{ task_id: string }>,
+  pendingLabel: "Starting Re-resolve...",
+  successLabel: "Re-resolve complete",
+  errorLabel: "Re-resolve failed",
+  category: "enrichment",
+  taskLabel: "Re-resolve targets",
+  timeout: 600_000,
+}));
+
+const catalogMatch = () => run(() => emitWithToast({
+  action: () => api.triggerXmatchEnrichment() as Promise<{ task_id: string }>,
+  pendingLabel: "Starting Catalog Match...",
+  successLabel: "Catalog Match complete",
+  errorLabel: "Catalog Match failed",
+  category: "enrichment",
+  taskLabel: "Catalog Match",
+  timeout: 600_000,
+}));
+
+const fetchDss = (forceAll: boolean) => run(() => emitWithToast({
+  action: () => api.triggerReferenceThumbnails(forceAll) as Promise<{ task_id: string }>,
+  pendingLabel: "Starting DSS fetch...",
+  successLabel: "DSS fetch complete",
+  errorLabel: "DSS fetch failed",
+  category: "thumbnail",
+  taskLabel: forceAll ? "Fetch DSS (all)" : "Fetch DSS (missing)",
+  timeout: 600_000,
+}));
+
+const regenThumbs = (purge: boolean) => run(() => emitWithToast({
+  action: () => api.regenerateThumbnails({ purge }) as Promise<{ task_id: string }>,
+  pendingLabel: purge ? "Deleting and regenerating thumbnails..." : "Regenerating thumbnails...",
+  successLabel: "Thumbnail regeneration complete",
+  errorLabel: "Thumbnail regeneration failed",
+  category: "thumbnail",
+  taskLabel: purge ? "Regen Thumbnails (purge)" : "Regen Thumbnails",
+  timeout: 1_800_000,
+}));
+
+const fullRebuild = () => run(() => emitWithToast({
+  action: () => api.rebuildTargets() as Promise<{ task_id: string }>,
+  pendingLabel: "Starting Full Rebuild...",
+  successLabel: "Full Rebuild complete",
+  errorLabel: "Full Rebuild failed",
+  category: "rebuild",
+  taskLabel: "Full Rebuild",
+  timeout: 3_600_000,
+}));
+```
+
+Where `run` is a small wrapper managing `busy()`/dialog visibility:
+
+```ts
+const [busy, setBusy] = createSignal(false);
+const run = async (fn: () => Promise<void>) => {
+  if (busy()) return;
+  setBusy(true);
+  setShowFullConfirm(false);
+  setShowRefThumbChoice(false);
+  setShowRegenChoice(false);
+  setConfirmPurgeRegen(false);
+  try { await fn(); } finally { setBusy(false); }
+};
+```
+
+Remove all props from `MaintenanceActions`; the component is now self-contained.
+
+- [ ] **Step 2: Update `ScanManager.tsx` to drop `MaintenanceActions` props.**
+
+Replace `<MaintenanceActions ... />` with `<MaintenanceActions />`.
+
+- [ ] **Step 3: Verify compilation.**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: zero errors.
+
+**Manual verification:** Navigate to Settings > Library. Click each maintenance button. Each fires an info toast, shows an entry in Now Running, and emits a success toast on completion. Confirm the Full Rebuild confirmation dialog still works and that post-confirm the job appears in Now Running.
+
+---
+
+### Task 110: Create `errorToastPoller.ts`
+
+**Files:**
+- Create: `frontend/src/store/errorToastPoller.ts`
+
+- [ ] **Step 1: Write the module.**
+
+```ts
+import { showToast } from "../components/Toast";
+import { api } from "../api/client";
+
+const LS_KEY = "galactilog_last_error_ts";
+
+function getLastSeenTs(): string {
+  try {
+    return localStorage.getItem(LS_KEY) ?? new Date(0).toISOString();
+  } catch {
+    return new Date(0).toISOString();
+  }
+}
+
+function setLastSeenTs(ts: string): void {
+  try {
+    localStorage.setItem(LS_KEY, ts);
+  } catch { /* ignore */ }
+}
+
+let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+async function checkErrors(): Promise<void> {
+  const since = getLastSeenTs();
+  try {
+    const res = await api.fetchActivityErrorsSince(since);
+    if (res.items.length === 0) return;
+
+    setLastSeenTs(res.items[0].timestamp);
+
+    const toShow = res.items.slice(0, 3);
+    for (const item of toShow) {
+      const msg = `[${item.category}] ${item.message} (ref #${item.id})`;
+      showToast(msg, "error", 0);
+    }
+    if (res.items.length > 3) {
+      showToast(`${res.items.length - 3} more errors, check the Activity log`, "error", 0);
+    }
+  } catch { /* non-blocking */ }
+}
+
+export function startErrorToastPoller(): void {
+  if (pollTimer) return;
+  checkErrors();
+  pollTimer = setInterval(checkErrors, 10_000);
+}
+
+export function stopErrorToastPoller(): void {
+  if (pollTimer) {
+    clearInterval(pollTimer);
+    pollTimer = null;
+  }
+}
+```
+
+- [ ] **Step 2: Verify compilation.**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: zero errors.
+
+**Manual verification:** Mounted in Task 111.
+
+---
+
+### Task 111: Mount the error poller at app root
+
+**Files:**
+- Modify: `frontend/src/App.tsx`
+
+- [ ] **Step 1: Wire the poller to auth state.**
+
+```tsx
+import { type Component, type ParentProps, Show, createEffect } from "solid-js";
+import { useLocation } from "@solidjs/router";
+import NavBar from "./components/NavBar";
+import { Toast } from "./components/Toast";
+import { useAuth } from "./components/AuthProvider";
+import {
+  startErrorToastPoller,
+  stopErrorToastPoller,
+} from "./store/errorToastPoller";
+
+const ErrorPollerMount: Component = () => {
+  const { user } = useAuth();
+
+  createEffect(() => {
+    if (user() !== null) {
+      startErrorToastPoller();
+    } else {
+      stopErrorToastPoller();
+    }
+  });
+
+  return null;
+};
+
+const App: Component<ParentProps> = (props) => {
+  const location = useLocation();
+
+  return (
+    <div class="min-h-screen bg-theme-base text-theme-text-primary relative z-10">
+      <Show when={location.pathname !== "/login"}>
+        <NavBar />
+        <ErrorPollerMount />
+      </Show>
+      {props.children}
+      <Toast />
+    </div>
+  );
+};
+
+export default App;
+```
+
+- [ ] **Step 2: Verify compilation.**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: zero errors.
+
+**Manual verification:** Log in. In the browser console run `localStorage.setItem("galactilog_last_error_ts", new Date(0).toISOString())`. Within 10 seconds, if any error-severity rows exist, persistent error toasts appear. Click the dismiss button and confirm they close.
+
+---
+
+### Task 112: Add Activity Log section to Settings page
+
+**Files:**
+- Create: `frontend/src/components/settings/ActivityLogTab.tsx`
+- Modify: `frontend/src/pages/SettingsPage.tsx`
+
+- [ ] **Step 1: Create `ActivityLogTab.tsx`.**
+
+```tsx
+import { Component, createSignal, onMount, Show } from "solid-js";
+import { api } from "../../api/client";
+import { useAuth } from "../AuthProvider";
+import { showToast } from "../Toast";
+
+const ActivityLogTab: Component = () => {
+  const { isAdmin } = useAuth();
+  const [retentionDays, setRetentionDays] = createSignal(90);
+  const [saving, setSaving] = createSignal(false);
+  const [clearing, setClearing] = createSignal(false);
+  const [showClearConfirm, setShowClearConfirm] = createSignal(false);
+  const [loading, setLoading] = createSignal(true);
+
+  onMount(async () => {
+    try {
+      const s = await api.getActivitySettings();
+      setRetentionDays(s.activity_retention_days);
+    } catch { /* ignore */ } finally {
+      setLoading(false);
+    }
+  });
+
+  const handleSave = async () => {
+    if (saving()) return;
+    setSaving(true);
+    try {
+      const res = await api.setActivitySettings({ retention_days: retentionDays() });
+      setRetentionDays(res.activity_retention_days);
+      showToast("Retention setting saved", "success", 3000);
+    } catch {
+      showToast("Failed to save retention setting", "error", 0);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleClear = async () => {
+    if (clearing()) return;
+    setShowClearConfirm(false);
+    setClearing(true);
+    try {
+      await api.clearActivityLog();
+      showToast("Activity log cleared", "success", 3000);
+    } catch {
+      showToast("Failed to clear activity log", "error", 0);
+    } finally {
+      setClearing(false);
+    }
+  };
+
+  return (
+    <div class="space-y-4">
+      <div class="bg-theme-surface border border-theme-border rounded-[var(--radius-md)] shadow-[var(--shadow-sm)] p-4 space-y-4">
+        <h3 class="text-theme-text-primary font-medium">Activity Log</h3>
+
+        <Show when={loading()}>
+          <p class="text-xs text-theme-text-secondary">Loading...</p>
+        </Show>
+
+        <Show when={!loading()}>
+          <div class="space-y-3">
+            <div class="flex items-center gap-3">
+              <label class="text-sm text-theme-text-secondary w-40 flex-shrink-0">
+                Retention (days)
+              </label>
+              <input
+                type="number"
+                min={1}
+                max={3650}
+                value={retentionDays()}
+                onInput={(e) => {
+                  const v = parseInt(e.currentTarget.value, 10);
+                  if (!isNaN(v) && v >= 1 && v <= 3650) setRetentionDays(v);
+                }}
+                class="w-24 px-2 py-1 text-sm bg-theme-base border border-theme-border rounded text-theme-text-primary focus:outline-none focus:border-theme-accent tabular-nums"
+              />
+              <button
+                onClick={handleSave}
+                disabled={saving() || !isAdmin()}
+                class="px-3 py-1.5 bg-theme-accent/15 text-theme-accent border border-theme-accent/30 rounded text-sm disabled:opacity-50 hover:bg-theme-accent/25 transition-colors"
+              >
+                {saving() ? "Saving..." : "Save"}
+              </button>
+            </div>
+            <p class="text-xs text-theme-text-secondary">
+              Events older than this many days are deleted by the nightly pruner. Min 1, max 3650.
+            </p>
+          </div>
+
+          <Show when={isAdmin()}>
+            <div class="border-t border-theme-border pt-4 space-y-2">
+              <Show when={!showClearConfirm()}>
+                <button
+                  onClick={() => setShowClearConfirm(true)}
+                  disabled={clearing()}
+                  class="px-3 py-1.5 border border-theme-error/50 text-theme-error rounded text-sm disabled:opacity-50 hover:bg-theme-error/20 transition-colors"
+                >
+                  Clear activity log
+                </button>
+              </Show>
+              <Show when={showClearConfirm()}>
+                <div class="bg-theme-error/10 border border-theme-error/40 rounded-[var(--radius-md)] p-3 space-y-2">
+                  <p class="text-sm text-theme-error font-medium">Clear all activity?</p>
+                  <p class="text-xs text-theme-error/70">
+                    This permanently deletes all activity log entries. The action cannot be undone.
+                  </p>
+                  <div class="flex gap-2 pt-1">
+                    <button
+                      onClick={handleClear}
+                      class="px-3 py-1.5 bg-theme-error text-theme-text-primary rounded text-xs font-medium hover:opacity-90 transition-colors"
+                    >
+                      Yes, clear all
+                    </button>
+                    <button
+                      onClick={() => setShowClearConfirm(false)}
+                      class="px-3 py-1.5 border border-theme-border-em text-theme-text-secondary rounded text-xs hover:text-theme-text-primary transition-colors"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              </Show>
+            </div>
+          </Show>
+        </Show>
+      </div>
+    </div>
+  );
+};
+
+export default ActivityLogTab;
+```
+
+- [ ] **Step 2: Register the tab in `SettingsPage.tsx`.**
+
+Lazy import:
+```ts
+const ActivityLogTab = lazy(() => import("../components/settings/ActivityLogTab"));
+```
+
+Add to `ALL_TABS`:
+```ts
+{ id: "activity-log", label: "Activity Log", adminOnly: true },
+```
+
+Add rendering clause:
+```tsx
+<Show when={activeTab() === "activity-log" && isAdmin()}>
+  <ActivityLogTab />
+</Show>
+```
+
+- [ ] **Step 3: Verify compilation.**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: zero errors.
+
+**Manual verification:** Navigate to Settings. Confirm Activity Log tab visible for admin. Change retention to 30, save, expect success toast. Click Clear activity log, confirm, expect the feed to empty.
+
+---
+
+### Task 113: Final integration pass
+
+**Files:**
+- Modify: `frontend/src/types/index.ts`
+- Modify: `frontend/src/components/ScanManager.tsx`
+- Modify: `frontend/src/api/client.ts`
+
+- [ ] **Step 1: Grep for remaining `ActivityEntry` references.**
+
+```
+cd frontend && grep -rn "ActivityEntry" src --include="*.ts" --include="*.tsx"
+```
+
+Replace each with `ActivityEvent` or remove dead references.
+
+- [ ] **Step 2: Clean up `ScanManager.tsx`.**
+
+Remove:
+- `ActivityEntry` import.
+- The `activity` signal, `refreshActivity`, `clearActivity` functions.
+- The `createEffect` that called `refreshActivity`.
+- Any `refreshActivity()` call in the `onMergesChanged` listener (keep `refreshDbSummary()`).
+
+- [ ] **Step 3: Verify `api.getActivity` / `api.clearActivity` callers are gone.**
+
+```
+cd frontend && grep -rn "api.getActivity\|api.clearActivity\b" src
+```
+
+Expected: no matches. All callers use `api.fetchActivity` and `api.clearActivityLog`.
+
+- [ ] **Step 4: Run full TypeScript build.**
+
+```
+cd frontend && npm run build
+```
+
+Expected: zero TypeScript errors. Bundle size warnings are acceptable.
+
+- [ ] **Step 5: Browser smoke test.**
+
+Log in at `http://localhost:3000`:
+
+1. Settings > Library. Activity card renders with History + filter pills.
+2. Click Scan Now. Now Running appears with a progress bar. Header badge shows "1 live". After completion, the region collapses and a history entry appears.
+3. Switch severity filter to warn. List updates. Switch back to all.
+4. Settings > Target Management. Run Detection. Now Running shows "Duplicate detection".
+5. Settings > Activity Log (admin). Retention input shows 90. Set 365, save.
+6. In browser console: `localStorage.setItem("galactilog_last_error_ts", new Date(0).toISOString())`. Within 10s, if errors exist, persistent error toasts appear.
+7. In the feed, click Load older when >50 events exist. Entries append below.
+
+- [ ] **Step 6: Final commit.**
+
+```
+git add frontend/src/types/index.ts frontend/src/components/ScanManager.tsx frontend/src/api/client.ts
+git commit -m "Final activity log integration: remove ActivityEntry, clean up dead code"
+```
+
+---
+
+## Notes for the implementer
+
+- Backend migration revision number (`0011`) is a placeholder. Run `alembic current` and adjust to match your actual head before committing Task 1.
+- Several frontend refactors assume backend trigger endpoints return `{ task_id: string }`. If any still return only `{ status, message }`, add a small follow-up backend task to change them, or add a `/settings/activity` GET/PUT endpoint alongside the GeneralSettings field from Task 16 so the frontend Settings UI (Task 112) has endpoints to call.
+- Per project convention, commits MUST NOT include `Co-Authored-By` or any AI attribution line.

--- a/guides/superpowers/specs/2026-04-15-activity-log-redesign-design.md
+++ b/guides/superpowers/specs/2026-04-15-activity-log-redesign-design.md
@@ -231,13 +231,13 @@ The store exposes `activeJobs: Accessor<ActiveJob[]>` and `hasActiveJobs: Access
 │  [all] [scan] [rebuild] [thumb] [enrich] [mosaic] [migr]│
 │                                                         │
 │  16:42  warn   scan    Scan stalled after 5 min idle  > │
-│  15:20  ok     reb     Rebuild complete, 42 targets     │
+│  15:20  info   reb     Rebuild complete, 42 targets     │
 │  15:20  warn   scan    Scan complete, 12 failures     > │
 │                        expanded:                        │
 │                          file1.fits, header parse error │
 │                          file2.fits, SIP ctype mismatch │
 │                          (10 more)                      │
-│  14:55  ok     user    Merge accepted: NGC 7000 ← NAm   │
+│  14:55  info   user    Merge accepted: NGC 7000 ← NAm   │
 │  14:12  info   migr    Data upgrade v7 → v8 complete    │
 │                                                         │
 │          [ Load older ]                                 │
@@ -274,7 +274,7 @@ New Celery beat task `prune_activity_events`:
 
 - Runs daily at 03:00 local time.
 - Executes `DELETE FROM activity_events WHERE timestamp < now() - interval 'N days'` where N is `activity_retention_days`.
-- Emits one `system` `info` event with `event_type=activity_pruned` and `details.deleted_count=N` only if N > 0.
+- Emits one `system` `info` event with `event_type=activity_pruned` and a `deleted_count` field in `details`, only when `deleted_count > 0`.
 
 ## Rollout
 

--- a/guides/superpowers/specs/2026-04-15-activity-log-redesign-design.md
+++ b/guides/superpowers/specs/2026-04-15-activity-log-redesign-design.md
@@ -1,0 +1,302 @@
+# Activity Log Redesign
+
+Date: 2026-04-15
+Status: approved for planning
+
+## Problem
+
+The Dashboard Activity Log mixes three concerns in one card: live scan progress, live rebuild status, and a 20-entry historical list. Many user-relevant events never reach the log (per-file ingest failures, thumbnail failures, mosaic detection results, mosaic composite failures, Gaia and VizieR failures, migration progress, filename candidate failures, scan filter errors). Toasts are a disconnected channel with ad-hoc firing rules. The result is a surface that feels random: some events appear, some do not, and live status feels bolted on.
+
+## Goals
+
+1. Every user-relevant event reaches a single durable store with severity and category.
+2. Live in-progress jobs render in a clearly separated region from history.
+3. Toasts follow a predictable rule rather than per-callsite judgement.
+4. Historical entries are filterable by severity and category.
+5. Retention is bounded and admin-configurable.
+
+## Non-goals (v1)
+
+- Websocket or SSE push. Polling is retained.
+- Per-target activity view on target detail pages.
+- Text search or target filter in the History region.
+- Activity surface visible outside the Dashboard.
+- Activity export (CSV etc).
+- Cancel controls for Celery-tracked jobs beyond current behavior.
+
+## Architecture
+
+Backend additions:
+
+- `backend/app/models/activity_event.py`: new SQLAlchemy model.
+- `backend/app/services/activity.py`: `emit()` and `emit_sync()` helpers. Single source of truth for activity writes.
+- `backend/app/api/activity.py`: `GET /activity` (paginated, filterable), `DELETE /activity` (admin).
+- `backend/app/worker/prune_activity.py`: nightly Celery beat task.
+- Alembic migration creating `activity_events` with defensive `IF NOT EXISTS` guards per project rules.
+
+Backend retained unchanged:
+
+- `/scan/status`, `/scan/rebuild-status`, `/tasks/{id}/status` endpoints and their Redis-backed state.
+
+Frontend additions:
+
+- `frontend/src/store/activeJobs.ts`: adapter merging scan status, rebuild status, and tracked Celery tasks into one `ActiveJob[]` observable.
+- Extension to `frontend/src/store/taskPoller.ts`: `track({id, category, label, cancelable})` method registers Celery tasks with the active-jobs adapter.
+- `frontend/src/api/client.ts`: new functions for `/activity` endpoints.
+
+Frontend rewritten:
+
+- `frontend/src/components/ActivityFeed.tsx`: single card with Now Running and History regions.
+- Toast firing rules codified in a helper `emitWithToast()`; per-callsite ad-hoc toast code in `MergesTab.tsx`, `MosaicsTab.tsx`, and `MaintenanceActions.tsx` is replaced.
+
+## Data model
+
+Table `activity_events`:
+
+```
+id              bigserial primary key
+timestamp       timestamptz not null default now()
+severity        varchar(16) not null   -- 'info' | 'warning' | 'error'
+category        varchar(32) not null
+event_type      varchar(64) not null
+message         text not null
+details         jsonb                  -- nullable
+target_id       integer                -- nullable, fk targets(id) ON DELETE SET NULL
+actor           varchar(64)            -- nullable
+duration_ms     integer                -- nullable
+
+indexes:
+  idx_activity_timestamp_desc  on (timestamp DESC)
+  idx_activity_severity_ts     on (severity, timestamp DESC)
+  idx_activity_category_ts     on (category, timestamp DESC)
+  idx_activity_target          on (target_id) where target_id is not null
+```
+
+Categories (fixed set, validated in `emit()`):
+
+- `scan`: file discovery, ingest, delta scans, orphan cleanup, stalls
+- `rebuild`: target rebuild (smart, full, cancelled)
+- `thumbnail`: thumbnail purge, regeneration, DSS reference fetch
+- `enrichment`: SIMBAD, VizieR, Gaia, xMatch
+- `mosaic`: mosaic detection, composite generation
+- `migration`: data migration runs (DATA_VERSION bumps)
+- `user_action`: merges accepted, filename candidates accepted, manual deletions
+- `system`: auth, startup, pruner output, catch-all
+
+Severity is `info`, `warning`, or `error`. Validated in the emit helper, not as a DB enum, so future values do not require a migration.
+
+## Emit helper
+
+```python
+async def emit(
+    db: AsyncSession,
+    *,
+    category: str,
+    severity: str,
+    event_type: str,
+    message: str,
+    details: dict | None = None,
+    target_id: int | None = None,
+    actor: str | None = None,
+    duration_ms: int | None = None,
+) -> None:
+    ...
+```
+
+Behavior:
+
+- Validates `severity` and `category` at runtime; raises on invalid values during development, logs and skips in production.
+- Inserts one row into `activity_events`.
+- Publishes a JSON payload to Redis pubsub channel `activity:new` for future push-based UI. Not subscribed to in v1.
+- Never raises to the caller. Emit failures are logged to Python logging only.
+
+`emit_sync()` mirrors the signature for Celery tasks using sync sessions.
+
+## Event backfill
+
+All existing activity writes (17 sites across `scan_state.py`, `scan.py`, `worker/tasks.py`) are refactored to call `emit()` in place of the current Redis-list push. The Redis key `scan:activity` is deleted on startup by the new code.
+
+New emit sites with aggregation where needed:
+
+| Site | event_type | severity | Aggregation |
+|------|-----------|----------|-------------|
+| Per-file ingest failures | `scan_files_failed` | warning | one summary per scan, `details.failed_files: [{path, reason}, ...]` |
+| Thumbnail regen failures | `thumbnail_regen_failed` | warning | one summary per rebuild |
+| Mosaic detection run | `mosaic_detection_complete` | info | one entry per run, `details.candidates: N` |
+| Mosaic composite failures | `mosaic_composite_failed` | error | one per mosaic |
+| Gaia, VizieR failures | `enrichment_query_failed` | warning | one summary per rebuild, `details.failed_targets: [...]` |
+| Migration progress ticks | (skipped) | n/a | only `data_upgrade_complete` and `data_upgrade_failed` survive |
+| Filename candidate failures | `filename_candidate_failed` | warning | one summary per ingest batch |
+| Scan filter invalid | `scan_filter_rejected` | error | one per occurrence |
+
+## API
+
+### `GET /activity`
+
+Auth: user.
+
+Query params:
+
+- `severity`: optional, repeatable. Values: `info`, `warning`, `error`.
+- `category`: optional, repeatable. Values from the fixed category set.
+- `limit`: optional, default 50, max 200.
+- `cursor`: optional, keyset pagination token encoding `(timestamp, id)` of the last row of the previous page.
+- `since`: optional ISO timestamp. Returns only rows with `timestamp > since`. Used by the error-toast poller.
+
+Response:
+
+```json
+{
+  "items": [
+    {
+      "id": 42,
+      "timestamp": "2026-04-15T16:42:10Z",
+      "severity": "warning",
+      "category": "scan",
+      "event_type": "scan_stalled",
+      "message": "Scan stalled after 5 min idle",
+      "details": null,
+      "target_id": null,
+      "actor": "system",
+      "duration_ms": null
+    }
+  ],
+  "next_cursor": "2026-04-15T15:20:00Z:31",
+  "total": 1284
+}
+```
+
+### `DELETE /activity`
+
+Auth: admin. Clears all rows. Replaces existing `DELETE /scan/activity`.
+
+### Settings
+
+One new admin setting:
+
+- `activity_retention_days`: integer, default 90, min 1, max 3650. Stored in the existing `settings` table.
+
+Exposed via the existing Settings page under an Activity Log section, alongside the Clear button.
+
+## Active Jobs adapter
+
+`frontend/src/store/activeJobs.ts`:
+
+```ts
+type ActiveJob = {
+  id: string;                 // 'scan', 'rebuild', or `celery:${taskId}`
+  category: 'scan' | 'rebuild' | 'thumbnail' | 'enrichment' | 'mosaic';
+  label: string;
+  subLabel?: string;
+  progress?: number;          // 0..1, undefined = indeterminate
+  startedAt: number;
+  detail?: string;
+  cancelable: boolean;
+  onCancel?: () => Promise<void>;
+};
+```
+
+Adapters:
+
+- `scanStatusToJob(ScanStatus)`: returns null when state is idle, complete, or stalled. Progress is `completed/total`. Cancel calls existing `POST /scan/stop`.
+- `rebuildStatusToJob(RebuildStatus)`: returns null when idle, complete, error, or cancelled. Progress is indeterminate. Cancel calls existing rebuild stop endpoint.
+- `celeryTaskToJob(trackedTask)`: returns an entry while Celery state is PENDING or STARTED. Not cancelable in v1.
+
+The store exposes `activeJobs: Accessor<ActiveJob[]>` and `hasActiveJobs: Accessor<boolean>`. Existing 2-second polling for scan and Celery is retained. Rebuild poll is aligned to 2 seconds if not already.
+
+`taskPoller.track()` is called by:
+
+- `MergesTab.tsx`: duplicate detection.
+- `MosaicsTab.tsx`: mosaic detection.
+- `MaintenanceActions.tsx`: xMatch enrichment, DSS reference thumbnails, thumbnail regen, smart rebuild, full rebuild, SIMBAD re-resolve.
+
+## Dashboard card layout
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Activity                                     [ 2 live ]│
+├─────────────────────────────────────────────────────────┤
+│  NOW RUNNING                                            │
+│                                                         │
+│  Scanning /mnt/fits                          [  Stop ]  │
+│  2,341 / 5,892 files, 42 files/sec                      │
+│  ████████████░░░░░░░░░░░░░░░░  42%                      │
+│                                                         │
+│  Mosaic composite: NGC 7000 (indeterminate)             │
+│  started 00:42 ago                                      │
+│  ▓▓░░░▓▓░░░▓▓░░                                         │
+├─────────────────────────────────────────────────────────┤
+│  HISTORY                                                │
+│  [ all ]  [ info ]  [ warn ]  [ error ]                 │
+│  [all] [scan] [rebuild] [thumb] [enrich] [mosaic] [migr]│
+│                                                         │
+│  16:42  warn   scan    Scan stalled after 5 min idle  > │
+│  15:20  ok     reb     Rebuild complete, 42 targets     │
+│  15:20  warn   scan    Scan complete, 12 failures     > │
+│                        expanded:                        │
+│                          file1.fits, header parse error │
+│                          file2.fits, SIP ctype mismatch │
+│                          (10 more)                      │
+│  14:55  ok     user    Merge accepted: NGC 7000 ← NAm   │
+│  14:12  info   migr    Data upgrade v7 → v8 complete    │
+│                                                         │
+│          [ Load older ]                                 │
+└─────────────────────────────────────────────────────────┘
+```
+
+Behavior:
+
+- The Now Running region collapses to zero height when `activeJobs.length === 0`. No empty-state placeholder text.
+- The header badge is hidden at zero, visible otherwise.
+- History initial load is 50 entries. `Load older` paginates by 50 using the keyset cursor. Filter changes reset pagination.
+- Row structure: time, severity icon, category label, message, chevron if `details` is present.
+- If `target_id` is set, the target name in the message renders as a link to that target detail page.
+- Expandable rows render `details` via category-aware renderers: `FailedFilesList`, `EnrichmentFailureList`, generic JSON fallback.
+- Styling uses existing theme tokens. Severity icons reuse the existing icon set. Now Running uses a subtly tinted background via `--color-bg-subtle` to distinguish the region without adding a heavy border.
+- Now Running has `role="status" aria-live="polite"`. Rows are keyboard-focusable.
+- New history entries do not auto-scroll. If new entries arrive while the user is scrolled down, a "N new" pill appears at the top and jumps to them on click.
+
+## Toast rules
+
+1. User-initiated action: toast on completion. Applies to merge accept, filename candidate accept, image delete, all maintenance buttons, manual scan start and stop.
+2. Background event: no toast. Includes scheduled scans, migration runs, mosaic detection after ingest.
+3. Exception: any event with severity `error` always toasts, regardless of source. Error toasts persist until dismissed.
+
+Implementation:
+
+- Frontend helper `emitWithToast()` wraps an API call, shows a pending toast, tracks the resulting Celery task via `activeJobs`, and replaces the toast on completion.
+- Background error channel: frontend polls `GET /activity?severity=error&since=<lastSeenErrorTs>` every 10 seconds. New rows trigger error toasts. `lastSeenErrorTs` persists in localStorage.
+- Error toasts include a "View in activity log" link that scrolls the Dashboard card to the matching row. Info and success toasts retain the 3-second auto-dismiss.
+
+## Pruner
+
+New Celery beat task `prune_activity_events`:
+
+- Runs daily at 03:00 local time.
+- Executes `DELETE FROM activity_events WHERE timestamp < now() - interval 'N days'` where N is `activity_retention_days`.
+- Emits one `system` `info` event with `event_type=activity_pruned` and `details.deleted_count=N` only if N > 0.
+
+## Rollout
+
+- Alembic migration creates `activity_events` with defensive guards. No data backfill from the old Redis list; entries there are ephemeral by design.
+- On first startup after deploy, `scan:activity` Redis key is deleted to reclaim memory.
+- Old endpoints `GET /scan/activity` and `DELETE /scan/activity` are removed in the same release. Frontend is updated in the same PR.
+- No feature flag. No `DATA_VERSION` bump (no change to target data derivation).
+
+## Open risks
+
+- High-volume emit during a bad scan: aggregation patterns mitigate, but a pathological scan with thousands of per-file failures still produces one large `details.failed_files` array. Cap `details.failed_files` at 500 entries with a trailing `truncated: true` flag.
+- Retention `min=1` allows an admin to accidentally set retention so short that errors disappear before they are seen. Acceptable: the setting is admin-only.
+- The error toast poller adds one HTTP request every 10 seconds per client. Negligible at expected scale.
+
+## Acceptance checklist
+
+- Every existing activity write site calls `emit()` rather than pushing to the Redis list.
+- Every event site identified in the backfill table writes through `emit()`.
+- The Dashboard Activity card renders Now Running and History regions as specified, with severity and category filters.
+- Active jobs from scan, rebuild, and at least one Celery task (merges duplicate detection) appear in Now Running simultaneously without visual regression.
+- User-initiated actions toast on completion; background non-error events do not toast.
+- Background errors trigger a toast regardless of current page.
+- Admin Settings page exposes `activity_retention_days` and the Clear button.
+- Pruner runs nightly and deletes rows older than the configured window.
+- Old `/scan/activity` endpoints are removed. Old Redis key is deleted on startup.

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,8 +1,15 @@
+# Note: `pid` and `error_log` belong in the main nginx.conf (http{} parent scope)
+# and are redirected there via sed in the Dockerfile. This file is included from
+# conf.d/*.conf inside http{}, so only server-context directives go here.
 server {
     listen 80;
     server_name _;
     root /usr/share/nginx/html;
     index index.html;
+
+    access_log /var/log/nginx/access.log;
+    # Note: *_temp_path directives are http-context only; they are injected into
+    # the main /etc/nginx/nginx.conf via sed in the Dockerfile.
 
     # Security headers (HSTS omitted - only effective over HTTPS; add to TLS terminator)
     add_header X-Frame-Options "DENY" always;

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,11 +1,23 @@
 [supervisord]
 nodaemon=true
-user=root
 logfile=/dev/null
 logfile_maxbytes=0
-pidfile=/var/run/supervisord.pid
+pidfile=/app/run/supervisord.pid
+
+[unix_http_server]
+file=/app/run/supervisor.sock
+chmod=0700
+
+[supervisorctl]
+serverurl=unix:///app/run/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory=supervisor.rpcinterface:make_main_rpcinterface
 
 [program:nginx]
+; Master runs as root so it can open /dev/stdout and /dev/stderr (owned by
+; PID 1 root) for access/error logs. Worker processes drop to galactilog via
+; the `user` directive in /etc/nginx/nginx.conf.
 command=nginx -g "daemon off;"
 priority=10
 autostart=true
@@ -21,6 +33,8 @@ directory=/app
 priority=20
 autostart=true
 autorestart=true
+user=galactilog
+environment=HOME="/tmp",USER="galactilog"
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/fd/2
@@ -32,17 +46,21 @@ directory=/app
 priority=30
 autostart=true
 autorestart=true
+user=galactilog
+environment=HOME="/tmp",USER="galactilog"
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/fd/2
 stderr_logfile_maxbytes=0
 
 [program:celery-beat]
-command=celery -A app.worker.celery_app beat --loglevel=info --schedule /tmp/celerybeat-schedule
+command=celery -A app.worker.celery_app beat --loglevel=info --schedule /app/run/celerybeat-schedule
 directory=/app
 priority=25
 autostart=true
 autorestart=true
+user=galactilog
+environment=HOME="/tmp",USER="galactilog"
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/fd/2


### PR DESCRIPTION
**Summary**:
This pull request implements a complete redesign of the activity log, introducing persistent storage, detailed task tracking, and new user controls. It also establishes a unified toast notification system for consistent user feedback on background operations and errors.

**Changes**:
*   **Activity Log System:**
    *   Introduced `ActivityEvent` SQLAlchemy model and `activity_events` table migration for persistent storage.
    *   Implemented `activity` Pydantic schemas and `emit()`, `emit_sync()` service helpers for logging.
    *   Added `GET /activity` and `DELETE /activity` API endpoints, replacing deprecated `/scan/activity` endpoints.
    *   Integrated `activity` API client functions for frontend interaction.
    *   Added `prune_activity_events` Celery beat task for daily log retention, configurable via `activity_retention_days` in `GeneralSettings`.
    *   Refactored numerous backend tasks (rebuild, thumbnail generation, migration, scan, mosaic composite) to use `emit_sync` for consistent activity logging.
    *   Added new aggregation emit sites for `thumbnail_regen_failed`, `enrichment_query_failed`, `filename_candidate_failed`, `mosaic_composite_failed`, and `mosaic_detection_complete`.
    *   Corrected `Now Running` entries that previously failed to clear by returning `task_id` from `rebuild`, `regen`, and `enrichment` endpoints.
*   **Frontend Task Management & UI:**
    *   Redesigned the `ActivityFeed` with distinct `Now Running` and `History` sections.
    *   Created an `activeJobs` store to centralize and merge scan, rebuild, and Celery task states.
    *   Integrated `track()` into `taskPoller` for registering Celery jobs.
    *   Added a dedicated `Activity Log` tab to `Settings` with controls for retention and clearing activity events.
    *   Updated frontend activity types in `frontend/src/types/index.ts`.
*   **Unified Toast Notifications:**
    *   Implemented an `emitWithToast` helper and a `persist` mode for the `Toast` component.
    *   Refactored `MaintenanceActions`, `MosaicsTab`, and `MergesTab` to use `emitWithToast` for consistent user feedback.
    *   Introduced an `errorToastPoller` store module for polling and displaying activity errors as toasts.
    *   Mounted the `errorToastPoller` at the application root, activated upon user authentication.
    *   Enabled toast stacking, implemented silent task-poller timeouts, and canceled superseded trackers to prevent stale notifications.
    *   Ensured `emitWithToast` terminal callbacks execute only for the latest invocation.
*   **Container Permissions:**
    *   Configured the container to run as a non-root `galactilog` user with PUID/PGID remapping, resolving bind-mount permission issues.

**Impact**:
*   **User Experience:** Significantly improved activity visibility, task tracking, and real-time feedback through unified toast notifications. New controls for activity log management.
*   **Backend API:** Introduction of new `/activity` endpoints and removal of legacy `/scan/activity` endpoints. Modifications to task-related API responses.
*   **Database Schema:** Addition of the `activity_events` table.
*   **Task Management System:** Centralized and robust system for tracking all background operations, including Celery tasks, scans, and rebuilds.
*   **Error Handling:** Standardized and more visible error reporting mechanism.
*   **Configuration:** New `activity_retention_days` setting for administrators.
*   **Deployment:** Enhanced container security and bind-mount compatibility due to non-root user execution.