### PR TITLE
Target and Mosaic Row Interaction Updates

### DIFF
--- a/frontend/src/components/TargetFeed.tsx
+++ b/frontend/src/components/TargetFeed.tsx
@@ -87,7 +87,7 @@ const TargetFeed: Component = () => {
       </Show>
 
       <Show when={targetData.loading || displayData()}>
-        <div class="space-y-3">
+        <div class="rounded-[var(--radius-md)] bg-theme-surface border border-theme-border p-4 space-y-4">
           {/* Skeleton: shown on initial load (no data yet) */}
           <Show when={targetData.loading && !displayData()}>
             <div class="rounded-[var(--radius-sm)] bg-theme-elevated border border-theme-border-em p-3">

--- a/frontend/src/components/TargetRow.tsx
+++ b/frontend/src/components/TargetRow.tsx
@@ -36,7 +36,7 @@ const TargetRow: Component<{
       {/* Desktop table row -- hidden below md */}
       <tr
         class="border-b border-theme-border cursor-pointer hover:bg-theme-hover transition-colors duration-150 hidden md:table-row"
-        onClick={() => navigate(`/targets/${encodeURIComponent(props.target.target_id)}?view=sessions`)}
+        onClick={() => toggleExpanded(props.target.target_id)}
       >
         <td class={`py-2.5 px-3 hover:text-theme-accent transition-colors ${
           props.target.target_id === "obj:__uncategorized__"
@@ -96,13 +96,14 @@ const TargetRow: Component<{
             </Show>
           )}
         </For>
-        <td class="py-2.5 px-3">
+        <td class="py-2.5 px-3 flex items-center gap-1.5">
           <button
             class="px-2.5 py-1 border border-theme-border-em rounded text-label text-theme-text-secondary hover:text-theme-text-primary hover:border-theme-accent transition-colors"
-            onClick={(e) => { e.stopPropagation(); toggleExpanded(props.target.target_id); }}
+            onClick={(e) => { e.stopPropagation(); navigate(`/targets/${encodeURIComponent(props.target.target_id)}?view=sessions`); }}
           >
-            {isOpen() ? "Collapse" : "Expand"}
+            Detail
           </button>
+          <span class="text-theme-text-tertiary text-xs select-none">{isOpen() ? "▲" : "▼"}</span>
         </td>
         <Show when={props.target.matched_sessions != null}>
           <td class="py-2.5 px-3 text-xs text-theme-warning">
@@ -114,7 +115,7 @@ const TargetRow: Component<{
       {/* Mobile card -- shown below md */}
       <tr
         class="md:hidden border-b border-theme-border cursor-pointer hover:bg-theme-hover transition-colors duration-150"
-        onClick={() => navigate(`/targets/${encodeURIComponent(props.target.target_id)}?view=sessions`)}
+        onClick={() => toggleExpanded(props.target.target_id)}
       >
         <td colspan="99" class="p-3">
           <div class="space-y-1.5">
@@ -134,12 +135,15 @@ const TargetRow: Component<{
                   </A>
                 )}
               </span>
-              <button
-                class="px-2 py-0.5 border border-theme-border-em rounded text-label text-theme-text-secondary hover:text-theme-text-primary hover:border-theme-accent transition-colors flex-shrink-0"
-                onClick={(e) => { e.stopPropagation(); toggleExpanded(props.target.target_id); }}
-              >
-                {isOpen() ? "Collapse" : "Expand"}
-              </button>
+              <div class="flex items-center gap-1.5 flex-shrink-0">
+                <button
+                  class="px-2 py-0.5 border border-theme-border-em rounded text-label text-theme-text-secondary hover:text-theme-text-primary hover:border-theme-accent transition-colors"
+                  onClick={(e) => { e.stopPropagation(); navigate(`/targets/${encodeURIComponent(props.target.target_id)}?view=sessions`); }}
+                >
+                  Detail
+                </button>
+                <span class="text-theme-text-tertiary text-xs select-none">{isOpen() ? "▲" : "▼"}</span>
+              </div>
             </div>
             <Show when={props.target.target_id !== "obj:__uncategorized__"}>
               <div class="font-mono text-theme-text-secondary text-xs">{props.target.primary_name}</div>

--- a/frontend/src/components/TargetRow.tsx
+++ b/frontend/src/components/TargetRow.tsx
@@ -36,7 +36,7 @@ const TargetRow: Component<{
       {/* Desktop table row -- hidden below md */}
       <tr
         class="border-b border-theme-border cursor-pointer hover:bg-theme-hover transition-colors duration-150 hidden md:table-row"
-        onClick={() => toggleExpanded(props.target.target_id)}
+        onClick={() => navigate(`/targets/${encodeURIComponent(props.target.target_id)}?view=sessions`)}
       >
         <td class={`py-2.5 px-3 hover:text-theme-accent transition-colors ${
           props.target.target_id === "obj:__uncategorized__"
@@ -96,14 +96,13 @@ const TargetRow: Component<{
             </Show>
           )}
         </For>
-        <td class="py-2.5 px-3 flex items-center gap-1.5">
+        <td class="py-2.5 px-3">
           <button
             class="px-2.5 py-1 border border-theme-border-em rounded text-label text-theme-text-secondary hover:text-theme-text-primary hover:border-theme-accent transition-colors"
-            onClick={(e) => { e.stopPropagation(); navigate(`/targets/${encodeURIComponent(props.target.target_id)}?view=sessions`); }}
+            onClick={(e) => { e.stopPropagation(); toggleExpanded(props.target.target_id); }}
           >
-            Detail
+            {isOpen() ? "Collapse" : "Expand"}
           </button>
-          <span class="text-theme-text-tertiary text-xs select-none">{isOpen() ? "▲" : "▼"}</span>
         </td>
         <Show when={props.target.matched_sessions != null}>
           <td class="py-2.5 px-3 text-xs text-theme-warning">
@@ -115,7 +114,7 @@ const TargetRow: Component<{
       {/* Mobile card -- shown below md */}
       <tr
         class="md:hidden border-b border-theme-border cursor-pointer hover:bg-theme-hover transition-colors duration-150"
-        onClick={() => toggleExpanded(props.target.target_id)}
+        onClick={() => navigate(`/targets/${encodeURIComponent(props.target.target_id)}?view=sessions`)}
       >
         <td colspan="99" class="p-3">
           <div class="space-y-1.5">
@@ -135,15 +134,12 @@ const TargetRow: Component<{
                   </A>
                 )}
               </span>
-              <div class="flex items-center gap-1.5 flex-shrink-0">
-                <button
-                  class="px-2 py-0.5 border border-theme-border-em rounded text-label text-theme-text-secondary hover:text-theme-text-primary hover:border-theme-accent transition-colors"
-                  onClick={(e) => { e.stopPropagation(); navigate(`/targets/${encodeURIComponent(props.target.target_id)}?view=sessions`); }}
-                >
-                  Detail
-                </button>
-                <span class="text-theme-text-tertiary text-xs select-none">{isOpen() ? "▲" : "▼"}</span>
-              </div>
+              <button
+                class="px-2 py-0.5 border border-theme-border-em rounded text-label text-theme-text-secondary hover:text-theme-text-primary hover:border-theme-accent transition-colors flex-shrink-0"
+                onClick={(e) => { e.stopPropagation(); toggleExpanded(props.target.target_id); }}
+              >
+                {isOpen() ? "Collapse" : "Expand"}
+              </button>
             </div>
             <Show when={props.target.target_id !== "obj:__uncategorized__"}>
               <div class="font-mono text-theme-text-secondary text-xs">{props.target.primary_name}</div>

--- a/frontend/src/components/settings/MosaicsTab.tsx
+++ b/frontend/src/components/settings/MosaicsTab.tsx
@@ -1,4 +1,5 @@
 import { Component, For, Show, createEffect, createMemo, createSignal, onMount } from "solid-js";
+import { useNavigate } from "@solidjs/router";
 import { api } from "../../api/client";
 import { showToast, dismissToast } from "../Toast";
 import { useAuth } from "../AuthProvider";
@@ -23,6 +24,7 @@ import { isColumnVisible } from "../../utils/displaySettings";
 
 export const MosaicsTab: Component = () => {
   const { isAdmin } = useAuth();
+  const navigate = useNavigate();
   const settingsCtx = useSettingsContext();
 
   // Keywords state
@@ -1054,7 +1056,7 @@ export const MosaicsTab: Component = () => {
               <For each={sortedMosaics()}>
                 {(m) => (
                   <>
-                    <tr class="border-b border-theme-border hover:bg-theme-base/30 cursor-pointer" onClick={() => toggleExpand(m.id)}>
+                    <tr class="border-b border-theme-border hover:bg-theme-base/30 cursor-pointer" onClick={() => navigate(`/mosaics/${m.id}`)}>
                       {/* Name cell */}
                       <td class="py-2.5 px-3 text-theme-text-primary text-sm">
                         <div class="flex items-center gap-2">
@@ -1151,15 +1153,12 @@ export const MosaicsTab: Component = () => {
                               </div>
                             </Show>
                           </Show>
-                          <a
-                            href={`/mosaics/${m.id}`}
-                            class="px-4 py-1.5 bg-theme-accent/15 text-theme-accent border border-theme-accent/30 rounded text-sm font-medium hover:bg-theme-accent/25 transition-colors"
+                          <button
+                            onClick={() => toggleExpand(m.id)}
+                            class="px-2.5 py-1 border border-theme-border-em rounded text-label text-theme-text-secondary hover:text-theme-text-primary hover:border-theme-accent transition-colors"
                           >
-                            Detail
-                          </a>
-                          <span class="text-theme-text-secondary text-xs ml-1">
-                            {expandedId() === m.id ? "▲" : "▼"}
-                          </span>
+                            {expandedId() === m.id ? "Collapse" : "Expand"}
+                          </button>
                         </div>
                       </td>
                     </tr>


### PR DESCRIPTION
**What's changed**:
*   Target feed now displays within a styled card container.
*   Clicking a target row now expands or collapses its details.
*   Use the new "Detail" button to navigate to a target's full page.
*   Clicking a mosaic row now navigates to its detail page.
*   An action button on mosaic rows toggles inline details.