### PR TITLE
security: harden authentication, authorization, and injection surfaces

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Cookie, Depends, HTTPException, Request, Response
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config import settings, limiter, async_redis
+from app.config import settings, limiter, async_redis, client_ip_from_request
 from app.database import get_session
 from app.models.user import User, UserRole
 from app.schemas.auth import (
@@ -76,10 +76,10 @@ def _clear_auth_cookies(response: Response) -> None:
 
 
 def _get_client_ip(request: Request) -> str:
-    forwarded = request.headers.get("x-forwarded-for")
-    if forwarded:
-        return forwarded.split(",")[0].strip()
-    return request.client.host if request.client else "unknown"
+    # Centralized in config.client_ip_from_request so the rate limiter and the
+    # login lockout derive the real client IP the same way (behind nginx the
+    # raw socket peer is always 127.0.0.1; X-Forwarded-For carries the client).
+    return client_ip_from_request(request)
 
 
 MAX_LOGIN_FAILURES = 5
@@ -87,15 +87,25 @@ LOGIN_FAILURE_WINDOW = 900       # 15 minutes
 LOCKOUT_DURATION = 1800          # 30 minutes
 
 
-async def _increment_login_failures(redis, username: str) -> None:
-    key = f"auth:failures:{username}"
+def _lockout_id(username: str, ip: str) -> str:
+    """Identity used for login failure tracking: per username + client IP.
+
+    Keying on both prevents a single client from locking out a victim account
+    globally, while still throttling brute-force attempts from one source.
+    """
+    return f"{username}|{ip}"
+
+
+async def _increment_login_failures(redis, username: str, ip: str) -> None:
+    identity = _lockout_id(username, ip)
+    key = f"auth:failures:{identity}"
     pipe = redis.pipeline()
     pipe.incr(key)
     pipe.expire(key, LOGIN_FAILURE_WINDOW)
     results = await pipe.execute()
     failures = results[0]
     if failures >= MAX_LOGIN_FAILURES:
-        await redis.setex(f"auth:lockout:{username}", LOCKOUT_DURATION, "locked")
+        await redis.setex(f"auth:lockout:{identity}", LOCKOUT_DURATION, "locked")
 
 
 # ---------------------------------------------------------------------------
@@ -111,10 +121,11 @@ async def login(
     session: AsyncSession = Depends(get_session),
 ):
     ip = _get_client_ip(request)
+    identity = _lockout_id(body.username, ip)
 
-    # Check account lockout
+    # Check account lockout (per username + client IP)
     async with async_redis() as redis:
-        locked = await redis.exists(f"auth:lockout:{body.username}")
+        locked = await redis.exists(f"auth:lockout:{identity}")
         if locked:
             audit_log("login", username=body.username, source_ip=ip, success=False, detail="Account locked")
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Account temporarily locked")
@@ -125,12 +136,12 @@ async def login(
         valid = verify_password_timing_safe(body.password, password_hash)
 
         if not valid or user is None or not user.is_active:
-            await _increment_login_failures(redis, body.username)
+            await _increment_login_failures(redis, body.username, ip)
             audit_log("login", username=body.username, source_ip=ip, success=False, detail="Invalid credentials")
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
 
         # Successful login - clear failure counter
-        await redis.delete(f"auth:failures:{body.username}")
+        await redis.delete(f"auth:failures:{identity}")
 
     access = create_access_token(user.id, user.role.value)
     refresh = generate_refresh_token()

--- a/backend/app/api/custom_columns.py
+++ b/backend/app/api/custom_columns.py
@@ -6,7 +6,7 @@ from sqlalchemy import select, func, and_
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_session
-from app.api.deps import get_current_user
+from app.api.deps import get_current_user, require_admin
 from app.models.user import User
 from app.models.custom_column import CustomColumn, CustomColumnValue, ColumnType, AppliesTo
 from app.schemas.custom_column import (
@@ -61,7 +61,7 @@ async def list_custom_columns(
 async def create_custom_column(
     body: CustomColumnCreate,
     session: AsyncSession = Depends(get_session),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_admin),
 ):
     base_slug = _slugify(body.name)
     slug = await _unique_slug(session, base_slug)
@@ -96,7 +96,7 @@ async def update_custom_column(
     column_id: uuid.UUID,
     body: CustomColumnUpdate,
     session: AsyncSession = Depends(get_session),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_admin),
 ):
     col = await session.get(CustomColumn, column_id)
     if not col:
@@ -125,7 +125,7 @@ async def update_custom_column(
 async def delete_custom_column(
     column_id: uuid.UUID,
     session: AsyncSession = Depends(get_session),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_admin),
 ):
     col = await session.get(CustomColumn, column_id)
     if not col:
@@ -190,7 +190,7 @@ async def get_mosaic_custom_values(
 async def set_custom_value(
     body: CustomColumnValueSet,
     session: AsyncSession = Depends(get_session),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_admin),
 ):
     col_id = uuid.UUID(body.column_id)
     target_id = uuid.UUID(body.target_id) if body.target_id else None

--- a/backend/app/api/integrations.py
+++ b/backend/app/api/integrations.py
@@ -1,8 +1,15 @@
+import ipaddress
 import logging
+import os
 import re
+import socket
+from urllib.parse import urlparse
 
 import httpx
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.api.deps import get_current_user
+from app.models.user import User
 from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
@@ -10,6 +17,84 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/integrations", tags=["integrations"])
 
 TIMEOUT = 5.0
+
+# Short timeout for the SSRF DNS resolution probe so a slow/hostile resolver
+# cannot hang the request.
+_DNS_TIMEOUT = 2.0
+
+
+def _is_blocked_ip(ip: ipaddress._BaseAddress) -> bool:
+    """Return True if *ip* points at loopback, link-local, or the cloud
+    metadata range (169.254.169.254 lives inside link-local 169.254.0.0/16).
+
+    Covers IPv4 (127.0.0.0/8, 169.254.0.0/16) and IPv6 (::1, fe80::/10),
+    including IPv4-mapped IPv6 forms which are unwrapped first.
+    """
+    # Unwrap IPv4-mapped / IPv4-compatible IPv6 (e.g. ::ffff:169.254.169.254).
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
+    return ip.is_loopback or ip.is_link_local
+
+
+def _validate_integration_url(url: str) -> None:
+    """Validate a caller-supplied integration URL to mitigate SSRF.
+
+    NINA/Stellarium typically run on the user's LAN, so normal private ranges
+    (10/8, 172.16/12, 192.168/16) are intentionally allowed. This rejects
+    non-http(s) schemes, loopback/link-local/metadata addresses (whether the
+    host is a literal IP or a hostname that resolves to one), and enforces an
+    optional host allowlist from GALACTILOG_INTEGRATION_ALLOWED_HOSTS.
+
+    Resolving the host introduces a residual TOCTOU window (DNS could change
+    between this check and the outbound request). That is accepted for this
+    self-hosted, authenticated, LAN-integration threat model.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise HTTPException(status_code=400, detail="URL scheme must be http or https")
+
+    host = parsed.hostname
+    if not host:
+        raise HTTPException(status_code=400, detail="URL must include a host")
+
+    # Literal IP (IPv4 or IPv6): block loopback/link-local/metadata directly.
+    literal_ip = None
+    try:
+        literal_ip = ipaddress.ip_address(host)
+    except ValueError:
+        pass
+    if literal_ip is not None and _is_blocked_ip(literal_ip):
+        raise HTTPException(status_code=400, detail="URL host resolves to a blocked address")
+
+    allowed = os.environ.get("GALACTILOG_INTEGRATION_ALLOWED_HOSTS")
+    if allowed:
+        allowed_hosts = {h.strip().lower() for h in allowed.split(",") if h.strip()}
+        if host.lower() not in allowed_hosts:
+            raise HTTPException(status_code=400, detail="URL host is not in the allowlist")
+
+    # Hostname: resolve and reject if ANY address is blocked. On resolution
+    # failure, only reject if it was a literal IP (already handled above);
+    # otherwise allow, so air-gapped LAN names that don't resolve here still work.
+    if literal_ip is None:
+        old_timeout = socket.getdefaulttimeout()
+        try:
+            socket.setdefaulttimeout(_DNS_TIMEOUT)
+            infos = socket.getaddrinfo(host, parsed.port, proto=socket.IPPROTO_TCP)
+        except (socket.gaierror, OSError):
+            infos = None
+        finally:
+            socket.setdefaulttimeout(old_timeout)
+        if infos:
+            for info in infos:
+                addr = info[4][0]
+                try:
+                    resolved = ipaddress.ip_address(addr)
+                except ValueError:
+                    continue
+                if _is_blocked_ip(resolved):
+                    raise HTTPException(
+                        status_code=400, detail="URL host resolves to a blocked address"
+                    )
 
 _CATALOG_RE = re.compile(
     r"^(NGC|IC|M|Sh2|LDN|LBN|Abell|Ced|vdB|Cr|Mel|Barnard|PGC|UGC|Arp)\s*[-]?\s*\d+",
@@ -47,9 +132,10 @@ class StellariumRequest(BaseModel):
 
 
 @router.post("/nina/send-coordinates")
-async def send_to_nina(req: NinaRequest):
+async def send_to_nina(req: NinaRequest, current_user: User = Depends(get_current_user)):
     import asyncio
 
+    _validate_integration_url(req.url)
     base = req.url.rstrip("/")
     endpoint = f"{base}/v2/api/framing/set-coordinates?RAangle={req.ra}&DecAngle={req.dec}"
     try:
@@ -74,7 +160,8 @@ async def send_to_nina(req: NinaRequest):
 
 
 @router.post("/stellarium/send-coordinates")
-async def send_to_stellarium(req: StellariumRequest):
+async def send_to_stellarium(req: StellariumRequest, current_user: User = Depends(get_current_user)):
+    _validate_integration_url(req.url)
     base = req.url.rstrip("/")
     try:
         async with httpx.AsyncClient(timeout=TIMEOUT) as client:

--- a/backend/app/api/metrics_endpoint.py
+++ b/backend/app/api/metrics_endpoint.py
@@ -1,12 +1,37 @@
-from fastapi import APIRouter
+import hmac
+import os
+
+from fastapi import APIRouter, Header, HTTPException, status
 from fastapi.responses import Response
 from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
 
 router = APIRouter(prefix="/api")
 
+_BEARER_PREFIX = "Bearer "
+
 
 @router.get("/metrics", include_in_schema=False)
-async def metrics():
+async def metrics(authorization: str | None = Header(default=None)):
+    # Optional bearer-token guard. When GALACTILOG_METRICS_TOKEN is set, require
+    # a matching `Authorization: Bearer <token>` header. When unset, no token is
+    # required (default behavior; access is restricted by the nginx allowlist).
+    expected_token = os.environ.get("GALACTILOG_METRICS_TOKEN")
+    if expected_token:
+        unauthorized = HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or missing metrics token",
+        )
+        # Require the "Bearer " scheme and a non-empty token; reject other
+        # schemes (e.g. "Basic ...") and a bare/empty bearer value.
+        if not authorization or not authorization.startswith(_BEARER_PREFIX):
+            raise unauthorized
+        presented_token = authorization[len(_BEARER_PREFIX):]
+        if not presented_token:
+            raise unauthorized
+        # Constant-time comparison to avoid a timing side-channel.
+        if not hmac.compare_digest(presented_token, expected_token):
+            raise unauthorized
+
     return Response(
         content=generate_latest(),
         media_type=CONTENT_TYPE_LATEST,

--- a/backend/app/api/mosaics.py
+++ b/backend/app/api/mosaics.py
@@ -24,7 +24,7 @@ from app.schemas.mosaic import (
     PanelThumbnail,
     PanelSessionsResponse, PanelSessionInfo, SessionStatusUpdate,
 )
-from app.api.auth import get_current_user
+from app.api.deps import get_current_user, require_admin
 from app.services.mosaic_composite import build_mosaic_composite, find_default_filter
 
 router = APIRouter(prefix="/mosaics", tags=["mosaics"])
@@ -508,7 +508,7 @@ async def _batch_panel_stats(
 @router.post("/detect")
 async def trigger_detection(
     session: AsyncSession = Depends(get_session),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_admin),
 ):
     from app.services.mosaic_detection import detect_mosaic_panels
 
@@ -641,7 +641,7 @@ async def accept_suggestion(
     suggestion_id: uuid.UUID,
     body: AcceptSuggestionRequest = AcceptSuggestionRequest(),
     session: AsyncSession = Depends(get_session),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_admin),
 ):
     suggestion = await session.get(MosaicSuggestion, suggestion_id)
     if not suggestion or suggestion.status != "pending":
@@ -738,7 +738,7 @@ async def accept_suggestion(
 async def dismiss_suggestion(
     suggestion_id: uuid.UUID,
     session: AsyncSession = Depends(get_session),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_admin),
 ):
     suggestion = await session.get(MosaicSuggestion, suggestion_id)
     if not suggestion or suggestion.status != "pending":
@@ -751,7 +751,7 @@ async def dismiss_suggestion(
 @router.post("/clear-reviews")
 async def clear_all_reviews(
     session: AsyncSession = Depends(get_session),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_admin),
 ):
     from sqlalchemy import update
     await session.execute(
@@ -954,7 +954,7 @@ async def list_mosaics(
 async def create_mosaic(
     body: MosaicCreate,
     session: AsyncSession = Depends(get_session),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_admin),
 ):
     mosaic = Mosaic(name=body.name, notes=body.notes)
     session.add(mosaic)
@@ -1330,7 +1330,7 @@ async def update_mosaic(
     mosaic_id: uuid.UUID,
     body: MosaicUpdate,
     session: AsyncSession = Depends(get_session),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_admin),
 ):
     mosaic = await session.get(Mosaic, mosaic_id)
     if not mosaic:
@@ -1351,7 +1351,7 @@ async def update_mosaic(
 async def delete_mosaic(
     mosaic_id: uuid.UUID,
     session: AsyncSession = Depends(get_session),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_admin),
 ):
     mosaic = await session.get(Mosaic, mosaic_id)
     if not mosaic:
@@ -1381,7 +1381,7 @@ async def add_panel(
     mosaic_id: uuid.UUID,
     body: MosaicPanelCreate,
     session: AsyncSession = Depends(get_session),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_admin),
 ):
     mosaic = await session.get(Mosaic, mosaic_id)
     if not mosaic:
@@ -1423,7 +1423,7 @@ async def batch_update_panels(
     mosaic_id: uuid.UUID,
     body: MosaicPanelBatchRequest,
     session: AsyncSession = Depends(get_session),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_admin),
 ):
     """Update multiple panels in a single transaction (positions, rotation, flip)."""
     q = (
@@ -1485,7 +1485,7 @@ async def update_panel(
     panel_id: uuid.UUID,
     body: MosaicPanelUpdate,
     session: AsyncSession = Depends(get_session),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_admin),
 ):
     panel = await session.get(MosaicPanel, panel_id)
     if not panel or panel.mosaic_id != mosaic_id:
@@ -1515,7 +1515,7 @@ async def remove_panel(
     mosaic_id: uuid.UUID,
     panel_id: uuid.UUID,
     session: AsyncSession = Depends(get_session),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_admin),
 ):
     panel = await session.get(MosaicPanel, panel_id)
     if not panel or panel.mosaic_id != mosaic_id:
@@ -1608,7 +1608,7 @@ async def update_panel_sessions(
     panel_id: uuid.UUID,
     body: SessionStatusUpdate,
     session: AsyncSession = Depends(get_session),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_admin),
 ):
     """Bulk include/exclude sessions for a panel."""
     from datetime import date as date_type

--- a/backend/app/api/planning.py
+++ b/backend/app/api/planning.py
@@ -3,18 +3,23 @@ from __future__ import annotations
 
 import asyncio
 
-from fastapi import APIRouter, Query, HTTPException
+from fastapi import APIRouter, Depends, Query, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import async_session
+from app.api.deps import get_current_user
 from app.api.stats import _extract_site_coords
+from app.models.user import User
 from app.services.usno import get_night_ephemeris
 
 router = APIRouter(prefix="/planning", tags=["planning"])
 
 
 @router.get("/night")
-async def get_night(date: str = Query(..., description="Date in YYYY-MM-DD format")):
+async def get_night(
+    date: str = Query(..., description="Date in YYYY-MM-DD format"),
+    user: User = Depends(get_current_user),
+):
     """Return astronomical twilight times and moon data for a given night.
 
     Observer location is derived from FITS header site coordinates.

--- a/backend/app/api/preview.py
+++ b/backend/app/api/preview.py
@@ -9,9 +9,11 @@ from fastapi.responses import FileResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.api.deps import get_current_user
 from app.config import get_sync_redis, settings
 from app.database import get_session
 from app.models import Image, UserSettings, SETTINGS_ROW_ID
+from app.models.user import User
 from app.schemas.settings import GeneralSettings
 from app.services.preview import generate_preview
 from app.services.preview_cache import PreviewCache
@@ -28,6 +30,7 @@ async def get_preview(
     image_id: UUID,
     resolution: int = Query(..., ge=0, le=20000),
     session: AsyncSession = Depends(get_session),
+    user: User = Depends(get_current_user),
 ) -> Response:
     """Serve a high-resolution preview JPEG for an image.
 

--- a/backend/app/api/targets.py
+++ b/backend/app/api/targets.py
@@ -35,7 +35,7 @@ def _parse_sexa_dec(s: str) -> float | None:
         return sign * (d + m / 60 + sec / 3600)
     except (ValueError, IndexError):
         return None
-from app.api.deps import get_current_user
+from app.api.deps import get_current_user, require_admin
 from app.config import settings, async_redis
 from app.models import Target, Image
 from app.models.catalog_membership import TargetCatalogMembership
@@ -1997,7 +1997,7 @@ async def update_target_notes(
     target_id: uuid.UUID,
     body: NotesUpdate,
     session: AsyncSession = Depends(get_session),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_admin),
 ):
     target = await session.get(Target, target_id)
     if not target:
@@ -2013,7 +2013,7 @@ async def update_session_notes(
     date: str,
     body: NotesUpdate,
     session: AsyncSession = Depends(get_session),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_admin),
 ):
     session_date = date_type.fromisoformat(date)
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,6 +1,10 @@
+import logging
+import os
 import secrets
 
 from pydantic_settings import BaseSettings
+
+logger = logging.getLogger(__name__)
 
 
 class Settings(BaseSettings):
@@ -11,6 +15,10 @@ class Settings(BaseSettings):
     previews_path: str = "/app/data/thumbnails/previews"
     thumbnail_max_width: int = 800
     jwt_secret: str = ""
+    # Path to persist an auto-generated JWT secret when GALACTILOG_JWT_SECRET is
+    # unset. Default lives under the FITS/thumbnail data volume so it survives
+    # restarts and is shared by all workers.
+    jwt_secret_file: str = "/app/data/.jwt_secret"
     access_token_expiry: int = 1800
     refresh_token_expiry: int = 604800
     https: bool = True
@@ -24,11 +32,69 @@ class Settings(BaseSettings):
 
 settings = Settings()
 
-# Auto-generate JWT secret if not set -- stable for the lifetime of the process,
-# but tokens won't survive a restart. Fine for getting started; set GALACTILOG_JWT_SECRET
-# in .env for persistence across restarts.
+
+def load_or_create_jwt_secret(secret_file: str) -> str:
+    """Load a persisted JWT secret from ``secret_file`` or create one.
+
+    The generated secret is written to a stable file so it survives process
+    restarts and is shared across multiple workers. The write tolerates
+    concurrent workers racing to create the file: if another worker wins the
+    race, the secret it persisted is read back and returned.
+    """
+    # Fast path: file already exists.
+    try:
+        with open(secret_file, "r", encoding="utf-8") as fh:
+            existing = fh.read().strip()
+        if existing:
+            return existing
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        logger.warning("Could not read JWT secret file %s: %s", secret_file, exc)
+
+    secret = secrets.token_hex(32)
+    parent = os.path.dirname(secret_file)
+    if parent:
+        try:
+            os.makedirs(parent, exist_ok=True)
+        except OSError as exc:
+            logger.warning("Could not create directory for JWT secret file %s: %s", parent, exc)
+
+    try:
+        # O_EXCL ensures only the first worker writes; others race-lose here.
+        fd = os.open(secret_file, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            os.write(fd, secret.encode("utf-8"))
+        finally:
+            os.close(fd)
+        return secret
+    except FileExistsError:
+        # Another worker created it first; read back its secret.
+        try:
+            with open(secret_file, "r", encoding="utf-8") as fh:
+                persisted = fh.read().strip()
+            if persisted:
+                return persisted
+        except OSError as exc:
+            logger.warning("Could not read JWT secret file %s after race: %s", secret_file, exc)
+        return secret
+    except OSError as exc:
+        # Could not persist (read-only FS etc.); fall back to in-memory secret.
+        logger.warning(
+            "Could not persist JWT secret to %s: %s. Using an in-memory secret; "
+            "sessions will not survive restarts.",
+            secret_file,
+            exc,
+        )
+        return secret
+
+
+# Auto-generate JWT secret if not set. The secret is persisted to a stable file
+# (settings.jwt_secret_file) so it survives restarts and is shared by all
+# workers. Operators should still set GALACTILOG_JWT_SECRET explicitly for
+# production/multi-host deployments (see the startup warning in main.py).
 if not settings.jwt_secret:
-    settings.jwt_secret = secrets.token_hex(32)
+    settings.jwt_secret = load_or_create_jwt_secret(settings.jwt_secret_file)
 
 import redis.asyncio as aioredis
 import redis as sync_redis
@@ -53,9 +119,31 @@ def get_sync_redis() -> sync_redis.Redis:
     return sync_redis.from_url(settings.redis_url, decode_responses=True)
 
 from slowapi import Limiter
-from slowapi.util import get_remote_address
+
+
+def client_ip_from_request(request) -> str:
+    """Derive the real client IP from the X-Forwarded-For header.
+
+    Security assumption: nginx is the sole entry point and the backend is bound
+    to localhost, so X-Forwarded-For can only have been set by our own trusted
+    proxy (clients cannot reach the app directly to spoof it). nginx sets the
+    header via ``$proxy_add_x_forwarded_for``, which appends the connecting peer
+    to any pre-existing value, producing the order
+    ``original-client, proxy1, proxy2, ...``; hence the left-most non-empty
+    entry is the originating client. Falls back to the direct socket peer
+    (request.client.host) when no header is present (e.g. local dev without
+    nginx).
+    """
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        for part in forwarded.split(","):
+            ip = part.strip()
+            if ip:
+                return ip
+    return request.client.host if request.client else "unknown"
+
 
 limiter = Limiter(
-    key_func=get_remote_address,
+    key_func=client_ip_from_request,
     storage_uri=settings.redis_url,
 )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,6 +2,7 @@ import logging
 import os
 from contextlib import asynccontextmanager
 from pathlib import Path
+from urllib.parse import urlparse
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -20,9 +21,16 @@ logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # Warn if JWT secret was auto-generated (won't survive restarts)
+    # Warn if JWT secret was auto-generated. It is now persisted to the secret
+    # file (settings.jwt_secret_file), so sessions survive single-host restarts;
+    # set GALACTILOG_JWT_SECRET explicitly for multi-host/multi-instance setups.
     if not os.environ.get("GALACTILOG_JWT_SECRET"):
-        logger.warning("GALACTILOG_JWT_SECRET is not set - using auto-generated secret. Sessions will not survive restarts. Set GALACTILOG_JWT_SECRET in .env for persistence.")
+        logger.warning(
+            "GALACTILOG_JWT_SECRET is not set - using an auto-generated secret "
+            "persisted to %s. Sessions survive restarts on this host. Set "
+            "GALACTILOG_JWT_SECRET explicitly for multi-host/multi-instance deployments.",
+            settings.jwt_secret_file,
+        )
 
     # Ensure required PostgreSQL extensions exist (idempotent)
     from sqlalchemy import text
@@ -115,6 +123,46 @@ async def lifespan(app: FastAPI):
     yield
 
 
+def _resolve_cors_config(raw_origins: str | None, allow_credentials: bool = True):
+    """Validate operator-supplied CORS origins.
+
+    Returns ``(origins, allow_credentials)``.
+
+    - Each origin must be well-formed (scheme http/https + host); malformed
+      entries are dropped with a warning.
+    - A wildcard ("*") combined with credentials is unsafe (and rejected by
+      browsers anyway). If "*" is present we disable credentials so the
+      server-side intent is explicit and safe.
+    """
+    if not raw_origins:
+        return [], allow_credentials
+
+    valid: list[str] = []
+    has_wildcard = False
+    for entry in raw_origins.split(","):
+        origin = entry.strip()
+        if not origin:
+            continue
+        if origin == "*":
+            has_wildcard = True
+            valid.append(origin)
+            continue
+        parsed = urlparse(origin)
+        if parsed.scheme in ("http", "https") and parsed.netloc:
+            valid.append(origin)
+        else:
+            logger.warning("Ignoring malformed CORS origin: %r", origin)
+
+    if has_wildcard and allow_credentials:
+        logger.warning(
+            "CORS wildcard '*' is configured with credentials enabled; "
+            "disabling allow_credentials (browsers reject '*' with credentials)."
+        )
+        allow_credentials = False
+
+    return valid, allow_credentials
+
+
 def create_app() -> FastAPI:
     application = FastAPI(
         title="GalactiLog",
@@ -131,12 +179,14 @@ def create_app() -> FastAPI:
         return JSONResponse(status_code=429, content={"detail": "Rate limit exceeded"})
 
     # CORS for dev mode
-    cors_origins = os.environ.get("GALACTILOG_CORS_ORIGINS")
+    cors_origins, cors_allow_credentials = _resolve_cors_config(
+        os.environ.get("GALACTILOG_CORS_ORIGINS"), allow_credentials=True
+    )
     if cors_origins:
         application.add_middleware(
             CORSMiddleware,
-            allow_origins=[o.strip() for o in cors_origins.split(",")],
-            allow_credentials=True,
+            allow_origins=cors_origins,
+            allow_credentials=cors_allow_credentials,
             allow_methods=["*"],
             allow_headers=["*"],
         )

--- a/backend/app/services/simbad.py
+++ b/backend/app/services/simbad.py
@@ -9,6 +9,15 @@ logger = logging.getLogger(__name__)
 SIMBAD_TAP_URL = "https://simbad.cds.unistra.fr/simbad/sim-tap/sync"
 
 
+def _escape_adql_string(value: str) -> str:
+    """Escape a value for use inside a single-quoted ADQL/SQL string literal.
+
+    Doubles single quotes per the SQL standard so the value cannot break out
+    of the surrounding quotes.
+    """
+    return value.replace("'", "''")
+
+
 def normalize_object_name(name: str, *, upper: bool = True) -> str:
     """Normalize a target name: strip outer whitespace, collapse inner spaces.
 
@@ -181,7 +190,7 @@ async def _fetch_tap_aliases(object_name: str) -> list[str]:
     safe_chars = string.printable.replace('\n', '').replace('\r', '').replace('\t', '')
     sanitized = ''.join(c for c in object_name if c in safe_chars).strip()
 
-    query = f"SELECT id FROM ident JOIN basic ON ident.oidref = basic.oid WHERE basic.main_id = '{sanitized}'"
+    query = f"SELECT id FROM ident JOIN basic ON ident.oidref = basic.oid WHERE basic.main_id = '{_escape_adql_string(sanitized)}'"
     try:
         async with httpx.AsyncClient(timeout=15.0) as client:
             resp = await client.get(

--- a/backend/app/services/vizier.py
+++ b/backend/app/services/vizier.py
@@ -49,10 +49,33 @@ def determine_vizier_catalog(catalog_id: str | None) -> tuple[str, str, str] | N
     cleaned = catalog_id.strip()
 
     for pattern, viz_id, table, num_col in _CATALOG_MAP:
-        if pattern.match(cleaned):
+        # fullmatch so trailing junk (e.g. an injected "'; DROP ...") does not
+        # partially match a catalog pattern.
+        if pattern.fullmatch(cleaned):
             return (viz_id, table, num_col)
 
     return None
+
+
+def _adql_quote(value: str) -> str:
+    """Escape a value for use inside a single-quoted ADQL/SQL string literal.
+
+    Doubles single quotes per the SQL standard so the value cannot break out
+    of the surrounding quotes.
+    """
+    return value.replace("'", "''")
+
+
+def _adql_int(value: str) -> int | None:
+    """Coerce a value to int for use in an unquoted ADQL numeric comparison.
+
+    Returns None if the value is not a clean integer, so callers can decline
+    to build a query rather than interpolate raw text.
+    """
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        return None
 
 
 def _extract_number(catalog_id: str) -> str:
@@ -75,7 +98,8 @@ def build_adql_query(catalog_id: str | None) -> str | None:
         return None
 
     viz_id, table, num_col = result
-    number = _extract_number(catalog_id)
+    raw_number = _extract_number(catalog_id)
+    number = _adql_int(raw_number)
 
     # Note: VizieR computed columns (_RA_icrs, _DE_icrs) appear in SELECT *
     # output but cannot be explicitly named in ADQL.  We only need size data
@@ -84,6 +108,8 @@ def build_adql_query(catalog_id: str | None) -> str | None:
 
     if viz_id == "VII/20":
         # Sharpless: Sh2 is integer, Diam in arcmin
+        if number is None:
+            return None
         return f'SELECT Sh2, Diam FROM {table} WHERE Sh2={number}'
 
     elif viz_id == "VII/9" and num_col == "LBN_COORD":
@@ -102,32 +128,44 @@ def build_adql_query(catalog_id: str | None) -> str | None:
 
     elif viz_id == "VII/9":
         # LBN: Seq is integer, Diam1/Diam2 in arcmin
+        if number is None:
+            return None
         return f'SELECT Seq, Diam1, Diam2 FROM {table} WHERE Seq={number}'
 
     elif viz_id == "VII/216":
         # RCW: RCW is integer, MajAxis/MinAxis in arcmin
+        if number is None:
+            return None
         return f'SELECT RCW, MajAxis, MinAxis FROM {table} WHERE RCW={number}'
 
     elif viz_id == "VII/21":
         # vdB: VdB is integer, BRadMax in arcmin (radius, need to double)
+        if number is None:
+            return None
         return f'SELECT VdB, BRadMax, RRadMax FROM {table} WHERE VdB={number}'
 
     elif viz_id == "VII/7A":
         # LDN: LDN is integer, Area in sq deg
+        if number is None:
+            return None
         return f'SELECT LDN, Area FROM {table} WHERE LDN={number}'
 
     elif viz_id == "VII/220A":
         # Barnard: Barn is CHAR(4), space-padded - use TRIM
+        if number is None:
+            return None
         return f"SELECT Barn, Diam FROM {table} WHERE TRIM(Barn)='{number}'"
 
     elif viz_id == "VII/231":
         # Cederblad: Ced is string
-        ced_num = catalog_id.split()[-1].strip() if " " in catalog_id else number
-        return f"SELECT Ced, Dim1, Dim2 FROM {table} WHERE TRIM(Ced)='{ced_num}'"
+        ced_num = catalog_id.split()[-1].strip() if " " in catalog_id else raw_number
+        return f"SELECT Ced, Dim1, Dim2 FROM {table} WHERE TRIM(Ced)='{_adql_quote(ced_num)}'"
 
     elif viz_id == "V/84":
         # Planetary nebulae (Abell PNe): query by Name containing "A <number>"
         # Join with diam table for optical diameter
+        if number is None:
+            return None
         return (
             f'SELECT m."Name", d.oDiam '
             f'FROM "V/84/main" AS m '
@@ -138,7 +176,7 @@ def build_adql_query(catalog_id: str | None) -> str | None:
     elif viz_id == "B/ocl":
         # Open clusters: Cluster is string like "Collinder 399"
         cluster_name = catalog_id.strip()
-        return f"SELECT \"Cluster\", Diam FROM {table} WHERE \"Cluster\"='{cluster_name}'"
+        return f"SELECT \"Cluster\", Diam FROM {table} WHERE \"Cluster\"='{_adql_quote(cluster_name)}'"
 
     return None
 

--- a/backend/tests/test_api_integrations.py
+++ b/backend/tests/test_api_integrations.py
@@ -1,0 +1,257 @@
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+from app.api.deps import get_current_user
+from app.models.user import User, UserRole
+
+
+def _admin_user():
+    u = MagicMock(spec=User)
+    u.id = uuid.uuid4()
+    u.role = UserRole.admin
+    u.is_active = True
+    return u
+
+
+def _auth_override():
+    async def override():
+        return _admin_user()
+    return override
+
+
+# ---------------------------------------------------------------------------
+# Authentication
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_nina_requires_auth():
+    """Unauthenticated request to NINA endpoint is rejected with 401."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/api/integrations/nina/send-coordinates",
+            json={"url": "http://192.168.1.50:1888", "ra": 10.0, "dec": 20.0},
+        )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_stellarium_requires_auth():
+    """Unauthenticated request to Stellarium endpoint is rejected with 401."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/api/integrations/stellarium/send-coordinates",
+            json={"url": "http://192.168.1.50:8090", "ra": 10.0, "dec": 20.0},
+        )
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# SSRF hardening
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_nina_rejects_metadata_ip():
+    """Authenticated request to the cloud metadata IP is rejected with 400."""
+    app.dependency_overrides[get_current_user] = _auth_override()
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                "/api/integrations/nina/send-coordinates",
+                json={"url": "http://169.254.169.254/latest/meta-data", "ra": 1.0, "dec": 2.0},
+            )
+        assert resp.status_code == 400
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_stellarium_rejects_bad_scheme():
+    """A non-http(s) scheme is rejected with 400."""
+    app.dependency_overrides[get_current_user] = _auth_override()
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                "/api/integrations/stellarium/send-coordinates",
+                json={"url": "file:///etc/passwd", "ra": 1.0, "dec": 2.0},
+            )
+        assert resp.status_code == 400
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_nina_accepts_lan_url_when_authenticated():
+    """A normal LAN URL is accepted for an authenticated user (httpx mocked)."""
+    app.dependency_overrides[get_current_user] = _auth_override()
+
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_resp)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    try:
+        with patch("app.api.integrations.httpx.AsyncClient", return_value=mock_client):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.post(
+                    "/api/integrations/nina/send-coordinates",
+                    json={"url": "http://192.168.1.50:1888", "ra": 10.0, "dec": 20.0},
+                )
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+        mock_client.get.assert_awaited()
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# Link-local boundary IPs
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("ip", ["169.254.0.1", "169.254.255.255", "169.254.169.254"])
+@pytest.mark.asyncio
+async def test_nina_rejects_link_local_boundaries(ip):
+    """Both ends of the link-local range (and the metadata IP) are rejected."""
+    app.dependency_overrides[get_current_user] = _auth_override()
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                "/api/integrations/nina/send-coordinates",
+                json={"url": f"http://{ip}:1888", "ra": 1.0, "dec": 2.0},
+            )
+        assert resp.status_code == 400
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_rejects_ipv6_loopback_literal():
+    """An IPv6 loopback literal host is rejected."""
+    app.dependency_overrides[get_current_user] = _auth_override()
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                "/api/integrations/stellarium/send-coordinates",
+                json={"url": "http://[::1]:8090", "ra": 1.0, "dec": 2.0},
+            )
+        assert resp.status_code == 400
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# Allowlist enforcement
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_allowlist_rejects_host_not_in_list(monkeypatch):
+    """When GALACTILOG_INTEGRATION_ALLOWED_HOSTS is set, a host outside it is rejected."""
+    monkeypatch.setenv("GALACTILOG_INTEGRATION_ALLOWED_HOSTS", "nina.lan,stellarium.lan")
+    app.dependency_overrides[get_current_user] = _auth_override()
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                "/api/integrations/nina/send-coordinates",
+                json={"url": "http://192.168.1.50:1888", "ra": 1.0, "dec": 2.0},
+            )
+        assert resp.status_code == 400
+        assert "allowlist" in resp.json()["detail"].lower()
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_allowlist_accepts_host_in_list(monkeypatch):
+    """A host present in the allowlist is accepted (httpx mocked)."""
+    monkeypatch.setenv("GALACTILOG_INTEGRATION_ALLOWED_HOSTS", "nina.lan,stellarium.lan")
+    app.dependency_overrides[get_current_user] = _auth_override()
+
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_resp)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    try:
+        with patch("app.api.integrations.httpx.AsyncClient", return_value=mock_client):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.post(
+                    "/api/integrations/nina/send-coordinates",
+                    json={"url": "http://nina.lan:1888", "ra": 1.0, "dec": 2.0},
+                )
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# Hostname resolving to a blocked IP
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_rejects_hostname_resolving_to_metadata_ip():
+    """A hostname that resolves to the metadata IP is rejected (getaddrinfo mocked)."""
+    app.dependency_overrides[get_current_user] = _auth_override()
+
+    def fake_getaddrinfo(host, port, *args, **kwargs):
+        return [(2, 1, 6, "", ("169.254.169.254", port or 80))]
+
+    try:
+        with patch("app.api.integrations.socket.getaddrinfo", side_effect=fake_getaddrinfo):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.post(
+                    "/api/integrations/nina/send-coordinates",
+                    json={"url": "http://evil.example.com:1888", "ra": 1.0, "dec": 2.0},
+                )
+        assert resp.status_code == 400
+        assert "blocked" in resp.json()["detail"].lower()
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_allows_hostname_resolving_to_lan_ip():
+    """A hostname resolving to a normal LAN IP is allowed (getaddrinfo + httpx mocked)."""
+    app.dependency_overrides[get_current_user] = _auth_override()
+
+    def fake_getaddrinfo(host, port, *args, **kwargs):
+        return [(2, 1, 6, "", ("192.168.1.50", port or 80))]
+
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_resp)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    try:
+        with patch("app.api.integrations.socket.getaddrinfo", side_effect=fake_getaddrinfo), \
+                patch("app.api.integrations.httpx.AsyncClient", return_value=mock_client):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.post(
+                    "/api/integrations/nina/send-coordinates",
+                    json={"url": "http://nina.lan:1888", "ra": 1.0, "dec": 2.0},
+                )
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -111,6 +111,51 @@ async def test_viewer_blocked_on_scan(viewer_user):
     app.dependency_overrides.clear()
 
 
+class TestLockoutIdentity:
+    def test_identity_includes_username_and_ip(self):
+        from app.api.auth import _lockout_id
+        assert _lockout_id("alice", "203.0.113.7") == "alice|203.0.113.7"
+
+    def test_different_ip_yields_different_identity(self):
+        from app.api.auth import _lockout_id
+        a = _lockout_id("alice", "203.0.113.7")
+        b = _lockout_id("alice", "198.51.100.4")
+        assert a != b
+
+    @pytest.mark.asyncio
+    async def test_increment_locks_out_after_threshold(self):
+        from app.api.auth import _increment_login_failures, MAX_LOGIN_FAILURES, _lockout_id
+        redis = MagicMock()
+        pipe = MagicMock()
+        pipe.incr = MagicMock()
+        pipe.expire = MagicMock()
+        pipe.execute = AsyncMock(return_value=[MAX_LOGIN_FAILURES])
+        redis.pipeline = MagicMock(return_value=pipe)
+        redis.setex = AsyncMock()
+
+        await _increment_login_failures(redis, "alice", "203.0.113.7")
+
+        identity = _lockout_id("alice", "203.0.113.7")
+        redis.setex.assert_awaited_once()
+        args = redis.setex.await_args.args
+        assert args[0] == f"auth:lockout:{identity}"
+
+    @pytest.mark.asyncio
+    async def test_increment_no_lockout_below_threshold(self):
+        from app.api.auth import _increment_login_failures
+        redis = MagicMock()
+        pipe = MagicMock()
+        pipe.incr = MagicMock()
+        pipe.expire = MagicMock()
+        pipe.execute = AsyncMock(return_value=[1])
+        redis.pipeline = MagicMock(return_value=pipe)
+        redis.setex = AsyncMock()
+
+        await _increment_login_failures(redis, "alice", "203.0.113.7")
+
+        redis.setex.assert_not_awaited()
+
+
 class TestPasswordPolicy:
     def test_short_password_rejected(self):
         from app.schemas.auth import PasswordChangeRequest

--- a/backend/tests/test_authz_custom_columns.py
+++ b/backend/tests/test_authz_custom_columns.py
@@ -1,0 +1,184 @@
+"""Authorization tests for custom_columns write endpoints (SEC-2).
+
+Viewer role must be read-only: state-changing endpoints require admin.
+"""
+
+import uuid
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from httpx import AsyncClient, ASGITransport
+
+from app.main import app
+from app.database import get_session
+from app.api.deps import get_current_user
+
+
+def _override_user(user):
+    app.dependency_overrides[get_current_user] = lambda: user
+
+
+def _override_session(mock_session):
+    async def _gen():
+        yield mock_session
+    app.dependency_overrides[get_session] = _gen
+
+
+@pytest.mark.asyncio
+async def test_create_custom_column_viewer_forbidden(viewer_user):
+    _override_user(viewer_user)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/api/custom-columns",
+                json={"name": "Seeing", "column_type": "text", "applies_to": "target"},
+            )
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_create_custom_column_admin_allowed(admin_user):
+    mock_session = AsyncMock()
+    # _unique_slug + max display_order queries
+    slug_result = MagicMock()
+    slug_result.scalar_one_or_none.return_value = None
+    order_result = MagicMock()
+    order_result.scalar.return_value = 0
+    mock_session.execute = AsyncMock(side_effect=[slug_result, order_result])
+    mock_session.add = MagicMock()
+    mock_session.commit = AsyncMock()
+
+    created = {}
+
+    async def _refresh(obj):
+        # Populate server-side defaults the response model needs.
+        obj.created_at = __import__("datetime").datetime.now()
+        created["obj"] = obj
+
+    mock_session.refresh = AsyncMock(side_effect=_refresh)
+
+    _override_session(mock_session)
+    _override_user(admin_user)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/api/custom-columns",
+                json={"name": "Seeing", "column_type": "text", "applies_to": "target"},
+            )
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["name"] == "Seeing"
+    finally:
+        app.dependency_overrides.clear()
+
+
+def _make_column():
+    from datetime import datetime
+    from app.models.custom_column import CustomColumn, ColumnType, AppliesTo
+    col = MagicMock(spec=CustomColumn)
+    col.id = uuid.uuid4()
+    col.name = "Seeing"
+    col.slug = "seeing"
+    col.column_type = ColumnType.text
+    col.applies_to = AppliesTo.target
+    col.dropdown_options = None
+    col.display_order = 0
+    col.created_by = uuid.uuid4()
+    col.created_at = datetime.now()
+    return col
+
+
+@pytest.mark.asyncio
+async def test_update_custom_column_viewer_forbidden(viewer_user):
+    _override_user(viewer_user)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.patch(
+                f"/api/custom-columns/{uuid.uuid4()}", json={"name": "x"}
+            )
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_update_custom_column_admin_allowed(admin_user):
+    col = _make_column()
+
+    mock_session = AsyncMock()
+    mock_session.get = AsyncMock(return_value=col)
+    mock_session.commit = AsyncMock()
+    mock_session.refresh = AsyncMock()
+
+    _override_session(mock_session)
+    _override_user(admin_user)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            # display_order-only update avoids the slug uniqueness query.
+            resp = await client.patch(
+                f"/api/custom-columns/{col.id}", json={"display_order": 3}
+            )
+        assert resp.status_code == 200, resp.text
+        assert col.display_order == 3
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_delete_custom_column_viewer_forbidden(viewer_user):
+    _override_user(viewer_user)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.delete(f"/api/custom-columns/{uuid.uuid4()}")
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_delete_custom_column_admin_allowed(admin_user):
+    col = _make_column()
+
+    mock_session = AsyncMock()
+    mock_session.get = AsyncMock(return_value=col)
+    mock_session.delete = AsyncMock()
+    mock_session.commit = AsyncMock()
+
+    _override_session(mock_session)
+    _override_user(admin_user)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.delete(f"/api/custom-columns/{col.id}")
+        assert resp.status_code == 204, resp.text
+        mock_session.delete.assert_awaited_once_with(col)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_set_custom_value_viewer_forbidden(viewer_user):
+    _override_user(viewer_user)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.put(
+                "/api/custom-columns/values",
+                json={"column_id": str(uuid.uuid4()), "value": "1"},
+            )
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/test_authz_mosaics.py
+++ b/backend/tests/test_authz_mosaics.py
@@ -1,0 +1,96 @@
+"""Authorization tests for mosaics write endpoints (SEC-2).
+
+Viewer role must be read-only: state-changing mosaic endpoints require admin.
+"""
+
+import uuid
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from httpx import AsyncClient, ASGITransport
+
+from app.main import app
+from app.database import get_session
+from app.api.deps import get_current_user
+
+
+def _override_user(user):
+    app.dependency_overrides[get_current_user] = lambda: user
+
+
+def _override_session(mock_session):
+    async def _gen():
+        yield mock_session
+    app.dependency_overrides[get_session] = _gen
+
+
+@pytest.mark.asyncio
+async def test_create_mosaic_viewer_forbidden(viewer_user):
+    _override_user(viewer_user)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post("/api/mosaics", json={"name": "M31 Mosaic"})
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_create_mosaic_admin_allowed(admin_user):
+    mock_session = AsyncMock()
+    mock_session.add = MagicMock()
+    mock_session.flush = AsyncMock()
+    mock_session.commit = AsyncMock()
+
+    _override_session(mock_session)
+    _override_user(admin_user)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post("/api/mosaics", json={"name": "M31 Mosaic"})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["name"] == "M31 Mosaic"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_delete_mosaic_viewer_forbidden(viewer_user):
+    _override_user(viewer_user)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.delete(f"/api/mosaics/{uuid.uuid4()}")
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_trigger_detection_viewer_forbidden(viewer_user):
+    _override_user(viewer_user)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post("/api/mosaics/detect")
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_clear_reviews_viewer_forbidden(viewer_user):
+    _override_user(viewer_user)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post("/api/mosaics/clear-reviews")
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/test_authz_targets_notes.py
+++ b/backend/tests/test_authz_targets_notes.py
@@ -1,0 +1,113 @@
+"""Authorization tests for targets notes write endpoints (SEC-2).
+
+Viewer role must be read-only: note-update endpoints require admin.
+"""
+
+import uuid
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from httpx import AsyncClient, ASGITransport
+
+from app.main import app
+from app.database import get_session
+from app.api.deps import get_current_user
+
+
+def _override_user(user):
+    app.dependency_overrides[get_current_user] = lambda: user
+
+
+def _override_session(mock_session):
+    async def _gen():
+        yield mock_session
+    app.dependency_overrides[get_session] = _gen
+
+
+@pytest.mark.asyncio
+async def test_update_target_notes_viewer_forbidden(viewer_user):
+    _override_user(viewer_user)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.put(
+                f"/api/targets/{uuid.uuid4()}/notes", json={"notes": "hello"}
+            )
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_update_target_notes_admin_allowed(admin_user):
+    from app.models import Target
+
+    target = MagicMock(spec=Target)
+    target.id = uuid.uuid4()
+    target.notes = None
+
+    mock_session = AsyncMock()
+    mock_session.get = AsyncMock(return_value=target)
+    mock_session.commit = AsyncMock()
+
+    _override_session(mock_session)
+    _override_user(admin_user)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.put(
+                f"/api/targets/{target.id}/notes", json={"notes": "observed"}
+            )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["status"] == "ok"
+        assert target.notes == "observed"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_update_session_notes_viewer_forbidden(viewer_user):
+    _override_user(viewer_user)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.put(
+                f"/api/targets/{uuid.uuid4()}/sessions/2026-01-01/notes",
+                json={"notes": "clear skies"},
+            )
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_update_session_notes_admin_allowed(admin_user):
+    target_id = uuid.uuid4()
+
+    # No existing session note -> endpoint inserts a new SessionNote.
+    note_result = MagicMock()
+    note_result.scalar_one_or_none.return_value = None
+
+    mock_session = AsyncMock()
+    mock_session.execute = AsyncMock(return_value=note_result)
+    mock_session.add = MagicMock()
+    mock_session.commit = AsyncMock()
+
+    _override_session(mock_session)
+    _override_user(admin_user)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.put(
+                f"/api/targets/{target_id}/sessions/2026-01-01/notes",
+                json={"notes": "clear skies"},
+            )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["status"] == "ok"
+        mock_session.add.assert_called_once()
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,4 +1,6 @@
-from app.config import Settings
+from unittest.mock import MagicMock
+
+from app.config import Settings, client_ip_from_request, load_or_create_jwt_secret
 
 
 def test_settings_defaults():
@@ -12,3 +14,75 @@ def test_settings_from_env(monkeypatch):
     monkeypatch.setenv("GALACTILOG_THUMBNAIL_MAX_WIDTH", "400")
     s = Settings()
     assert s.thumbnail_max_width == 400
+
+
+# ---------------------------------------------------------------------------
+# SEC-5: real client IP extraction (rate limiter / lockout key_func)
+# ---------------------------------------------------------------------------
+
+def _req(headers=None, client_host="127.0.0.1"):
+    request = MagicMock()
+    request.headers = headers or {}
+    if client_host is None:
+        request.client = None
+    else:
+        request.client = MagicMock()
+        request.client.host = client_host
+    return request
+
+
+def test_client_ip_uses_forwarded_for():
+    req = _req(headers={"x-forwarded-for": "203.0.113.7"})
+    assert client_ip_from_request(req) == "203.0.113.7"
+
+
+def test_client_ip_takes_leftmost_of_chain():
+    # nginx appends: original-client, proxy1, proxy2
+    req = _req(headers={"x-forwarded-for": "203.0.113.7, 10.0.0.1, 127.0.0.1"})
+    assert client_ip_from_request(req) == "203.0.113.7"
+
+
+def test_client_ip_skips_leading_empty_entries():
+    req = _req(headers={"x-forwarded-for": " , 203.0.113.7"})
+    assert client_ip_from_request(req) == "203.0.113.7"
+
+
+def test_client_ip_falls_back_to_socket_peer():
+    req = _req(headers={}, client_host="198.51.100.4")
+    assert client_ip_from_request(req) == "198.51.100.4"
+
+
+def test_client_ip_unknown_when_no_client():
+    req = _req(headers={}, client_host=None)
+    assert client_ip_from_request(req) == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# SEC-7: persisted JWT secret
+# ---------------------------------------------------------------------------
+
+def test_jwt_secret_generated_and_persisted(tmp_path):
+    secret_file = tmp_path / "subdir" / ".jwt_secret"
+    assert not secret_file.exists()
+
+    secret = load_or_create_jwt_secret(str(secret_file))
+
+    assert secret
+    assert secret_file.exists()
+    assert secret_file.read_text(encoding="utf-8").strip() == secret
+
+
+def test_jwt_secret_loaded_when_file_exists(tmp_path):
+    secret_file = tmp_path / ".jwt_secret"
+    secret_file.write_text("deadbeef" * 8, encoding="utf-8")
+
+    secret = load_or_create_jwt_secret(str(secret_file))
+
+    assert secret == "deadbeef" * 8
+
+
+def test_jwt_secret_stable_across_calls(tmp_path):
+    secret_file = tmp_path / ".jwt_secret"
+    first = load_or_create_jwt_secret(str(secret_file))
+    second = load_or_create_jwt_secret(str(secret_file))
+    assert first == second

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -1,0 +1,37 @@
+from app.main import _resolve_cors_config
+
+
+def test_no_origins_returns_empty():
+    origins, creds = _resolve_cors_config(None)
+    assert origins == []
+    assert creds is True
+
+
+def test_valid_origins_pass_through():
+    origins, creds = _resolve_cors_config("http://localhost:3000, https://app.example.com")
+    assert origins == ["http://localhost:3000", "https://app.example.com"]
+    assert creds is True
+
+
+def test_wildcard_disables_credentials():
+    origins, creds = _resolve_cors_config("*", allow_credentials=True)
+    assert "*" in origins
+    assert creds is False
+
+
+def test_wildcard_among_others_disables_credentials():
+    origins, creds = _resolve_cors_config("http://localhost:3000, *")
+    assert creds is False
+
+
+def test_malformed_origins_dropped():
+    origins, creds = _resolve_cors_config(
+        "http://good.example.com, not-a-url, ftp://bad.example.com, http://"
+    )
+    assert origins == ["http://good.example.com"]
+    assert creds is True
+
+
+def test_empty_entries_ignored():
+    origins, creds = _resolve_cors_config("http://localhost:3000, , ")
+    assert origins == ["http://localhost:3000"]

--- a/backend/tests/test_metrics_endpoint.py
+++ b/backend/tests/test_metrics_endpoint.py
@@ -1,0 +1,79 @@
+"""Tests for the GET /api/metrics endpoint token guard.
+
+External access is blocked at the nginx layer (allowlist), which is not
+unit-testable here. The optional bearer-token guard is enforced in-app when
+GALACTILOG_METRICS_TOKEN is set; these tests cover that behavior.
+"""
+import pytest
+
+from httpx import AsyncClient, ASGITransport
+
+from app.main import app
+
+
+@pytest.mark.asyncio
+async def test_metrics_no_token_when_env_unset(monkeypatch):
+    """When GALACTILOG_METRICS_TOKEN is unset, no Authorization header is required."""
+    monkeypatch.delenv("GALACTILOG_METRICS_TOKEN", raising=False)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/metrics")
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_metrics_rejects_missing_token_when_env_set(monkeypatch):
+    """When the env var is set, a request without the bearer token is rejected."""
+    monkeypatch.setenv("GALACTILOG_METRICS_TOKEN", "s3cr3t")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/metrics")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_metrics_rejects_wrong_token_when_env_set(monkeypatch):
+    """A mismatched bearer token is rejected."""
+    monkeypatch.setenv("GALACTILOG_METRICS_TOKEN", "s3cr3t")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/api/metrics", headers={"Authorization": "Bearer wrong"}
+        )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_metrics_rejects_wrong_scheme_when_env_set(monkeypatch):
+    """A non-Bearer scheme (e.g. Basic) is rejected even if it carries the token."""
+    monkeypatch.setenv("GALACTILOG_METRICS_TOKEN", "s3cr3t")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/api/metrics", headers={"Authorization": "Basic s3cr3t"}
+        )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_metrics_rejects_empty_bearer_token_when_env_set(monkeypatch):
+    """A bare/empty bearer token is rejected."""
+    monkeypatch.setenv("GALACTILOG_METRICS_TOKEN", "s3cr3t")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/api/metrics", headers={"Authorization": "Bearer "}
+        )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_metrics_accepts_correct_token_when_env_set(monkeypatch):
+    """The correct bearer token is accepted and metrics are served."""
+    monkeypatch.setenv("GALACTILOG_METRICS_TOKEN", "s3cr3t")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/api/metrics", headers={"Authorization": "Bearer s3cr3t"}
+        )
+    assert resp.status_code == 200

--- a/backend/tests/test_planning_api.py
+++ b/backend/tests/test_planning_api.py
@@ -1,0 +1,57 @@
+"""Tests for the GET /api/planning/night endpoint.
+
+These tests use dependency overrides on the FastAPI app so no real
+Postgres connection is required. The ephemeris computation is patched out.
+"""
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from httpx import AsyncClient, ASGITransport
+
+from app.main import app
+from app.api.deps import get_current_user
+
+
+@pytest.mark.asyncio
+async def test_planning_night_requires_auth():
+    """Endpoint returns 401 when no access_token cookie is present."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/planning/night?date=2026-06-09")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_planning_night_authenticated_proceeds(viewer_user):
+    """Authenticated request reaches the handler and returns ephemeris data."""
+    app.dependency_overrides[get_current_user] = lambda: viewer_user
+
+    class _Coords:
+        latitude = 40.0
+        longitude = -105.0
+
+    class _FakeSessionCtx:
+        async def __aenter__(self):
+            return AsyncMock()
+
+        async def __aexit__(self, *args):
+            return False
+
+    try:
+        with patch(
+            "app.api.planning.async_session",
+            return_value=_FakeSessionCtx(),
+        ), patch(
+            "app.api.planning._extract_site_coords",
+            new=AsyncMock(return_value=_Coords()),
+        ), patch(
+            "app.api.planning.get_night_ephemeris",
+            return_value={"twilight": "ok"},
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.get("/api/planning/night?date=2026-06-09")
+        assert resp.status_code == 200
+        assert resp.json() == {"twilight": "ok"}
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)

--- a/backend/tests/test_preview_api.py
+++ b/backend/tests/test_preview_api.py
@@ -11,10 +11,20 @@ from httpx import AsyncClient, ASGITransport
 
 from app.main import app
 from app.database import get_session
+from app.api.deps import get_current_user
 
 
 @pytest.mark.asyncio
-async def test_preview_endpoint_404_for_missing_image():
+async def test_preview_endpoint_requires_auth():
+    """Endpoint returns 401 when no access_token cookie is present."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(f"/api/preview/{uuid.uuid4()}?resolution=400")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_preview_endpoint_404_for_missing_image(viewer_user):
     """Endpoint returns 404 when no Image row exists for the given UUID."""
 
     async def _fake_session():
@@ -25,6 +35,7 @@ async def test_preview_endpoint_404_for_missing_image():
         yield session
 
     app.dependency_overrides[get_session] = _fake_session
+    app.dependency_overrides[get_current_user] = lambda: viewer_user
     try:
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -33,10 +44,11 @@ async def test_preview_endpoint_404_for_missing_image():
         assert resp.json()["detail"] == "Image not found"
     finally:
         app.dependency_overrides.pop(get_session, None)
+        app.dependency_overrides.pop(get_current_user, None)
 
 
 @pytest.mark.asyncio
-async def test_preview_endpoint_404_for_missing_file(tmp_path):
+async def test_preview_endpoint_404_for_missing_file(tmp_path, viewer_user):
     """Endpoint returns 404 when the Image row exists but file_path is not on disk."""
     nonexistent = tmp_path / "does_not_exist.fits"
 
@@ -51,6 +63,7 @@ async def test_preview_endpoint_404_for_missing_file(tmp_path):
         yield session
 
     app.dependency_overrides[get_session] = _fake_session
+    app.dependency_overrides[get_current_user] = lambda: viewer_user
     try:
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -59,3 +72,4 @@ async def test_preview_endpoint_404_for_missing_file(tmp_path):
         assert resp.json()["detail"] == "File not found on disk"
     finally:
         app.dependency_overrides.pop(get_session, None)
+        app.dependency_overrides.pop(get_current_user, None)

--- a/backend/tests/test_simbad.py
+++ b/backend/tests/test_simbad.py
@@ -12,6 +12,7 @@ from app.services.simbad import (
     build_primary_name,
     _fetch_tap_aliases,
     _get_simbad_id,
+    _escape_adql_string,
 )
 
 
@@ -514,3 +515,43 @@ class TestGetSimbadId:
         """Descriptive suffix after ' - ' should be stripped, then checked in Stellarium."""
         result = _get_simbad_id("Horsehead Nebula - some description")
         assert result == "Barnard 33"
+
+
+class TestEscapeAdqlString:
+    def test_doubles_single_quote(self):
+        assert _escape_adql_string("M31'; DROP TABLE x--") == "M31''; DROP TABLE x--"
+
+    def test_no_quote_unchanged(self):
+        assert _escape_adql_string("NGC 7000") == "NGC 7000"
+
+    def test_multiple_quotes(self):
+        assert _escape_adql_string("a'b'c") == "a''b''c"
+
+    @pytest.mark.asyncio
+    async def test_tap_query_escapes_injected_quote(self):
+        """A single quote in the object name is doubled in the constructed ADQL."""
+        captured = {}
+
+        class _FakeResp:
+            text = "id\n"
+
+            def raise_for_status(self):
+                pass
+
+        class _FakeClient:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+            async def get(self, url, params=None, timeout=None):
+                captured["query"] = params["query"]
+                return _FakeResp()
+
+        with patch("app.services.simbad.httpx.AsyncClient", return_value=_FakeClient()):
+            await _fetch_tap_aliases("M31'; DROP TABLE x--")
+
+        # The injected quote must be doubled and not break out of the literal.
+        assert "main_id = 'M31''; DROP TABLE x--'" in captured["query"]
+        assert "main_id = 'M31'; DROP" not in captured["query"]

--- a/backend/tests/test_vizier.py
+++ b/backend/tests/test_vizier.py
@@ -1,5 +1,54 @@
 import pytest
-from app.services.vizier import determine_vizier_catalog, build_adql_query
+from app.services.vizier import (
+    determine_vizier_catalog,
+    build_adql_query,
+    _adql_quote,
+    _adql_int,
+)
+
+
+class TestAdqlEscaping:
+    def test_adql_quote_doubles_single_quote(self):
+        assert _adql_quote("a'b") == "a''b"
+
+    def test_adql_quote_injection(self):
+        assert _adql_quote("x'; DROP TABLE y--") == "x''; DROP TABLE y--"
+
+    def test_adql_int_valid(self):
+        assert _adql_int("129") == 129
+        assert _adql_int(" 33 ") == 33
+
+    def test_adql_int_rejects_non_numeric(self):
+        assert _adql_int("129; DROP") is None
+        assert _adql_int("") is None
+
+    def test_cluster_name_injection_does_not_match(self):
+        """fullmatch prevents an injected cluster name from over-matching B/ocl."""
+        # "Collinder 399'; DROP ..." no longer matches the cluster pattern,
+        # so no query is built at all.
+        assert determine_vizier_catalog("Collinder 399'; DROP TABLE x--") is None
+        assert build_adql_query("Collinder 399'; DROP TABLE x--") is None
+
+    def test_cluster_name_quote_escaped(self):
+        """A legitimately matching cluster value still has quotes doubled.
+
+        Ced uses a permissive `(.+)$` capture, so a quote in the value is kept
+        and must be escaped rather than allowed to break out of the literal.
+        """
+        q = build_adql_query("Ced 51'--")
+        assert q is not None
+        assert "''" in q
+        assert "='51'--'" not in q
+
+    def test_cederblad_quote_escaped(self):
+        q = build_adql_query("Ced 51'--")
+        assert q is not None
+        assert "''" in q
+
+    def test_numeric_catalog_rejects_injection(self):
+        """A Sharpless id whose number part is not an int yields no query."""
+        # Forge a value where _extract_number returns non-numeric text.
+        assert build_adql_query("SH 2-1 OR 1=1") is None
 
 
 class TestDetermineVizierCatalog:

--- a/nginx.conf
+++ b/nginx.conf
@@ -25,6 +25,28 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
+    # Prometheus metrics: restrict to localhost + private/Docker networks where
+    # Telegraf scrapes internally; deny external clients. Must precede the
+    # general /api block (exact-match `=` takes precedence regardless of order).
+    location = /api/metrics {
+        allow 127.0.0.1;
+        allow 10.0.0.0/8;
+        allow 172.16.0.0/12;
+        allow 192.168.0.0/16;
+        deny all;
+
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering on;
+        proxy_buffer_size 8k;
+        proxy_buffers 16 8k;
+        proxy_busy_buffers_size 16k;
+        add_header Cache-Control "no-store" always;
+    }
+
     location /api {
         proxy_pass http://127.0.0.1:8000;
         proxy_set_header Host $host;


### PR DESCRIPTION
Closes the high-priority security items from the improvement roadmap.

Access control
- Write actions on mosaics, target and session notes, and custom columns now require an admin account. Viewer accounts are read-only as intended; a viewer attempting any of these changes now receives a forbidden response instead of silently succeeding.
- The image preview endpoint and the nightly planning data now require a logged-in user. Because the app authenticates by cookie, signed-in users see no difference; previously anyone could fetch FITS preview images and the observing location without logging in.
- The NINA and Stellarium send-coordinates actions now require a logged-in user and validate the destination URL, so the server can no longer be tricked into reaching arbitrary or internal addresses. Local-network instruments keep working; an optional host allowlist is available via GALACTILOG_INTEGRATION_ALLOWED_HOSTS.

Sessions and login
- The JWT signing secret is now persisted when not explicitly configured, so users stay logged in across application restarts and across multiple workers. Previously a restart or deploy logged everyone out unless the secret was set by hand.
- Login lockout and rate limiting now key off the real client IP via the proxy forwarded header instead of a single shared address, so one user's failed logins can no longer lock out or throttle everyone behind the same proxy.

Exposure and injection
- The Prometheus metrics endpoint is no longer reachable from outside; access is restricted to local and private networks so internal scraping keeps working, with an optional bearer-token guard.
- Cross-origin requests with credentials are rejected when a wildcard origin is configured, and malformed origins are dropped.
- External catalog lookups to SIMBAD and VizieR now escape and validate the object name before building the query, preventing injection into those requests.