### PR TITLE
Add Metrics Tab to Settings Page for Admins

### DIFF
--- a/frontend/src/components/settings/MetricsTab.tsx
+++ b/frontend/src/components/settings/MetricsTab.tsx
@@ -1,0 +1,832 @@
+import { Component, createEffect, createMemo, createResource, createSignal, For, onCleanup, Show } from "solid-js";
+import { parsePrometheusText, type MetricFamily } from "../../utils/prometheusParse";
+import { aggregate, emptyPrev, type Health, type PrevCounters } from "../../utils/metricsAggregate";
+
+type RefreshOption = "off" | "5" | "15" | "30" | "60";
+
+interface Snapshot {
+  families: MetricFamily[];
+  fetchedAt: Date;
+}
+
+const ChevronIcon: Component<{ size?: number }> = (props) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={props.size ?? 12} height={props.size ?? 12} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+    <polyline points="9 18 15 12 9 6" />
+  </svg>
+);
+
+const CopyIcon: Component = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+  </svg>
+);
+
+function formatNumber(n: number, digits = 1): string {
+  if (!isFinite(n)) return "0";
+  if (Math.abs(n) >= 1000) return Math.round(n).toLocaleString();
+  return n.toFixed(digits);
+}
+
+function formatInt(n: number): string {
+  if (!isFinite(n)) return "0";
+  return Math.round(n).toLocaleString();
+}
+
+function formatMs(ms: number): string {
+  if (!isFinite(ms) || ms <= 0) return "0 ms";
+  if (ms < 1) return `${ms.toFixed(2)} ms`;
+  if (ms < 10) return `${ms.toFixed(1)} ms`;
+  if (ms < 1000) return `${Math.round(ms)} ms`;
+  return `${(ms / 1000).toFixed(2)} s`;
+}
+
+function formatSeconds(s: number): string {
+  if (!isFinite(s) || s <= 0) return "0 s";
+  if (s < 1) return `${Math.round(s * 1000)} ms`;
+  if (s < 60) return `${s.toFixed(1)} s`;
+  if (s < 3600) return `${Math.round(s / 60)} min`;
+  return `${(s / 3600).toFixed(1)} h`;
+}
+
+function formatBytes(b: number): string {
+  if (!isFinite(b) || b <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let i = 0;
+  let v = b;
+  while (v >= 1024 && i < units.length - 1) { v /= 1024; i++; }
+  return `${v.toFixed(v >= 100 ? 0 : 1)} ${units[i]}`;
+}
+
+function formatUptime(s: number): string {
+  if (!isFinite(s) || s <= 0) return "0m";
+  const d = Math.floor(s / 86400);
+  const h = Math.floor((s % 86400) / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  if (d > 0) return `${d}d ${h}h ${m}m`;
+  if (h > 0) return `${h}h ${m}m`;
+  return `${m}m`;
+}
+
+function formatDateTime(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+}
+
+function statusColorClass(status: string): string {
+  const sc = parseInt(status, 10);
+  if (isNaN(sc)) return "text-theme-text-secondary";
+  if (sc >= 500) return "text-red-400";
+  if (sc >= 400) return "text-amber-400";
+  if (sc >= 300) return "text-blue-400";
+  return "text-green-400";
+}
+
+const StatusPill: Component<{ health: Health }> = (props) => {
+  const label = () => props.health === "green" ? "Healthy" : props.health === "amber" ? "Degraded" : "Unhealthy";
+  const classes = () => {
+    if (props.health === "green") return "bg-green-900/40 text-green-300";
+    if (props.health === "amber") return "bg-amber-900/40 text-amber-300";
+    return "bg-red-900/40 text-red-300";
+  };
+  const dotClass = () => {
+    if (props.health === "green") return "bg-green-500";
+    if (props.health === "amber") return "bg-amber-500";
+    return "bg-red-500";
+  };
+  return (
+    <span class={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium ${classes()}`}>
+      <span class={`w-1.5 h-1.5 rounded-full ${dotClass()}`} />
+      {label()}
+    </span>
+  );
+};
+
+const Card: Component<{ children: any; class?: string }> = (props) => (
+  <div class={`rounded-[var(--radius-md)] bg-theme-surface border border-theme-border ${props.class ?? ""}`}>
+    {props.children}
+  </div>
+);
+
+const Kpi: Component<{ value: string; label: string }> = (props) => (
+  <div>
+    <div class="text-2xl tabular-nums text-theme-text-primary">{props.value}</div>
+    <div class="text-xs text-theme-text-secondary mt-1">{props.label}</div>
+  </div>
+);
+
+const DetailsToggle: Component<{ summary: any; children: any }> = (props) => (
+  <details class="group">
+    <summary class="flex items-center gap-2 text-xs text-theme-text-secondary hover:text-theme-text-primary cursor-pointer list-none [&::-webkit-details-marker]:hidden">
+      <span class="transition-transform duration-150 group-open:rotate-90"><ChevronIcon /></span>
+      {props.summary}
+    </summary>
+    <div class="mt-4 space-y-4">{props.children}</div>
+  </details>
+);
+
+export const MetricsTab: Component = () => {
+  const [refreshOpt, setRefreshOpt] = createSignal<RefreshOption>("15");
+  const [tick, setTick] = createSignal(0);
+  const [lastSnapshot, setLastSnapshot] = createSignal<Snapshot | null>(null);
+  const [fetchError, setFetchError] = createSignal<string | null>(null);
+
+  let prevCounters: PrevCounters = emptyPrev();
+
+  createEffect(() => {
+    const opt = refreshOpt();
+    let handle: ReturnType<typeof setInterval> | null = null;
+    if (opt !== "off") {
+      const seconds = parseInt(opt, 10);
+      handle = setInterval(() => setTick((t) => t + 1), seconds * 1000);
+    }
+    onCleanup(() => {
+      if (handle !== null) clearInterval(handle);
+    });
+  });
+
+  const [data] = createResource(tick, async () => {
+    try {
+      const res = await fetch("/api/metrics", { credentials: "include" });
+      if (!res.ok) {
+        setFetchError(`HTTP ${res.status}`);
+        return lastSnapshot();
+      }
+      const text = await res.text();
+      const families = parsePrometheusText(text);
+      if (families.length === 0) {
+        setFetchError("No metric families returned");
+        return lastSnapshot();
+      }
+      const snap: Snapshot = { families, fetchedAt: new Date() };
+      setLastSnapshot(snap);
+      setFetchError(null);
+      return snap;
+    } catch (e) {
+      setFetchError(e instanceof Error ? e.message : String(e));
+      return lastSnapshot();
+    }
+  });
+
+  const aggregated = createMemo(() => {
+    const snap = lastSnapshot();
+    if (!snap) return null;
+    return aggregate(snap.families, prevCounters, snap.fetchedAt.getTime());
+  });
+
+  createEffect(() => {
+    const a = aggregated();
+    if (a) prevCounters = a.nextPrev;
+  });
+
+  const onIntervalChange = (e: Event) => {
+    const val = (e.currentTarget as HTMLSelectElement).value as RefreshOption;
+    setRefreshOpt(val);
+  };
+
+  const copyScrapeUrl = async () => {
+    try { await navigator.clipboard.writeText(`${window.location.origin}/api/metrics`); } catch { /* ignore */ }
+  };
+
+  return (
+    <div class="space-y-6">
+      {/* Header */}
+      <Card class="p-5">
+        <div class="flex flex-wrap items-center gap-3">
+          <div class="flex items-center gap-2">
+            <label for="metrics-refresh" class="text-xs text-theme-text-secondary">Refresh</label>
+            <select
+              id="metrics-refresh"
+              value={refreshOpt()}
+              onChange={onIntervalChange}
+              class="bg-theme-surface border border-theme-border text-theme-text-primary rounded-[var(--radius-sm)] px-2.5 py-1.5 text-sm"
+            >
+              <option value="off">Off</option>
+              <option value="5">5s</option>
+              <option value="15">15s</option>
+              <option value="30">30s</option>
+              <option value="60">60s</option>
+            </select>
+          </div>
+          <button
+            onClick={() => setTick((t) => t + 1)}
+            class="px-3 py-1.5 text-xs font-medium rounded-[var(--radius-sm)] bg-blue-500/15 text-blue-400 border border-blue-500/30 hover:bg-blue-500/25"
+          >
+            Refresh now
+          </button>
+          <span class="text-xs text-theme-text-secondary">
+            Last updated:{" "}
+            <span class="tabular-nums text-theme-text-primary">
+              {lastSnapshot() ? lastSnapshot()!.fetchedAt.toLocaleTimeString() : "--:--:--"}
+            </span>
+          </span>
+
+          <div class="flex-1" />
+
+          <div class="flex items-center gap-2">
+            <span class="text-xs text-theme-text-secondary">Scrape URL</span>
+            <span class="inline-flex items-center gap-2 font-mono text-xs px-2.5 py-1 rounded-[var(--radius-sm)] bg-theme-surface border border-theme-border text-theme-text-primary">
+              /api/metrics
+              <button onClick={copyScrapeUrl} class="text-theme-text-secondary hover:text-theme-text-primary" title="Copy URL" aria-label="Copy URL">
+                <CopyIcon />
+              </button>
+            </span>
+          </div>
+        </div>
+      </Card>
+
+      <Show when={fetchError()}>
+        <Card class="p-4">
+          <div class="text-sm text-red-400">Failed to load metrics: {fetchError()}</div>
+        </Card>
+      </Show>
+
+      <Show when={aggregated()} fallback={
+        <Show when={!lastSnapshot() && data.loading}>
+          <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <For each={[1, 2, 3, 4]}>{() => (
+              <Card class="p-6">
+                <div class="h-5 w-24 bg-theme-elevated rounded animate-pulse mb-4" />
+                <div class="h-8 w-32 bg-theme-elevated rounded animate-pulse" />
+              </Card>
+            )}</For>
+          </div>
+        </Show>
+      }>
+        {(agg) => (
+          <>
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+              <ApiCard summary={agg().api} />
+              <DbCard summary={agg().db} />
+              <JobsCard summary={agg().jobs} />
+              <OverallCard summary={agg().overall} />
+            </div>
+            <RawMetrics families={lastSnapshot()!.families} prevTotals={prevCounters} />
+          </>
+        )}
+      </Show>
+    </div>
+  );
+};
+
+const ApiCard: Component<{ summary: import("../../utils/metricsAggregate").ApiSummary }> = (props) => (
+  <Card class="p-6 space-y-5">
+    <div class="flex items-center justify-between gap-3">
+      <h2 class="text-sm font-semibold text-theme-text-primary">API</h2>
+      <StatusPill health={props.summary.health} />
+    </div>
+    <div class="grid grid-cols-3 gap-4">
+      <Kpi value={formatNumber(props.summary.rps)} label="requests/sec" />
+      <Kpi value={`${props.summary.errorRatePct.toFixed(1)}%`} label="error rate" />
+      <Kpi value={formatMs(props.summary.p95Ms)} label="p95 latency" />
+    </div>
+    <DetailsToggle summary="Details">
+      <div class="rounded-[var(--radius-sm)] overflow-hidden border border-theme-border">
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="text-xs text-theme-text-secondary">
+              <th class="text-left font-medium px-4 py-2 border-b border-theme-border">percentile</th>
+              <th class="text-right font-medium px-4 py-2 border-b border-theme-border">latency</th>
+            </tr>
+          </thead>
+          <tbody>
+            <PctRow label="p50" value={formatMs(props.summary.p50Ms)} />
+            <PctRow label="p95" value={formatMs(props.summary.p95Ms)} />
+            <PctRow label="p99" value={formatMs(props.summary.p99Ms)} last />
+          </tbody>
+        </table>
+      </div>
+      <Show when={props.summary.slowest.length > 0}>
+        <div>
+          <div class="text-xs text-theme-text-secondary mb-2">Top 5 slowest endpoints</div>
+          <div class="rounded-[var(--radius-sm)] overflow-hidden border border-theme-border">
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="text-xs text-theme-text-secondary">
+                  <th class="text-left font-medium px-4 py-2 border-b border-theme-border">endpoint</th>
+                  <th class="text-right font-medium px-4 py-2 border-b border-theme-border">p95</th>
+                  <th class="text-right font-medium px-4 py-2 border-b border-theme-border">req/s</th>
+                </tr>
+              </thead>
+              <tbody>
+                <For each={props.summary.slowest}>{(row, i) => (
+                  <tr class={i() < props.summary.slowest.length - 1 ? "border-b border-theme-border" : ""}>
+                    <td class="font-mono text-xs px-4 py-2">{row.method} {row.endpoint}</td>
+                    <td class="text-right tabular-nums px-4 py-2">{formatMs(row.p95Ms)}</td>
+                    <td class="text-right tabular-nums text-theme-text-secondary px-4 py-2">{formatNumber(row.rps)}</td>
+                  </tr>
+                )}</For>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </Show>
+      <Show when={props.summary.topErrors.length > 0}>
+        <div>
+          <div class="text-xs text-theme-text-secondary mb-2">Top 5 endpoints by errors</div>
+          <div class="rounded-[var(--radius-sm)] overflow-hidden border border-theme-border">
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="text-xs text-theme-text-secondary">
+                  <th class="text-left font-medium px-4 py-2 border-b border-theme-border">endpoint</th>
+                  <th class="text-left font-medium px-4 py-2 border-b border-theme-border">status</th>
+                  <th class="text-right font-medium px-4 py-2 border-b border-theme-border">count</th>
+                  <th class="text-right font-medium px-4 py-2 border-b border-theme-border">share</th>
+                </tr>
+              </thead>
+              <tbody>
+                <For each={props.summary.topErrors}>{(row, i) => (
+                  <tr class={i() < props.summary.topErrors.length - 1 ? "border-b border-theme-border" : ""}>
+                    <td class="font-mono text-xs px-4 py-2">{row.endpoint}</td>
+                    <td class={`font-mono text-xs px-4 py-2 ${statusColorClass(row.status)}`}>{row.status}</td>
+                    <td class="text-right tabular-nums px-4 py-2">{formatInt(row.count)}</td>
+                    <td class="text-right tabular-nums text-theme-text-secondary px-4 py-2">{row.sharePct.toFixed(1)}%</td>
+                  </tr>
+                )}</For>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </Show>
+    </DetailsToggle>
+  </Card>
+);
+
+const PctRow: Component<{ label: string; value: string; last?: boolean }> = (props) => (
+  <tr class={props.last ? "" : "border-b border-theme-border"}>
+    <td class="font-mono text-xs px-4 py-2">{props.label}</td>
+    <td class="text-right tabular-nums px-4 py-2">{props.value}</td>
+  </tr>
+);
+
+const DbCard: Component<{ summary: import("../../utils/metricsAggregate").DbSummary }> = (props) => {
+  const utilPct = () => props.summary.poolSize > 0 ? (props.summary.poolUsed / props.summary.poolSize) * 100 : 0;
+  return (
+    <Card class="p-6 space-y-5">
+      <div class="flex items-center justify-between gap-3">
+        <h2 class="text-sm font-semibold text-theme-text-primary">Database</h2>
+        <StatusPill health={props.summary.health} />
+      </div>
+      <div class="grid grid-cols-3 gap-4">
+        <Kpi value={formatNumber(props.summary.qps)} label="queries/sec" />
+        <Kpi value={formatMs(props.summary.p95Ms)} label="p95 query" />
+        <Kpi value={`${formatInt(props.summary.poolUsed)} / ${formatInt(props.summary.poolSize)}`} label="pool" />
+      </div>
+      <DetailsToggle summary="Details">
+        <div class="rounded-[var(--radius-sm)] overflow-hidden border border-theme-border">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="text-xs text-theme-text-secondary">
+                <th class="text-left font-medium px-4 py-2 border-b border-theme-border">metric</th>
+                <th class="text-right font-medium px-4 py-2 border-b border-theme-border">value</th>
+              </tr>
+            </thead>
+            <tbody>
+              <PctRow label="avg query time" value={formatMs(props.summary.avgMs)} />
+              <PctRow label="p95" value={formatMs(props.summary.p95Ms)} />
+              <PctRow label="p99" value={formatMs(props.summary.p99Ms)} last />
+            </tbody>
+          </table>
+        </div>
+        <div>
+          <div class="flex items-center justify-between text-xs text-theme-text-secondary mb-2">
+            <span>Pool utilization</span>
+            <span class="tabular-nums text-theme-text-primary">{utilPct().toFixed(0)}%</span>
+          </div>
+          <div class="h-2.5 rounded bg-theme-elevated overflow-hidden">
+            <div
+              class={`h-full rounded ${utilPct() >= 90 ? "bg-red-500/60" : utilPct() >= 70 ? "bg-amber-500/60" : "bg-blue-500/60"}`}
+              style={{ width: `${Math.min(100, utilPct())}%` }}
+            />
+          </div>
+          <div class="text-xs text-theme-text-secondary mt-2 tabular-nums">
+            {formatInt(props.summary.poolUsed)} / {formatInt(props.summary.poolSize)} connections in use, {formatInt(props.summary.overflow)} overflow
+          </div>
+        </div>
+        <div>
+          <div class="text-xs text-theme-text-secondary mb-2">Queries per request</div>
+          <div class="rounded-[var(--radius-sm)] overflow-hidden border border-theme-border">
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="text-xs text-theme-text-secondary">
+                  <th class="text-left font-medium px-4 py-2 border-b border-theme-border">statistic</th>
+                  <th class="text-right font-medium px-4 py-2 border-b border-theme-border">queries</th>
+                </tr>
+              </thead>
+              <tbody>
+                <PctRow label="median" value={formatNumber(props.summary.qprMedian, 0)} />
+                <PctRow label="p95" value={formatNumber(props.summary.qprP95, 0)} />
+                <PctRow label="max" value={formatNumber(props.summary.qprMax, 0)} last />
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </DetailsToggle>
+    </Card>
+  );
+};
+
+const JobsCard: Component<{ summary: import("../../utils/metricsAggregate").JobsSummary }> = (props) => {
+  const utilPct = () => props.summary.workersTotal > 0 ? (props.summary.workersActive / props.summary.workersTotal) * 100 : 0;
+  return (
+    <Card class="p-6 space-y-5">
+      <div class="flex items-center justify-between gap-3">
+        <h2 class="text-sm font-semibold text-theme-text-primary">Background Jobs</h2>
+        <StatusPill health={props.summary.health} />
+      </div>
+      <div class="grid grid-cols-3 gap-4">
+        <Kpi value={formatInt(props.summary.queueDepth)} label="queue depth" />
+        <Kpi value={`${formatInt(props.summary.workersActive)} / ${formatInt(props.summary.workersTotal)}`} label="workers" />
+        <Kpi value={formatInt(props.summary.failuresWindow)} label="failures (since last refresh)" />
+      </div>
+      <DetailsToggle summary="Details">
+        <div>
+          <div class="flex items-center justify-between text-xs text-theme-text-secondary mb-2">
+            <span>Worker utilization</span>
+            <span class="tabular-nums text-theme-text-primary">{utilPct().toFixed(0)}%</span>
+          </div>
+          <div class="h-2.5 rounded bg-theme-elevated overflow-hidden">
+            <div
+              class={`h-full rounded ${utilPct() >= 90 ? "bg-red-500/60" : utilPct() >= 70 ? "bg-amber-500/60" : "bg-blue-500/60"}`}
+              style={{ width: `${Math.min(100, utilPct())}%` }}
+            />
+          </div>
+          <div class="text-xs text-theme-text-secondary mt-2 tabular-nums">
+            {formatInt(props.summary.workersActive)} / {formatInt(props.summary.workersTotal)} busy
+          </div>
+        </div>
+        <Show when={props.summary.slowest.length > 0}>
+          <div>
+            <div class="text-xs text-theme-text-secondary mb-2">Slowest tasks (p95)</div>
+            <div class="rounded-[var(--radius-sm)] overflow-hidden border border-theme-border">
+              <table class="w-full text-sm">
+                <thead>
+                  <tr class="text-xs text-theme-text-secondary">
+                    <th class="text-left font-medium px-4 py-2 border-b border-theme-border">task_name</th>
+                    <th class="text-right font-medium px-4 py-2 border-b border-theme-border">p95</th>
+                    <th class="text-right font-medium px-4 py-2 border-b border-theme-border">runs</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <For each={props.summary.slowest}>{(row, i) => (
+                    <tr class={i() < props.summary.slowest.length - 1 ? "border-b border-theme-border" : ""}>
+                      <td class="font-mono text-xs px-4 py-2">{row.taskName}</td>
+                      <td class="text-right tabular-nums px-4 py-2">{formatSeconds(row.p95Seconds)}</td>
+                      <td class="text-right tabular-nums text-theme-text-secondary px-4 py-2">{formatInt(row.runs)}</td>
+                    </tr>
+                  )}</For>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </Show>
+        <Show when={props.summary.failures.length > 0}>
+          <div>
+            <div class="text-xs text-theme-text-secondary mb-2">Recent failures</div>
+            <div class="rounded-[var(--radius-sm)] overflow-hidden border border-theme-border">
+              <table class="w-full text-sm">
+                <thead>
+                  <tr class="text-xs text-theme-text-secondary">
+                    <th class="text-left font-medium px-4 py-2 border-b border-theme-border">task_name</th>
+                    <th class="text-right font-medium px-4 py-2 border-b border-theme-border">count</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <For each={props.summary.failures}>{(row, i) => (
+                    <tr class={i() < props.summary.failures.length - 1 ? "border-b border-theme-border" : ""}>
+                      <td class="font-mono text-xs px-4 py-2">{row.taskName}</td>
+                      <td class="text-right tabular-nums px-4 py-2">{formatInt(row.count)}</td>
+                    </tr>
+                  )}</For>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </Show>
+      </DetailsToggle>
+    </Card>
+  );
+};
+
+const OverallCard: Component<{ summary: import("../../utils/metricsAggregate").OverallSummary }> = (props) => (
+  <Card class="p-6 space-y-5">
+    <div class="flex items-center justify-between gap-3">
+      <h2 class="text-sm font-semibold text-theme-text-primary">Overall</h2>
+      <StatusPill health={props.summary.health} />
+    </div>
+    <div class="grid grid-cols-3 gap-4">
+      <Kpi value={formatUptime(props.summary.uptimeSeconds)} label="uptime" />
+      <Kpi value={formatBytes(props.summary.memoryBytes)} label="memory" />
+      <Kpi value={formatInt(props.summary.openFds)} label="open FDs" />
+    </div>
+    <DetailsToggle summary="Details">
+      <div class="rounded-[var(--radius-sm)] overflow-hidden border border-theme-border">
+        <table class="w-full text-sm">
+          <tbody>
+            <tr class="border-b border-theme-border">
+              <td class="text-theme-text-secondary px-4 py-2">Python version</td>
+              <td class="text-right tabular-nums font-mono text-xs px-4 py-2">{props.summary.pythonVersion || "n/a"}</td>
+            </tr>
+            <tr>
+              <td class="text-theme-text-secondary px-4 py-2">Process start time</td>
+              <td class="text-right tabular-nums font-mono text-xs px-4 py-2">{props.summary.startedAt ? formatDateTime(props.summary.startedAt) : "n/a"}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <Show when={props.summary.gc}>
+        {(gc) => (
+          <div>
+            <div class="text-xs text-theme-text-secondary mb-2">GC collections</div>
+            <div class="rounded-[var(--radius-sm)] overflow-hidden border border-theme-border">
+              <table class="w-full text-sm">
+                <thead>
+                  <tr class="text-xs text-theme-text-secondary">
+                    <th class="text-left font-medium px-4 py-2 border-b border-theme-border">generation</th>
+                    <th class="text-right font-medium px-4 py-2 border-b border-theme-border">collections</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <PctRow label="gen0" value={formatInt(gc().gen0)} />
+                  <PctRow label="gen1" value={formatInt(gc().gen1)} />
+                  <PctRow label="gen2" value={formatInt(gc().gen2)} last />
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+      </Show>
+    </DetailsToggle>
+  </Card>
+);
+
+const RawMetrics: Component<{ families: MetricFamily[]; prevTotals: PrevCounters }> = (props) => {
+  const groups = createMemo(() => {
+    const http: MetricFamily[] = [];
+    const db: MetricFamily[] = [];
+    const celery: MetricFamily[] = [];
+    const other: MetricFamily[] = [];
+    for (const f of props.families) {
+      if (f.name.startsWith("galactilog_http_")) http.push(f);
+      else if (f.name.startsWith("galactilog_db_")) db.push(f);
+      else if (f.name.startsWith("galactilog_celery_")) celery.push(f);
+      else other.push(f);
+    }
+    return [
+      { key: "HTTP", prefix: "galactilog_http_*", items: http, open: true },
+      { key: "Database", prefix: "galactilog_db_*", items: db, open: true },
+      { key: "Celery", prefix: "galactilog_celery_*", items: celery, open: false },
+      { key: "Other", prefix: "*", items: other, open: false },
+    ];
+  });
+
+  return (
+    <details class="rounded-[var(--radius-md)] bg-theme-surface border border-theme-border group">
+      <summary class="px-5 py-4 flex items-center gap-3 cursor-pointer list-none [&::-webkit-details-marker]:hidden">
+        <span class="text-theme-text-secondary transition-transform duration-150 group-open:rotate-90"><ChevronIcon size={14} /></span>
+        <h2 class="text-sm font-semibold text-theme-text-primary">Show raw metrics</h2>
+        <span class="text-xs text-theme-text-secondary">grouped by subsystem</span>
+      </summary>
+      <div class="p-5 space-y-6">
+        <For each={groups()}>{(grp) => (
+          <Show when={grp.items.length > 0}>
+            <RawGroup title={grp.key} prefix={grp.prefix} items={grp.items} defaultOpen={grp.open} prevTotals={props.prevTotals} />
+          </Show>
+        )}</For>
+      </div>
+    </details>
+  );
+};
+
+const RawGroup: Component<{ title: string; prefix: string; items: MetricFamily[]; defaultOpen: boolean; prevTotals: PrevCounters }> = (props) => (
+  <details class="rounded-[var(--radius-md)] bg-theme-surface border border-theme-border group" open={props.defaultOpen}>
+    <summary class="px-5 py-4 flex items-center gap-3 border-b border-theme-border cursor-pointer list-none [&::-webkit-details-marker]:hidden">
+      <span class="text-theme-text-secondary transition-transform duration-150 group-open:rotate-90"><ChevronIcon size={14} /></span>
+      <h2 class="text-sm font-semibold text-theme-text-primary">{props.title}</h2>
+      <span class="text-xs text-theme-text-secondary font-mono">{props.prefix}</span>
+      <span class="ml-auto inline-flex items-center px-2 py-0.5 rounded-full text-xs text-theme-text-secondary bg-theme-elevated border border-theme-border tabular-nums">
+        {props.items.length} metric{props.items.length === 1 ? "" : "s"}
+      </span>
+    </summary>
+    <div class="p-5 space-y-5">
+      <For each={props.items}>{(fam) => <RawFamily family={fam} prevTotals={props.prevTotals} />}</For>
+    </div>
+  </details>
+);
+
+const RawFamily: Component<{ family: MetricFamily; prevTotals: PrevCounters }> = (props) => {
+  return (
+    props.family.type === "gauge" ? <GaugeView family={props.family} /> :
+    props.family.type === "counter" ? <CounterView family={props.family} prevTotals={props.prevTotals} /> :
+    props.family.type === "histogram" ? <HistogramView family={props.family} /> :
+    <UntypedView family={props.family} />
+  );
+};
+
+const GaugeView: Component<{ family: MetricFamily }> = (props) => (
+  <div class="rounded-[var(--radius-sm)] bg-theme-elevated border border-theme-border p-4">
+    <div class="text-xs text-theme-text-secondary font-mono">{props.family.name}</div>
+    <Show when={props.family.samples.length === 1 && Object.keys(props.family.samples[0].labels).filter(k => k !== "__suffix__").length === 0}
+      fallback={
+        <div class="mt-3 rounded-[var(--radius-sm)] overflow-hidden border border-theme-border">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="text-xs text-theme-text-secondary">
+                <th class="text-left font-medium px-4 py-2 border-b border-theme-border">labels</th>
+                <th class="text-right font-medium px-4 py-2 border-b border-theme-border">value</th>
+              </tr>
+            </thead>
+            <tbody>
+              <For each={props.family.samples}>{(s, i) => (
+                <tr class={i() < props.family.samples.length - 1 ? "border-b border-theme-border" : ""}>
+                  <td class="font-mono text-xs px-4 py-2">{labelPairsText(s.labels)}</td>
+                  <td class="text-right tabular-nums px-4 py-2">{formatNumber(s.value)}</td>
+                </tr>
+              )}</For>
+            </tbody>
+          </table>
+        </div>
+      }
+    >
+      <div class="text-2xl font-semibold tabular-nums text-theme-text-primary mt-2">{formatNumber(props.family.samples[0].value)}</div>
+    </Show>
+    <Show when={props.family.help}>
+      <div class="text-xs italic text-theme-text-secondary mt-1">{props.family.help}</div>
+    </Show>
+  </div>
+);
+
+function labelPairsText(labels: Record<string, string>): string {
+  return Object.entries(labels)
+    .filter(([k]) => k !== "__suffix__")
+    .map(([k, v]) => `${k}="${v}"`)
+    .join(", ");
+}
+
+const CounterView: Component<{ family: MetricFamily; prevTotals: PrevCounters }> = (props) => {
+  const rows = createMemo(() => {
+    const out: Array<{ labels: Record<string, string>; value: number; rate: number }> = [];
+    let total = 0;
+    for (const s of props.family.samples) {
+      const suffix = s.labels["__suffix__"] ?? "";
+      if (suffix !== "" && suffix !== "_total") continue;
+      const labels: Record<string, string> = {};
+      for (const [k, v] of Object.entries(s.labels)) if (k !== "__suffix__") labels[k] = v;
+      const key = labelKey(props.family.name, labels);
+      const prev = props.prevTotals.totals.get(key);
+      const dt = props.prevTotals.timestampMs > 0 ? (Date.now() - props.prevTotals.timestampMs) / 1000 : 0;
+      const rate = prev !== undefined && dt > 0 ? Math.max(0, (s.value - prev) / dt) : 0;
+      total += s.value;
+      out.push({ labels, value: s.value, rate });
+    }
+    out.sort((a, b) => b.value - a.value);
+    return { rows: out, total };
+  });
+
+  const totalRate = createMemo(() => {
+    const dt = props.prevTotals.timestampMs > 0 ? (Date.now() - props.prevTotals.timestampMs) / 1000 : 0;
+    if (dt <= 0) return 0;
+    let prevSum = 0;
+    for (const [k, v] of props.prevTotals.totals) if (k.startsWith(props.family.name + "{")) prevSum += v;
+    return Math.max(0, (rows().total - prevSum) / dt);
+  });
+
+  const labelCols = createMemo(() => {
+    const set = new Set<string>();
+    for (const r of rows().rows) for (const k of Object.keys(r.labels)) set.add(k);
+    return Array.from(set);
+  });
+
+  return (
+    <div class="rounded-[var(--radius-sm)] bg-theme-elevated border border-theme-border p-4">
+      <div class="flex items-start justify-between gap-3 mb-3">
+        <div>
+          <div class="text-xs text-theme-text-secondary font-mono">{props.family.name}</div>
+          <Show when={props.family.help}><div class="text-xs italic text-theme-text-secondary mt-0.5">{props.family.help}</div></Show>
+        </div>
+        <div class="text-right">
+          <div class="text-2xl font-semibold tabular-nums text-theme-text-primary">{formatInt(rows().total)}</div>
+          <div class="text-xs text-theme-text-secondary tabular-nums">{formatNumber(totalRate())}/s since last refresh</div>
+        </div>
+      </div>
+      <Show when={labelCols().length > 0}>
+        <div class="rounded-[var(--radius-sm)] overflow-hidden border border-theme-border">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="text-xs text-theme-text-secondary">
+                <For each={labelCols()}>{(c) => <th class="text-left font-medium px-4 py-2 border-b border-theme-border">{c}</th>}</For>
+                <th class="text-right font-medium px-4 py-2 border-b border-theme-border">total</th>
+                <th class="text-right font-medium px-4 py-2 border-b border-theme-border">rate/s</th>
+              </tr>
+            </thead>
+            <tbody>
+              <For each={rows().rows}>{(row, i) => (
+                <tr class={i() < rows().rows.length - 1 ? "border-b border-theme-border" : ""}>
+                  <For each={labelCols()}>{(c) => {
+                    const v = row.labels[c] ?? "";
+                    const cls = c === "status_code" ? statusColorClass(v) : "";
+                    return <td class={`font-mono text-xs px-4 py-2 ${cls}`}>{v}</td>;
+                  }}</For>
+                  <td class="text-right tabular-nums px-4 py-2">{formatInt(row.value)}</td>
+                  <td class="text-right tabular-nums text-theme-text-secondary px-4 py-2">{formatNumber(row.rate)}</td>
+                </tr>
+              )}</For>
+            </tbody>
+          </table>
+        </div>
+      </Show>
+    </div>
+  );
+};
+
+function labelKey(name: string, labels: Record<string, string>): string {
+  const keys = Object.keys(labels).filter((k) => k !== "__suffix__").sort();
+  return name + "{" + keys.map((k) => `${k}=${labels[k]}`).join(",") + "}";
+}
+
+const HistogramView: Component<{ family: MetricFamily }> = (props) => {
+  const groups = createMemo(() => {
+    type G = { labels: Record<string, string>; buckets: Array<{ le: number; count: number }>; sum: number; count: number };
+    const map = new Map<string, G>();
+    for (const s of props.family.samples) {
+      const suffix = s.labels["__suffix__"] ?? "";
+      const labels: Record<string, string> = {};
+      for (const [k, v] of Object.entries(s.labels)) if (k !== "__suffix__" && k !== "le") labels[k] = v;
+      const keyParts = Object.keys(labels).sort().map(k => `${k}=${labels[k]}`).join(",");
+      let g = map.get(keyParts);
+      if (!g) { g = { labels, buckets: [], sum: 0, count: 0 }; map.set(keyParts, g); }
+      if (suffix === "_bucket") {
+        const leRaw = s.labels["le"];
+        const le = leRaw === "+Inf" ? Infinity : Number(leRaw);
+        g.buckets.push({ le, count: s.value });
+      } else if (suffix === "_sum") g.sum = s.value;
+      else if (suffix === "_count") g.count = s.value;
+    }
+    for (const g of map.values()) g.buckets.sort((a, b) => a.le - b.le);
+    return Array.from(map.values());
+  });
+
+  return (
+    <div>
+      <div class="text-xs text-theme-text-secondary font-mono mb-2">{props.family.name}</div>
+      <Show when={props.family.help}><div class="text-xs italic text-theme-text-secondary mb-3">{props.family.help}</div></Show>
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <For each={groups()}>{(g) => {
+          const avgMs = g.count > 0 ? (g.sum / g.count) * 1000 : 0;
+          const top = g.buckets.length ? g.buckets[g.buckets.length - 1].count : 0;
+          return (
+            <div class="rounded-[var(--radius-sm)] bg-theme-elevated border border-theme-border p-4">
+              <div class="flex flex-wrap items-baseline justify-between gap-2 mb-3">
+                <div class="flex items-center gap-2 text-xs font-mono">
+                  <For each={Object.entries(g.labels)}>{([k, v]) => {
+                    const cls = k === "status_code" ? statusColorClass(v) : "text-theme-text-secondary";
+                    return <span class={cls}>{k}={v}</span>;
+                  }}</For>
+                </div>
+                <div class="flex items-center gap-4 text-xs text-theme-text-secondary">
+                  <span>count <span class="tabular-nums text-theme-text-primary">{formatInt(g.count)}</span></span>
+                  <span>sum <span class="tabular-nums text-theme-text-primary">{formatNumber(g.sum, 2)} s</span></span>
+                  <span>avg <span class="tabular-nums text-theme-text-primary">{formatMs(avgMs)}</span></span>
+                </div>
+              </div>
+              <div class="space-y-1.5">
+                <For each={g.buckets}>{(b) => {
+                  const pct = top > 0 ? (b.count / top) * 100 : 0;
+                  const leLabel = isFinite(b.le) ? `le=${b.le}` : "le=+Inf";
+                  return (
+                    <div class="grid grid-cols-[5rem_1fr_5rem] items-center gap-3 text-xs">
+                      <span class="font-mono text-theme-text-secondary">{leLabel}</span>
+                      <div class="h-2 rounded bg-theme-elevated overflow-hidden border border-theme-border">
+                        <div class="h-full rounded bg-blue-500/55" style={{ width: `${Math.min(100, pct)}%` }} />
+                      </div>
+                      <span class={`tabular-nums text-right ${!isFinite(b.le) ? "font-semibold text-theme-text-primary" : "text-theme-text-primary"}`}>{formatInt(b.count)}</span>
+                    </div>
+                  );
+                }}</For>
+              </div>
+            </div>
+          );
+        }}</For>
+      </div>
+    </div>
+  );
+};
+
+const UntypedView: Component<{ family: MetricFamily }> = (props) => (
+  <div class="rounded-[var(--radius-sm)] bg-theme-elevated border border-theme-border p-4">
+    <div class="text-xs text-theme-text-secondary font-mono">{props.family.name}</div>
+    <Show when={props.family.help}><div class="text-xs italic text-theme-text-secondary mt-0.5">{props.family.help}</div></Show>
+    <div class="mt-3 rounded-[var(--radius-sm)] overflow-hidden border border-theme-border">
+      <table class="w-full text-sm">
+        <tbody>
+          <For each={props.family.samples}>{(s, i) => (
+            <tr class={i() < props.family.samples.length - 1 ? "border-b border-theme-border" : ""}>
+              <td class="font-mono text-xs px-4 py-2">{labelPairsText(s.labels)}</td>
+              <td class="text-right tabular-nums px-4 py-2">{formatNumber(s.value)}</td>
+            </tr>
+          )}</For>
+        </tbody>
+      </table>
+    </div>
+  </div>
+);

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -38,6 +38,7 @@ const DisplayTab = lazy(() => import("../components/DisplayTab"));
 const AstroBinTab = lazy(() => import("../components/settings/AstroBinTab"));
 const CustomColumnsTab = lazy(() => import("../components/CustomColumnsTab"));
 const ActivityLogTab = lazy(() => import("../components/settings/ActivityLogTab"));
+const MetricsTab = lazy(() => import("../components/settings/MetricsTab").then(m => ({ default: m.MetricsTab })));
 
 const ALL_TABS = [
   { id: "scan", label: "Library" },
@@ -49,6 +50,7 @@ const ALL_TABS = [
   { id: "backup", label: "Backup & Restore", adminOnly: true },
   { id: "users", label: "Users", adminOnly: true },
   { id: "activity-log", label: "Activity Log", adminOnly: true },
+  { id: "metrics", label: "Metrics", adminOnly: true },
 ] as const;
 
 type TabId = (typeof ALL_TABS)[number]["id"];
@@ -98,6 +100,7 @@ export const SettingsPage: Component = () => {
             <li><strong class="text-theme-text-primary">Custom Columns</strong>: user-defined columns on targets, sessions, and rigs.</li>
             <li><strong class="text-theme-text-primary">Backup & Restore</strong> (admin): export and import the configuration as a versioned JSON file.</li>
             <li><strong class="text-theme-text-primary">Users</strong> (admin): manage accounts and roles.</li>
+            <li><strong class="text-theme-text-primary">Metrics</strong> (admin): live Prometheus metrics with API, database, job, and process health summaries.</li>
           </ul>
         </HelpPopover>
       </div>
@@ -149,6 +152,9 @@ export const SettingsPage: Component = () => {
         </Show>
         <Show when={activeTab() === "activity-log" && isAdmin()}>
           <ActivityLogTab />
+        </Show>
+        <Show when={activeTab() === "metrics" && isAdmin()}>
+          <MetricsTab />
         </Show>
       </Suspense>
     </div>

--- a/frontend/src/utils/metricsAggregate.ts
+++ b/frontend/src/utils/metricsAggregate.ts
@@ -1,0 +1,431 @@
+import type { MetricFamily, Sample } from "./prometheusParse";
+
+export type Health = "green" | "amber" | "red";
+
+export interface ApiSummary {
+  rps: number;
+  errorRatePct: number;
+  p50Ms: number;
+  p95Ms: number;
+  p99Ms: number;
+  slowest: Array<{ endpoint: string; method: string; status: string; p95Ms: number; rps: number }>;
+  topErrors: Array<{ endpoint: string; status: string; count: number; sharePct: number }>;
+  health: Health;
+}
+
+export interface DbSummary {
+  qps: number;
+  avgMs: number;
+  p95Ms: number;
+  p99Ms: number;
+  poolUsed: number;
+  poolSize: number;
+  overflow: number;
+  qprMedian: number;
+  qprP95: number;
+  qprMax: number;
+  health: Health;
+}
+
+export interface JobsSummary {
+  queueDepth: number;
+  workersActive: number;
+  workersTotal: number;
+  failuresWindow: number;
+  slowest: Array<{ taskName: string; p95Seconds: number; runs: number }>;
+  failures: Array<{ taskName: string; count: number }>;
+  health: Health;
+}
+
+export interface OverallSummary {
+  uptimeSeconds: number;
+  memoryBytes: number;
+  openFds: number;
+  pythonVersion: string;
+  startedAt: Date | null;
+  gc: { gen0: number; gen1: number; gen2: number } | null;
+  health: Health;
+}
+
+export interface PrevCounters {
+  timestampMs: number;
+  totals: Map<string, number>;
+}
+
+export const emptyPrev = (): PrevCounters => ({ timestampMs: 0, totals: new Map() });
+
+function labelKey(name: string, labels: Record<string, string>): string {
+  const keys = Object.keys(labels).filter((k) => k !== "__suffix__").sort();
+  const parts = keys.map((k) => `${k}=${labels[k]}`);
+  return name + "{" + parts.join(",") + "}";
+}
+
+function findFamily(families: MetricFamily[], name: string): MetricFamily | undefined {
+  return families.find((f) => f.name === name);
+}
+
+function sumBySuffix(fam: MetricFamily | undefined, suffix: string, keyFilter?: (labels: Record<string, string>) => boolean): Sample[] {
+  if (!fam) return [];
+  return fam.samples.filter((s) => (s.labels["__suffix__"] ?? "") === suffix && (!keyFilter || keyFilter(s.labels)));
+}
+
+// Group histogram samples by the set of non-bucket labels (exclude "le", "__suffix__")
+interface HistoSet {
+  labels: Record<string, string>;
+  buckets: Array<{ le: number; count: number }>;
+  sum: number;
+  count: number;
+}
+
+function groupHistogram(fam: MetricFamily | undefined): HistoSet[] {
+  if (!fam) return [];
+  const groups = new Map<string, HistoSet>();
+  const keyOf = (labels: Record<string, string>) => {
+    const keys = Object.keys(labels).filter((k) => k !== "le" && k !== "__suffix__").sort();
+    return keys.map((k) => `${k}=${labels[k]}`).join(",");
+  };
+  for (const s of fam.samples) {
+    const suffix = s.labels["__suffix__"] ?? "";
+    const k = keyOf(s.labels);
+    let g = groups.get(k);
+    if (!g) {
+      const lbl: Record<string, string> = {};
+      for (const [lk, lv] of Object.entries(s.labels)) {
+        if (lk !== "le" && lk !== "__suffix__") lbl[lk] = lv;
+      }
+      g = { labels: lbl, buckets: [], sum: 0, count: 0 };
+      groups.set(k, g);
+    }
+    if (suffix === "_bucket") {
+      const leRaw = s.labels["le"];
+      const le = leRaw === "+Inf" ? Infinity : Number(leRaw);
+      g.buckets.push({ le, count: s.value });
+    } else if (suffix === "_sum") {
+      g.sum = s.value;
+    } else if (suffix === "_count") {
+      g.count = s.value;
+    }
+  }
+  for (const g of groups.values()) g.buckets.sort((a, b) => a.le - b.le);
+  return Array.from(groups.values());
+}
+
+// Compute quantile using Prometheus histogram_quantile with linear interpolation.
+// When the quantile lands in the +Inf bucket, return the upper bound of the previous finite bucket.
+export function histogramQuantile(q: number, buckets: Array<{ le: number; count: number }>): number {
+  if (!buckets.length) return 0;
+  const sorted = buckets.slice().sort((a, b) => a.le - b.le);
+  const total = sorted[sorted.length - 1]?.count ?? 0;
+  if (total <= 0) return 0;
+  const rank = q * total;
+  let prevLe = 0;
+  let prevCount = 0;
+  for (let i = 0; i < sorted.length; i++) {
+    const b = sorted[i];
+    if (b.count >= rank) {
+      if (!isFinite(b.le)) {
+        // find last finite bucket upper bound
+        for (let j = i - 1; j >= 0; j--) {
+          if (isFinite(sorted[j].le)) return sorted[j].le;
+        }
+        return 0;
+      }
+      const bucketCount = b.count - prevCount;
+      if (bucketCount <= 0) return b.le;
+      const fraction = (rank - prevCount) / bucketCount;
+      return prevLe + (b.le - prevLe) * fraction;
+    }
+    prevLe = isFinite(b.le) ? b.le : prevLe;
+    prevCount = b.count;
+  }
+  return prevLe;
+}
+
+function mergeBuckets(groups: HistoSet[]): { buckets: Array<{ le: number; count: number }>; count: number; sum: number } {
+  const byLe = new Map<number, number>();
+  let count = 0;
+  let sum = 0;
+  for (const g of groups) {
+    count += g.count;
+    sum += g.sum;
+    for (const b of g.buckets) {
+      byLe.set(b.le, (byLe.get(b.le) ?? 0) + b.count);
+    }
+  }
+  const buckets = Array.from(byLe.entries())
+    .map(([le, c]) => ({ le, count: c }))
+    .sort((a, b) => a.le - b.le);
+  return { buckets, count, sum };
+}
+
+function rateFor(key: string, current: number, prev: PrevCounters, dtSeconds: number): number {
+  if (prev.timestampMs === 0 || dtSeconds <= 0) return 0;
+  const p = prev.totals.get(key);
+  if (p === undefined) return 0;
+  const d = current - p;
+  if (d < 0) return 0;
+  return d / dtSeconds;
+}
+
+function fmtPct(n: number): number {
+  if (!isFinite(n)) return 0;
+  return Math.max(0, n);
+}
+
+function healthApi(errPct: number, p95Ms: number): Health {
+  if (errPct < 1 && p95Ms < 500) return "green";
+  if (errPct < 5 || p95Ms < 2000) return "amber";
+  return "red";
+}
+
+function healthDb(poolUsed: number, poolSize: number, overflow: number): Health {
+  const ratio = poolSize > 0 ? poolUsed / poolSize : 0;
+  if (ratio < 0.7 && overflow === 0) return "green";
+  if (ratio < 0.9 && overflow === 0) return "amber";
+  return "red";
+}
+
+function healthJobs(queueDepth: number, workersTotal: number, failures: number): Health {
+  const cap2 = workersTotal * 2;
+  const cap5 = workersTotal * 5;
+  if (queueDepth < cap2 && failures === 0) return "green";
+  if (queueDepth < cap5 || failures <= 3) return "amber";
+  return "red";
+}
+
+export function aggregate(
+  families: MetricFamily[],
+  prev: PrevCounters,
+  nowMs: number,
+): { api: ApiSummary; db: DbSummary; jobs: JobsSummary; overall: OverallSummary; nextPrev: PrevCounters } {
+  const dtSeconds = prev.timestampMs > 0 ? Math.max(0, (nowMs - prev.timestampMs) / 1000) : 0;
+  const nextTotals = new Map<string, number>();
+
+  // --- HTTP requests counter ---
+  const httpReqsFam = findFamily(families, "galactilog_http_requests_total");
+  let totalReqs = 0;
+  let errorReqs = 0;
+  let totalWindow = 0;
+  let errorWindow = 0;
+  const perEndpointCounts: Array<{ method: string; endpoint: string; status: string; count: number; key: string }> = [];
+  if (httpReqsFam) {
+    for (const s of httpReqsFam.samples) {
+      const suffix = s.labels["__suffix__"] ?? "";
+      if (suffix !== "" && suffix !== "_total") continue;
+      const method = s.labels["method"] ?? "";
+      const endpoint = s.labels["endpoint"] ?? "";
+      const status = s.labels["status_code"] ?? "";
+      const k = labelKey("galactilog_http_requests_total", { method, endpoint, status_code: status });
+      nextTotals.set(k, s.value);
+      totalReqs += s.value;
+      const sc = parseInt(status, 10);
+      if (!isNaN(sc) && sc >= 400) errorReqs += s.value;
+      const prv = prev.totals.get(k);
+      const delta = prv !== undefined ? Math.max(0, s.value - prv) : 0;
+      totalWindow += delta;
+      if (status.startsWith("4") || status.startsWith("5")) errorWindow += delta;
+      perEndpointCounts.push({ method, endpoint, status, count: s.value, key: k });
+    }
+  }
+  const prevTotalReqsSum = (() => {
+    if (prev.timestampMs === 0) return 0;
+    let s = 0;
+    for (const [k, v] of prev.totals) if (k.startsWith("galactilog_http_requests_total{")) s += v;
+    return s;
+  })();
+  const rps = dtSeconds > 0 ? Math.max(0, (totalReqs - prevTotalReqsSum) / dtSeconds) : 0;
+  const errorRatePct = prev.timestampMs === 0
+    ? 0
+    : totalWindow > 0 ? fmtPct((errorWindow / totalWindow) * 100) : 0;
+
+  // --- HTTP duration histogram: overall percentiles + per-endpoint p95 ---
+  const httpDurFam = findFamily(families, "galactilog_http_request_duration_seconds");
+  const httpGroups = groupHistogram(httpDurFam);
+  const merged = mergeBuckets(httpGroups);
+  const p50Ms = httpGroups.length ? histogramQuantile(0.5, merged.buckets) * 1000 : 0;
+  const p95Ms = httpGroups.length ? histogramQuantile(0.95, merged.buckets) * 1000 : 0;
+  const p99Ms = httpGroups.length ? histogramQuantile(0.99, merged.buckets) * 1000 : 0;
+
+  // slowest endpoints: per (method, endpoint) aggregated across statuses
+  const byEp = new Map<string, { method: string; endpoint: string; status: string; buckets: Array<{ le: number; count: number }>; count: number }>();
+  for (const g of httpGroups) {
+    const method = g.labels["method"] ?? "";
+    const endpoint = g.labels["endpoint"] ?? "";
+    const status = g.labels["status_code"] ?? "";
+    const k = `${method}|${endpoint}|${status}`;
+    byEp.set(k, { method, endpoint, status, buckets: g.buckets, count: g.count });
+  }
+  const slowest = Array.from(byEp.values())
+    .map((e) => {
+      const p95 = histogramQuantile(0.95, e.buckets) * 1000;
+      const countKey = labelKey("galactilog_http_requests_total", { method: e.method, endpoint: e.endpoint, status_code: e.status });
+      const cur = nextTotals.get(countKey) ?? 0;
+      const prv = prev.totals.get(countKey);
+      const epRps = dtSeconds > 0 && prv !== undefined ? Math.max(0, (cur - prv) / dtSeconds) : 0;
+      return { endpoint: e.endpoint, method: e.method, status: e.status, p95Ms: p95, rps: epRps };
+    })
+    .sort((a, b) => b.p95Ms - a.p95Ms)
+    .slice(0, 5);
+
+  const errorRows = perEndpointCounts
+    .filter((r) => {
+      const sc = parseInt(r.status, 10);
+      return !isNaN(sc) && sc >= 400;
+    })
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 5);
+  const topErrors = errorRows.map((r) => ({
+    endpoint: r.endpoint ? `${r.method} ${r.endpoint}` : r.method,
+    status: r.status,
+    count: r.count,
+    sharePct: errorReqs > 0 ? (r.count / errorReqs) * 100 : 0,
+  }));
+
+  const api: ApiSummary = {
+    rps,
+    errorRatePct,
+    p50Ms,
+    p95Ms,
+    p99Ms,
+    slowest,
+    topErrors,
+    health: healthApi(errorRatePct, p95Ms),
+  };
+
+  // --- DB ---
+  const dbQueryFam = findFamily(families, "galactilog_db_query_duration_seconds");
+  const dbGroups = groupHistogram(dbQueryFam);
+  const dbMerged = mergeBuckets(dbGroups);
+  const dbP95Ms = dbGroups.length ? histogramQuantile(0.95, dbMerged.buckets) * 1000 : 0;
+  const dbP99Ms = dbGroups.length ? histogramQuantile(0.99, dbMerged.buckets) * 1000 : 0;
+  const dbAvgMs = dbMerged.count > 0 ? (dbMerged.sum / dbMerged.count) * 1000 : 0;
+  const dbCurCount = dbMerged.count;
+  const dbCountKey = "galactilog_db_query_duration_seconds_count";
+  nextTotals.set(dbCountKey, dbCurCount);
+  const dbQps = rateFor(dbCountKey, dbCurCount, prev, dtSeconds);
+
+  const poolSize = gaugeValue(families, "galactilog_db_pool_size");
+  const poolUsed = gaugeValue(families, "galactilog_db_pool_checked_out");
+  const overflow = gaugeValue(families, "galactilog_db_pool_overflow");
+
+  const qprFam = findFamily(families, "galactilog_db_queries_per_request");
+  const qprGroups = groupHistogram(qprFam);
+  const qprMerged = mergeBuckets(qprGroups);
+  const qprMedian = qprGroups.length ? histogramQuantile(0.5, qprMerged.buckets) : 0;
+  const qprP95 = qprGroups.length ? histogramQuantile(0.95, qprMerged.buckets) : 0;
+  // "max" approximated as the top finite bucket having observations
+  let qprMax = 0;
+  for (const b of qprMerged.buckets) {
+    if (b.count > 0 && isFinite(b.le)) qprMax = Math.max(qprMax, b.le);
+  }
+
+  const db: DbSummary = {
+    qps: dbQps,
+    avgMs: dbAvgMs,
+    p95Ms: dbP95Ms,
+    p99Ms: dbP99Ms,
+    poolUsed,
+    poolSize,
+    overflow,
+    qprMedian,
+    qprP95,
+    qprMax,
+    health: healthDb(poolUsed, poolSize, overflow),
+  };
+
+  // --- Jobs ---
+  const queueDepth = gaugeValue(families, "galactilog_celery_queue_depth");
+  const workersActive = gaugeValue(families, "galactilog_celery_workers_active");
+  const workersTotal = gaugeValue(families, "galactilog_celery_workers_total");
+
+  const taskDurFam = findFamily(families, "galactilog_celery_task_duration_seconds");
+  const taskGroups = groupHistogram(taskDurFam);
+  const slowestTasks = taskGroups
+    .map((g) => ({
+      taskName: g.labels["task_name"] ?? "",
+      p95Seconds: histogramQuantile(0.95, g.buckets),
+      runs: g.count,
+    }))
+    .sort((a, b) => b.p95Seconds - a.p95Seconds)
+    .slice(0, 5);
+
+  const failFam = findFamily(families, "galactilog_celery_task_failures_total");
+  const failRows: Array<{ taskName: string; count: number }> = [];
+  let failuresWindowTotal = 0;
+  if (failFam) {
+    for (const s of failFam.samples) {
+      const suffix = s.labels["__suffix__"] ?? "";
+      if (suffix !== "" && suffix !== "_total") continue;
+      const taskName = s.labels["task_name"] ?? "";
+      const k = labelKey("galactilog_celery_task_failures_total", { task_name: taskName });
+      nextTotals.set(k, s.value);
+      const prv = prev.totals.get(k);
+      const delta = prv !== undefined ? Math.max(0, s.value - prv) : 0;
+      if (delta > 0) failuresWindowTotal += delta;
+      failRows.push({ taskName, count: prv !== undefined ? delta : s.value });
+    }
+  }
+  failRows.sort((a, b) => b.count - a.count);
+
+  const jobs: JobsSummary = {
+    queueDepth,
+    workersActive,
+    workersTotal,
+    failuresWindow: prev.timestampMs > 0 ? failuresWindowTotal : 0,
+    slowest: slowestTasks,
+    failures: failRows.filter((r) => r.count > 0).slice(0, 10),
+    health: healthJobs(queueDepth, workersTotal, prev.timestampMs > 0 ? failuresWindowTotal : 0),
+  };
+
+  // --- Overall ---
+  const startTs = gaugeValue(families, "process_start_time_seconds");
+  const uptimeSeconds = startTs > 0 ? Math.max(0, nowMs / 1000 - startTs) : 0;
+  const memoryBytes = gaugeValue(families, "process_resident_memory_bytes");
+  const openFds = gaugeValue(families, "process_open_fds");
+
+  let pythonVersion = "";
+  const pyInfo = findFamily(families, "python_info");
+  if (pyInfo && pyInfo.samples.length) {
+    pythonVersion = pyInfo.samples[0].labels["version"] ?? "";
+  }
+
+  const gcFam = findFamily(families, "python_gc_collections_total");
+  let gc: { gen0: number; gen1: number; gen2: number } | null = null;
+  if (gcFam) {
+    const g = { gen0: 0, gen1: 0, gen2: 0 };
+    for (const s of gcFam.samples) {
+      const suffix = s.labels["__suffix__"] ?? "";
+      if (suffix !== "" && suffix !== "_total") continue;
+      const gen = s.labels["generation"];
+      if (gen === "0") g.gen0 = s.value;
+      else if (gen === "1") g.gen1 = s.value;
+      else if (gen === "2") g.gen2 = s.value;
+    }
+    gc = g;
+  }
+
+  const overall: OverallSummary = {
+    uptimeSeconds,
+    memoryBytes,
+    openFds,
+    pythonVersion,
+    startedAt: startTs > 0 ? new Date(startTs * 1000) : null,
+    gc,
+    health: "green",
+  };
+
+  return {
+    api,
+    db,
+    jobs,
+    overall,
+    nextPrev: { timestampMs: nowMs, totals: nextTotals },
+  };
+}
+
+function gaugeValue(families: MetricFamily[], name: string): number {
+  const fam = findFamily(families, name);
+  if (!fam || fam.samples.length === 0) return 0;
+  // For labeled gauges, return the first; callers should use findFamily directly when needed
+  return fam.samples[0].value;
+}

--- a/frontend/src/utils/prometheusParse.ts
+++ b/frontend/src/utils/prometheusParse.ts
@@ -1,0 +1,204 @@
+export type MetricType = "gauge" | "counter" | "histogram" | "summary" | "untyped";
+
+export interface Sample {
+  labels: Record<string, string>;
+  value: number;
+}
+
+export interface MetricFamily {
+  name: string;
+  type: MetricType;
+  help: string;
+  samples: Sample[];
+}
+
+function parseValue(raw: string): number {
+  const s = raw.trim();
+  if (s === "NaN") return NaN;
+  if (s === "+Inf" || s === "Inf") return Infinity;
+  if (s === "-Inf") return -Infinity;
+  const n = Number(s);
+  return n;
+}
+
+function parseLabels(inner: string): Record<string, string> {
+  const labels: Record<string, string> = {};
+  let i = 0;
+  const n = inner.length;
+  while (i < n) {
+    while (i < n && (inner[i] === " " || inner[i] === "," || inner[i] === "\t")) i++;
+    if (i >= n) break;
+    let keyStart = i;
+    while (i < n && inner[i] !== "=") i++;
+    if (i >= n) break;
+    const key = inner.slice(keyStart, i).trim();
+    i++;
+    while (i < n && inner[i] === " ") i++;
+    if (i >= n || inner[i] !== '"') break;
+    i++;
+    let val = "";
+    while (i < n) {
+      const c = inner[i];
+      if (c === "\\") {
+        const nx = inner[i + 1];
+        if (nx === "\\") { val += "\\"; i += 2; continue; }
+        if (nx === '"') { val += '"'; i += 2; continue; }
+        if (nx === "n") { val += "\n"; i += 2; continue; }
+        val += nx ?? "";
+        i += 2;
+        continue;
+      }
+      if (c === '"') { i++; break; }
+      val += c;
+      i++;
+    }
+    labels[key] = val;
+  }
+  return labels;
+}
+
+function parseSampleLine(line: string): { name: string; sample: Sample } | null {
+  let i = 0;
+  const n = line.length;
+  while (i < n && line[i] !== "{" && line[i] !== " " && line[i] !== "\t") i++;
+  const name = line.slice(0, i);
+  if (!name) return null;
+  let labels: Record<string, string> = {};
+  if (i < n && line[i] === "{") {
+    i++;
+    // find matching close, respecting quoted strings
+    let depth = 1;
+    let start = i;
+    while (i < n && depth > 0) {
+      const c = line[i];
+      if (c === '"') {
+        i++;
+        while (i < n) {
+          if (line[i] === "\\") { i += 2; continue; }
+          if (line[i] === '"') { i++; break; }
+          i++;
+        }
+        continue;
+      }
+      if (c === "}") { depth--; if (depth === 0) break; }
+      i++;
+    }
+    labels = parseLabels(line.slice(start, i));
+    if (i < n && line[i] === "}") i++;
+  }
+  while (i < n && (line[i] === " " || line[i] === "\t")) i++;
+  if (i >= n) return null;
+  // value until next whitespace (timestamp ignored)
+  let vStart = i;
+  while (i < n && line[i] !== " " && line[i] !== "\t") i++;
+  const valStr = line.slice(vStart, i);
+  const value = parseValue(valStr);
+  if (valStr.length === 0) return null;
+  return { name, sample: { labels, value } };
+}
+
+function baseNameFor(sampleName: string, familyName: string, type: MetricType): string {
+  if (type === "histogram") {
+    if (sampleName === familyName + "_bucket") return familyName;
+    if (sampleName === familyName + "_sum") return familyName;
+    if (sampleName === familyName + "_count") return familyName;
+  }
+  if (type === "summary") {
+    if (sampleName === familyName + "_sum") return familyName;
+    if (sampleName === familyName + "_count") return familyName;
+  }
+  return sampleName;
+}
+
+export function parsePrometheusText(text: string): MetricFamily[] {
+  const lines = text.split(/\r?\n/);
+  const families = new Map<string, MetricFamily>();
+  const helpByName = new Map<string, string>();
+  const typeByName = new Map<string, MetricType>();
+
+  for (const rawLine of lines) {
+    const line = rawLine;
+    if (!line) continue;
+    if (line.startsWith("#")) {
+      const rest = line.slice(1).trimStart();
+      if (rest.startsWith("HELP ")) {
+        const after = rest.slice(5);
+        const sp = after.indexOf(" ");
+        if (sp > 0) {
+          const mname = after.slice(0, sp);
+          const help = after.slice(sp + 1);
+          helpByName.set(mname, help);
+          const fam = families.get(mname);
+          if (fam) fam.help = help;
+        }
+        continue;
+      }
+      if (rest.startsWith("TYPE ")) {
+        const after = rest.slice(5);
+        const sp = after.indexOf(" ");
+        if (sp > 0) {
+          const mname = after.slice(0, sp);
+          const tword = after.slice(sp + 1).trim() as MetricType;
+          const t: MetricType = (["gauge", "counter", "histogram", "summary", "untyped"] as MetricType[])
+            .includes(tword) ? tword : "untyped";
+          typeByName.set(mname, t);
+          if (!families.has(mname)) {
+            families.set(mname, {
+              name: mname,
+              type: t,
+              help: helpByName.get(mname) ?? "",
+              samples: [],
+            });
+          } else {
+            const fam = families.get(mname)!;
+            fam.type = t;
+          }
+        }
+        continue;
+      }
+      continue;
+    }
+    const parsed = parseSampleLine(line);
+    if (!parsed) continue;
+    const { name: sampleName, sample } = parsed;
+
+    // Determine owning family: try each known family whose base matches
+    let owner: MetricFamily | null = null;
+    for (const [fname, fam] of families) {
+      if (baseNameFor(sampleName, fname, fam.type) === fname) {
+        owner = fam;
+        break;
+      }
+    }
+    if (!owner) {
+      for (const suffix of ["_bucket", "_sum", "_count"]) {
+        if (sampleName.endsWith(suffix)) {
+          const base = sampleName.slice(0, -suffix.length);
+          const fam = families.get(base);
+          if (fam) { owner = fam; break; }
+        }
+      }
+    }
+    if (!owner) {
+      const t = typeByName.get(sampleName) ?? "untyped";
+      owner = {
+        name: sampleName,
+        type: t,
+        help: helpByName.get(sampleName) ?? "",
+        samples: [],
+      };
+      families.set(sampleName, owner);
+    }
+    // For histogram _bucket samples, retain the `le` label verbatim and include original sample name context via labels
+    const labels = sample.labels;
+    if (owner.type === "histogram" || owner.type === "summary") {
+      const suffix = sampleName === owner.name
+        ? ""
+        : sampleName.slice(owner.name.length);
+      if (suffix) labels["__suffix__"] = suffix;
+    }
+    owner.samples.push({ labels, value: sample.value });
+  }
+
+  return Array.from(families.values());
+}


### PR DESCRIPTION
**Summary**
This PR introduces a new Metrics tab on the Settings page, providing administrators with a Prometheus health overview.

**Changes**
*   Added a new "Metrics" tab to the Settings page.
*   Implemented a Prometheus health overview within the new Metrics tab.
*   Restricted access to the Metrics tab to administrators only.
*   Introduced new utility functions for aggregating and parsing Prometheus metrics data.

**Impact**
*   **Frontend**: Modifies the `SettingsPage` component to include the new tab.
*   **Frontend**: Adds new components and utility modules for metrics display and Prometheus data processing.