### PR TITLE
Implement panel deletion and 'As new panel' option

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -658,10 +658,10 @@ export const api = {
   deleteMosaic: (id: string) =>
     fetchJson<{ status: string }>(`/mosaics/${id}`, { method: "DELETE" }),
 
-  addMosaicPanel: (mosaicId: string, targetId: string, label: string) =>
+  addMosaicPanel: (mosaicId: string, targetId: string, label: string, objectPattern?: string | null) =>
     fetchJson<{ status: string; panel_id: string }>(`/mosaics/${mosaicId}/panels`, {
       method: "POST",
-      body: JSON.stringify({ target_id: targetId, panel_label: label }),
+      body: JSON.stringify({ target_id: targetId, panel_label: label, object_pattern: objectPattern }),
     }),
 
   updateMosaicPanel: (

--- a/frontend/src/pages/MosaicDetailPage.tsx
+++ b/frontend/src/pages/MosaicDetailPage.tsx
@@ -269,6 +269,37 @@ const MosaicDetailPage: Component = () => {
                     refetch();
                   };
 
+                  const suggestNextLabel = (label: string): string => {
+                    const m = label.match(/^(.*) \(([a-z])\)$/i);
+                    if (m) {
+                      const nextChar = String.fromCharCode(m[2].charCodeAt(0) + 1);
+                      return `${m[1]} (${nextChar})`;
+                    }
+                    return `${label} (b)`;
+                  };
+
+                  const handleIncludeAsNewPanel = async (sessionDate: string) => {
+                    const data = mosaic();
+                    if (!data) return;
+                    const suggested = suggestNextLabel(panel.panel_label);
+                    const newLabel = window.prompt("New panel label:", suggested);
+                    if (!newLabel || !newLabel.trim()) return;
+                    const label = newLabel.trim();
+                    try {
+                      const res = await api.addMosaicPanel(
+                        data.id,
+                        panel.target_id,
+                        label,
+                        panel.object_pattern ?? null,
+                      );
+                      await api.updatePanelSessions(data.id, res.panel_id, [sessionDate], []);
+                      showToast(`Created panel '${label}' with session`);
+                      refetch();
+                    } catch (err) {
+                      showToast(`Failed to create panel: ${err instanceof Error ? err.message : String(err)}`, "error", 5000);
+                    }
+                  };
+
                   return (
                     <div class="border border-theme-border rounded-[var(--radius-sm)] overflow-hidden">
                       <button
@@ -365,12 +396,20 @@ const MosaicDetailPage: Component = () => {
                                         <td class="px-2 py-1 text-right text-theme-text-secondary">{sess.total_frames}</td>
                                         <td class="px-2 py-1 text-right text-theme-text-secondary">{formatIntegration(sess.total_integration_seconds)}</td>
                                         <td class="px-2 py-1 text-right">
-                                          <button
-                                            onClick={() => handleInclude([sess.session_date])}
-                                            class="text-xs text-theme-accent hover:underline"
-                                          >
-                                            Include
-                                          </button>
+                                          <div class="flex gap-2 justify-end">
+                                            <button
+                                              onClick={() => handleInclude([sess.session_date])}
+                                              class="text-xs text-theme-accent hover:underline"
+                                            >
+                                              Include
+                                            </button>
+                                            <button
+                                              onClick={() => handleIncludeAsNewPanel(sess.session_date)}
+                                              class="text-xs text-theme-accent hover:underline"
+                                            >
+                                              As new panel
+                                            </button>
+                                          </div>
                                         </td>
                                       </tr>
                                     )}

--- a/frontend/src/pages/MosaicDetailPage.tsx
+++ b/frontend/src/pages/MosaicDetailPage.tsx
@@ -422,6 +422,28 @@ const MosaicDetailPage: Component = () => {
                           <Show when={!panelSessions.loading && included().length === 0 && available().length === 0}>
                             <div class="p-3 text-xs text-theme-text-secondary">No sessions found for this panel.</div>
                           </Show>
+
+                          <Show when={included().length === 0 && !panelSessions.loading}>
+                            <div class="p-3 border-t border-theme-border/50 flex justify-end">
+                              <button
+                                onClick={async () => {
+                                  if (!window.confirm(`Delete panel "${panel.panel_label}"?`)) return;
+                                  const data = mosaic();
+                                  if (!data) return;
+                                  try {
+                                    await api.removeMosaicPanel(data.id, panel.panel_id);
+                                    showToast(`Deleted panel "${panel.panel_label}"`);
+                                    refetch();
+                                  } catch {
+                                    showToast("Failed to delete panel", "error");
+                                  }
+                                }}
+                                class="text-xs text-theme-text-secondary hover:text-theme-danger transition-colors"
+                              >
+                                Delete panel
+                              </button>
+                            </div>
+                          </Show>
                         </div>
                       </Show>
                     </div>


### PR DESCRIPTION
**Summary**
This PR introduces the ability to delete panels that contain no sessions and adds an option to create a new panel when including mosaic sessions.

**Changes**
*   Add a delete button to panels that do not contain any included sessions.
*   Introduce an "As new panel" option when including mosaic sessions.

**Impact**
*   `frontend/src/api/client.ts`: Updates to the API client to support new panel operations.
*   `frontend/src/pages/MosaicDetailPage.tsx`: Modifications to the Mosaic Detail Page UI and logic to display the delete panel button and the "As new panel" option.