### PR TITLE
Improved Target Identity and Catalog Stability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,21 @@ guides/plans/
 guides/specs/
 guides/superpowers/
 
+# Image files at the repo root only (stray screenshots, scratch exports)
+# Subdirectory images (frontend assets, images/, docs references) stay tracked.
+/*.png
+/*.jpg
+/*.jpeg
+/*.gif
+/*.bmp
+/*.webp
+/*.tif
+/*.tiff
+/*.ico
+/*.svg
+/*.heic
+/*.avif
+
 # Log files
 *.log
 .worktrees/

--- a/backend/alembic/versions/0007_targets_catalog_id_normalized.py
+++ b/backend/alembic/versions/0007_targets_catalog_id_normalized.py
@@ -1,0 +1,143 @@
+"""Add targets.catalog_id_normalized, dedupe identities, add UNIQUE index.
+
+Canonical catalog identity = UPPER(collapse_ws(catalog_id)). Two active targets
+must never share one. This migration:
+  1. Adds the column (guarded for create_all-bootstrapped installs).
+  2. Backfills it from catalog_id.
+  3. Dedupes existing duplicate identities by soft-merging losers (most-images
+     target wins) into the winner and NULLing the losers' normalized id.
+  4. Creates the UNIQUE index only if no active duplicates remain.
+
+All DDL is defensive per CLAUDE.md (see 0002 / 0006).
+"""
+import logging
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import text, inspect as sa_inspect
+
+logger = logging.getLogger("alembic.runtime.migration")
+
+revision = "0007"
+down_revision = "0006"
+branch_labels = None
+depends_on = None
+
+_NORM = "UPPER(REGEXP_REPLACE(TRIM(catalog_id), '\\s+', ' ', 'g'))"
+
+
+def _column_exists(table: str, column: str) -> bool:
+    inspector = sa_inspect(op.get_bind())
+    return column in [c["name"] for c in inspector.get_columns(table)]
+
+
+def _add_column_if_not_exists(table: str, col: sa.Column) -> None:
+    if not _column_exists(table, col.name):
+        op.add_column(table, col)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    # 1. Column (guarded).
+    _add_column_if_not_exists(
+        "targets", sa.Column("catalog_id_normalized", sa.String(100), nullable=True)
+    )
+
+    # 2. Backfill for active, catalogued targets.
+    bind.execute(text(f"""
+        UPDATE targets
+        SET catalog_id_normalized = {_NORM}
+        WHERE merged_into_id IS NULL
+          AND catalog_id IS NOT NULL
+          AND TRIM(catalog_id) <> ''
+    """))
+
+    # 3. Dedupe: for each normalized id shared by 2+ active targets, keep the
+    #    one with the most images (tie-break oldest id) and soft-merge the rest.
+    dup_groups = bind.execute(text("""
+        SELECT catalog_id_normalized
+        FROM targets
+        WHERE merged_into_id IS NULL AND catalog_id_normalized IS NOT NULL
+        GROUP BY catalog_id_normalized
+        HAVING COUNT(*) > 1
+    """)).scalars().all()
+
+    for norm in dup_groups:
+        members = bind.execute(text("""
+            SELECT t.id,
+                   (SELECT COUNT(*) FROM images i WHERE i.resolved_target_id = t.id) AS n_img
+            FROM targets t
+            WHERE t.merged_into_id IS NULL AND t.catalog_id_normalized = :norm
+            ORDER BY n_img DESC, t.id ASC
+        """), {"norm": norm}).all()
+
+        winner_id = members[0][0]
+        loser_ids = [m[0] for m in members[1:]]
+        if not loser_ids:
+            continue
+
+        for loser_id in loser_ids:
+            # Move images.
+            bind.execute(text("""
+                UPDATE images SET resolved_target_id = :w
+                WHERE resolved_target_id = :l
+            """), {"w": winner_id, "l": loser_id})
+            # Reassign mosaic panels.
+            bind.execute(text("""
+                UPDATE mosaic_panels SET target_id = :w WHERE target_id = :l
+            """), {"w": winner_id, "l": loser_id})
+            # Merge aliases (loser primary_name + aliases) into winner, de-duped.
+            bind.execute(text("""
+                UPDATE targets w SET aliases = (
+                    SELECT ARRAY(
+                        SELECT DISTINCT e FROM unnest(
+                            COALESCE(w.aliases, ARRAY[]::varchar[])
+                            || ARRAY[l.primary_name]
+                            || COALESCE(l.aliases, ARRAY[]::varchar[])
+                        ) AS e
+                        WHERE e <> w.primary_name
+                    )
+                )
+                FROM targets l
+                WHERE w.id = :w AND l.id = :l
+            """), {"w": winner_id, "l": loser_id})
+            # Soft-delete loser and clear its identity so the unique index skips it.
+            bind.execute(text("""
+                UPDATE targets
+                SET merged_into_id = :w, merged_at = now(),
+                    catalog_id_normalized = NULL
+                WHERE id = :l
+            """), {"w": winner_id, "l": loser_id})
+
+    # 4. Create the UNIQUE index only if the data is now clean.
+    remaining = bind.execute(text("""
+        SELECT COUNT(*) FROM (
+            SELECT 1 FROM targets
+            WHERE merged_into_id IS NULL AND catalog_id_normalized IS NOT NULL
+            GROUP BY catalog_id_normalized
+            HAVING COUNT(*) > 1
+        ) d
+    """)).scalar_one()
+
+    if remaining == 0:
+        op.execute(text(
+            "CREATE UNIQUE INDEX IF NOT EXISTS uq_targets_catalog_id_normalized "
+            "ON targets (catalog_id_normalized)"
+        ))
+    else:
+        # Leave the index uncreated; backfill + duplicate-detection resolve the
+        # rest, and a later `alembic upgrade head` re-run creates it once clean.
+        # The migration still succeeds (revision advances to 0007); the unique
+        # index lands on the next upgrade after duplicates are cleared.
+        logger.warning(
+            "0007: %d duplicate catalog identities remain; UNIQUE index NOT "
+            "created. Resolve duplicates (backfill / duplicate-detection) then "
+            "re-run `alembic upgrade head` to create the index.", remaining,
+        )
+
+
+def downgrade() -> None:
+    op.execute(text("DROP INDEX IF EXISTS uq_targets_catalog_id_normalized"))
+    if _column_exists("targets", "catalog_id_normalized"):
+        op.drop_column("targets", "catalog_id_normalized")

--- a/backend/alembic/versions/0007_targets_catalog_id_normalized.py
+++ b/backend/alembic/versions/0007_targets_catalog_id_normalized.py
@@ -126,14 +126,22 @@ def upgrade() -> None:
             "ON targets (catalog_id_normalized)"
         ))
     else:
-        # Leave the index uncreated; backfill + duplicate-detection resolve the
-        # rest, and a later `alembic upgrade head` re-run creates it once clean.
-        # The migration still succeeds (revision advances to 0007); the unique
-        # index lands on the next upgrade after duplicates are cleared.
+        # Leave the index uncreated. The migration still succeeds (revision
+        # advances to 0007), but the unique index is not present. Re-running
+        # `alembic upgrade head` will NOT re-execute this block because the
+        # revision is already stamped. The operator must resolve the remaining
+        # duplicates (via the app's merge tools or the catalog-identity backfill
+        # endpoint) and then create the index manually:
+        #
+        #   CREATE UNIQUE INDEX IF NOT EXISTS uq_targets_catalog_id_normalized
+        #       ON targets (catalog_id_normalized);
         logger.warning(
-            "0007: %d duplicate catalog identities remain; UNIQUE index NOT "
-            "created. Resolve duplicates (backfill / duplicate-detection) then "
-            "re-run `alembic upgrade head` to create the index.", remaining,
+            "0007: %d active targets still share a normalized catalog identity; "
+            "the UNIQUE index uq_targets_catalog_id_normalized was NOT created. "
+            "Resolve the remaining duplicates (use the app's merge tools or the "
+            "catalog-identity backfill endpoint), then create the index manually: "
+            "CREATE UNIQUE INDEX IF NOT EXISTS uq_targets_catalog_id_normalized "
+            "ON targets (catalog_id_normalized);", remaining,
         )
 
 

--- a/backend/app/api/merges.py
+++ b/backend/app/api/merges.py
@@ -296,13 +296,20 @@ async def list_merged_targets(
     ]
 
 
-@router.get("/{target_id}/merge-history", response_model=list[MergedTargetResponse])
+@router.get("/{target_id:path}/merge-history", response_model=list[MergedTargetResponse])
 async def get_merge_history(
-    target_id: uuid.UUID,
+    target_id: str,
     session: AsyncSession = Depends(get_session),
     user: User = Depends(get_current_user),
 ):
     """Return all targets that were merged into a given target."""
+    # Synthetic "obj:<name>" pseudo-targets (and any non-UUID id) have no DB row
+    # and can never have merge history, so return an empty list rather than 422.
+    try:
+        target_id = uuid.UUID(target_id)
+    except ValueError:
+        return []
+
     target = await session.get(Target, target_id)
     if not target:
         raise HTTPException(status_code=404, detail="Target not found")

--- a/backend/app/api/scan.py
+++ b/backend/app/api/scan.py
@@ -36,7 +36,7 @@ from app.services.scan_state import (
     get_scan_state, get_failed_files, start_scanning, set_ingesting, set_idle, reset_scan,
     get_rebuild_state, request_cancel,
 )
-from app.worker.tasks import regenerate_thumbnail, run_scan, rebuild_targets, smart_rebuild_targets, retry_unresolved, backfill_csv_metrics, generate_reference_thumbnails, purge_and_regenerate_thumbnails, regenerate_missing_thumbnails
+from app.worker.tasks import regenerate_thumbnail, run_scan, rebuild_targets, smart_rebuild_targets, retry_unresolved, backfill_csv_metrics, generate_reference_thumbnails, purge_and_regenerate_thumbnails, regenerate_missing_thumbnails, backfill_catalog_identity
 
 logger = logging.getLogger(__name__)
 
@@ -246,6 +246,26 @@ async def trigger_retry_unresolved(user: User = Depends(require_admin)):
 
         task = retry_unresolved.delay()
         return {"status": "accepted", "message": "Retry unresolved queued as background task", "task_id": task.id}
+
+
+@router.post("/backfill-catalog-identity", response_model=ScanAcceptResponse)
+async def trigger_backfill_catalog_identity(user: User = Depends(require_admin)):
+    """Repair corrupted SIMBAD cache and re-link catalog orphans by identity.
+
+    Re-runs the shared catalog-identity matcher over unlinked light frames and
+    attaches those that now resolve to an existing target. One-time after deploy,
+    safely re-runnable. Runs as a background Celery task.
+    """
+    async with async_redis() as r:
+        state = await get_scan_state(r)
+        if state.state in ("scanning", "ingesting"):
+            raise HTTPException(
+                status_code=409,
+                detail="A scan is already running. Wait for it to complete first.",
+            )
+
+        task = backfill_catalog_identity.delay()
+        return {"status": "accepted", "message": "Catalog-identity backfill queued as background task", "task_id": task.id}
 
 
 @router.post("/generate-reference-thumbnails", response_model=ScanAcceptResponse)

--- a/backend/app/models/target.py
+++ b/backend/app/models/target.py
@@ -47,4 +47,5 @@ class Target(Base):
 
     __table_args__ = (
         Index("ix_targets_aliases", "aliases", postgresql_using="gin"),
+        Index("uq_targets_catalog_id_normalized", "catalog_id_normalized", unique=True),
     )

--- a/backend/app/models/target.py
+++ b/backend/app/models/target.py
@@ -15,6 +15,7 @@ class Target(Base):
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     primary_name: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
     catalog_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    catalog_id_normalized: Mapped[str | None] = mapped_column(String(100), nullable=True)
     common_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
     aliases: Mapped[list[str]] = mapped_column(ARRAY(String), nullable=False, default=list)
     ra: Mapped[float | None] = mapped_column(Float, nullable=True)

--- a/backend/app/services/openngc.py
+++ b/backend/app/services/openngc.py
@@ -188,7 +188,9 @@ def enrich_target_from_openngc(session: Session, target: Target) -> bool:
         ngc_common = extract_openngc_common_name(entry.common_names)
         if ngc_common:
             target.common_name = ngc_common
-            # Rebuild primary_name with the new common name
+            # Rebuild primary_name with the new common name.
+            # primary_name is a label; catalog_id (and its normalized identity)
+            # are unchanged here, so catalog_id_normalized stays valid.
             from app.services.simbad import build_primary_name
             target.primary_name = build_primary_name(target.catalog_id, ngc_common)
             updated = True

--- a/backend/app/services/simbad.py
+++ b/backend/app/services/simbad.py
@@ -50,6 +50,18 @@ def normalize_object_name(name: str, *, upper: bool = True) -> str:
     return cleaned.upper() if upper else cleaned
 
 
+def normalize_catalog_id(catalog_id: str | None) -> str | None:
+    """Canonical catalog-identity key: whitespace-collapsed, uppercased.
+
+    Returns None for falsy/blank input so callers can store NULL when a target
+    has no catalog identity. Equivalent to normalize_object_name(x, upper=True)
+    but None-safe, since catalog_id is nullable on the targets table.
+    """
+    if not catalog_id or not catalog_id.strip():
+        return None
+    return normalize_object_name(catalog_id, upper=True)
+
+
 # Ordered list: index = priority (lower wins).
 CATALOG_PATTERNS: list[re.Pattern] = [
     re.compile(r"^M\s*\d+$"),                         # 0  Messier

--- a/backend/app/services/simbad_repair.py
+++ b/backend/app/services/simbad_repair.py
@@ -1,0 +1,61 @@
+"""Detect and repair pre-b9c61a6 SIMBAD cache rows.
+
+Those rows stored quote-wrapped aliases (literal `"` characters) that
+curate_aliases then dropped, leaving empty common_name/aliases. catalog_id is
+still derivable from main_id, so identity matching does not depend on this
+repair, but display, search, and the name-fallback match path all benefit from
+restoring correct labels. Re-fetching is idempotent and rate-limited.
+"""
+import logging
+import time
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models.simbad_cache import SimbadCache
+from app.services.simbad import _query_simbad_raw, save_simbad_cache, _run_async
+
+logger = logging.getLogger(__name__)
+
+
+def _query_simbad_raw_sync(main_id: str):
+    """Sync wrapper over the async SIMBAD raw query (for Celery workers)."""
+    return _run_async(_query_simbad_raw(main_id))
+
+
+def _row_is_corrupted(row: SimbadCache) -> bool:
+    """A positive cache row whose raw_aliases contain a literal quote char."""
+    if row.main_id is None:
+        return False
+    for alias in (row.raw_aliases or []):
+        if alias is not None and '"' in alias:
+            return True
+    return False
+
+
+def repair_corrupted_simbad_cache(
+    session: Session, *, limit: int = 5000, sleep: float = 0.3,
+) -> dict:
+    """Re-fetch corrupted positive cache rows. Returns a summary dict."""
+    rows = session.execute(
+        select(SimbadCache).where(SimbadCache.main_id.isnot(None)).limit(limit)
+    ).scalars().all()
+
+    corrupted = [r for r in rows if _row_is_corrupted(r)]
+    repaired = 0
+    failed = 0
+
+    for row in corrupted:
+        fresh = _query_simbad_raw_sync(row.main_id)
+        if fresh is None:
+            failed += 1
+            logger.warning("simbad_repair: re-fetch failed for '%s'", row.main_id)
+            continue
+        save_simbad_cache(row.query_name, fresh, session)
+        session.commit()
+        repaired += 1
+        time.sleep(sleep)
+
+    logger.info("simbad_repair: %d repaired, %d failed of %d corrupted",
+                repaired, failed, len(corrupted))
+    return {"corrupted": len(corrupted), "repaired": repaired, "failed": failed}

--- a/backend/app/services/target_resolver.py
+++ b/backend/app/services/target_resolver.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 from app.models import Target
 from app.services.simbad import (
     normalize_object_name,
+    normalize_catalog_id,
     resolve_target_name_cached,
     _PANEL_RE,
 )
@@ -73,6 +74,43 @@ def find_target_by_name(object_name: str, session: Session) -> Target | None:
             Target.primary_name == normalize_object_name(object_name, upper=False),
         )
     ).scalar_one_or_none()
+    return target
+
+
+def match_target_by_identity(
+    resolved: dict, object_name: str, session: Session,
+) -> "Target | None":
+    """Find an existing target for a resolved identity, identity-first.
+
+    Order:
+      1. Normalized catalog identity (catalog_id_normalized) -- stable, primary.
+      2. Name fallback via find_target_by_name (aliases / primary_name) for
+         non-catalog objects or when identity is not yet populated.
+
+    On a match, the normalized incoming OBJECT string is recorded as an alias so
+    future direct lookups hit and the linkage is visible. Returns the Target or
+    None. Never creates.
+    """
+    cat_norm = normalize_catalog_id(resolved.get("catalog_id"))
+    target: "Target | None" = None
+
+    if cat_norm:
+        target = session.execute(
+            select(Target).where(
+                Target.merged_into_id.is_(None),
+                Target.catalog_id_normalized == cat_norm,
+            )
+        ).scalar_one_or_none()
+
+    if target is None:
+        target = find_target_by_name(object_name, session)
+
+    if target is not None:
+        incoming = _PANEL_RE.sub("", normalize_object_name(object_name)).strip()
+        if incoming and incoming not in [a.upper() for a in (target.aliases or [])]:
+            # Reassign to trigger ORM change tracking on the ARRAY column.
+            target.aliases = list(target.aliases or []) + [incoming]
+
     return target
 
 

--- a/backend/app/services/target_resolver.py
+++ b/backend/app/services/target_resolver.py
@@ -235,6 +235,7 @@ def resolve_target(
     # single create-collision cannot cascade NULLs across the scan batch.
     existing = match_target_by_identity(result, object_name, session)
     if existing is not None:
+        session.commit()
         return str(existing.id)
 
     return _create_target(result, normalized, session)

--- a/backend/app/services/target_resolver.py
+++ b/backend/app/services/target_resolver.py
@@ -223,15 +223,18 @@ def resolve_target(
         session.commit()
 
     if result is None:
+        # Only names that did NOT resolve to any identity are negative-cached.
         if redis:
             redis.sadd(NEGATIVE_CACHE_KEY, normalized)
             redis.expire(NEGATIVE_CACHE_KEY, NEGATIVE_CACHE_TTL)
         return None
 
-    # Check again after SIMBAD - another worker may have created this target
-    # while we were waiting on SIMBAD
-    existing = find_target_by_name(result["primary_name"], session)
-    if existing:
+    # The name resolved to a (possibly catalog) identity. Re-check via the shared
+    # identity matcher in case a concurrent worker created the target while we
+    # waited on SIMBAD. A resolved identity is NEVER negative-cached below, so a
+    # single create-collision cannot cascade NULLs across the scan batch.
+    existing = match_target_by_identity(result, object_name, session)
+    if existing is not None:
         return str(existing.id)
 
     return _create_target(result, normalized, session)

--- a/backend/app/services/target_resolver.py
+++ b/backend/app/services/target_resolver.py
@@ -173,7 +173,10 @@ def _create_target(
         # FINAL post-enrichment primary_name, then by catalog identity.
         cat_norm = normalize_catalog_id(simbad_result.get("catalog_id"))
         existing = session.execute(
-            select(Target).where(Target.primary_name == target.primary_name)
+            select(Target).where(
+                Target.merged_into_id.is_(None),
+                Target.primary_name == target.primary_name,
+            )
         ).scalar_one_or_none()
         if existing is None and cat_norm:
             existing = session.execute(

--- a/backend/app/services/target_resolver.py
+++ b/backend/app/services/target_resolver.py
@@ -117,7 +117,16 @@ def match_target_by_identity(
 def _create_target(
     simbad_result: dict, normalized_name: str, session: Session,
 ) -> str | None:
-    """Create a new Target from a SIMBAD result. Handles race conditions."""
+    """Enrich the resolved identity, match an existing target, else create one.
+
+    Order (eliminates the insert-then-rename-then-collide class):
+      1. Enrich the in-memory identity from OpenNGC so primary_name is final.
+      2. Match an existing target by catalog identity (then name fallback).
+         If found, link to it (and record the incoming OBJECT as an alias).
+      3. Otherwise insert. The IntegrityError net re-queries by the FINAL
+         post-enrichment primary_name AND by catalog identity, never returning
+         None for a name that resolved.
+    """
     aliases = simbad_result.get("aliases", [])
     # Strip panel suffixes from the FITS-derived lookup name before adding as alias
     clean_name = _PANEL_RE.sub("", normalized_name).strip()
@@ -127,16 +136,30 @@ def _create_target(
     target = Target(
         primary_name=simbad_result["primary_name"],
         catalog_id=simbad_result.get("catalog_id"),
+        catalog_id_normalized=normalize_catalog_id(simbad_result.get("catalog_id")),
         common_name=simbad_result.get("common_name"),
         aliases=aliases,
         ra=simbad_result.get("ra"),
         dec=simbad_result.get("dec"),
         object_type=simbad_result.get("object_type"),
     )
+
+    # Enrich the detached instance so primary_name / catalog_id are final BEFORE
+    # any match or insert. enrich_target_from_openngc reads target.catalog_id and
+    # may rewrite primary_name; it does not change catalog_id, so the normalized
+    # identity computed above stays correct.
+    enrich_target_from_openngc(session, target)
+
+    # Match by final identity. If an existing target carries this identity, link
+    # to it rather than inserting a colliding row.
+    existing = match_target_by_identity(simbad_result, normalized_name, session)
+    if existing is not None:
+        session.commit()
+        return str(existing.id)
+
     try:
         session.add(target)
         session.flush()
-        enrich_target_from_openngc(session, target)
         session.commit()
         if target.size_major is None:
             enrich_target_from_vizier(session, target)
@@ -146,10 +169,19 @@ def _create_target(
         return str(target.id)
     except IntegrityError:
         session.rollback()
-        # Another worker inserted this target - re-query
+        # Race: another worker inserted this identity/name. Re-query by the
+        # FINAL post-enrichment primary_name, then by catalog identity.
+        cat_norm = normalize_catalog_id(simbad_result.get("catalog_id"))
         existing = session.execute(
-            select(Target).where(Target.primary_name == simbad_result["primary_name"])
+            select(Target).where(Target.primary_name == target.primary_name)
         ).scalar_one_or_none()
+        if existing is None and cat_norm:
+            existing = session.execute(
+                select(Target).where(
+                    Target.merged_into_id.is_(None),
+                    Target.catalog_id_normalized == cat_norm,
+                )
+            ).scalar_one_or_none()
         return str(existing.id) if existing else None
 
 

--- a/backend/app/worker/tasks.py
+++ b/backend/app/worker/tasks.py
@@ -17,7 +17,8 @@ from app.services.simbad import (
     normalize_object_name, resolve_target_name_cached,
     curate_simbad_result, get_cached_simbad,
 )
-from app.services.target_resolver import resolve_target, normalize_sql_expr
+from app.services.target_resolver import resolve_target, normalize_sql_expr, match_target_by_identity
+from app.services.simbad_repair import repair_corrupted_simbad_cache
 from app.services.thumbnail import generate_thumbnail
 from app.services.xisf_parser import extract_xisf_metadata, generate_xisf_thumbnail
 from app.services.session_date import compute_session_date, extract_longitude
@@ -1325,6 +1326,90 @@ def retry_unresolved(self) -> dict:
                 details={"failed_targets": failed, "total": total}, actor="system",
             )
     logger.info("retry_unresolved: done - resolved=%d, failed=%d", resolved, failed)
+    return {"status": "complete", **details}
+
+
+@celery_app.task(bind=True)
+def backfill_catalog_identity(self) -> dict:
+    """Re-link catalog orphans by identity and repair corrupted SIMBAD cache.
+
+    Phase 1 (required): repair pre-b9c61a6 SIMBAD cache rows whose quote-
+    corrupted aliases curate to empty.
+    Phase 2: for each distinct unlinked LIGHT OBJECT name, resolve it and match
+    an existing target by catalog identity; link the images if matched. Names
+    that resolve to nothing or to no existing target stay orphaned for
+    duplicate-detection plus manual accept. One-time and safely re-runnable.
+    """
+    logger.info("backfill_catalog_identity: starting")
+    clear_cancel_sync(_redis)
+    set_rebuild_running_sync(_redis, "backfill", "Repairing SIMBAD cache...")
+
+    # Phase 1: corrupted-cache repair.
+    with Session(_sync_engine) as session:
+        repair_summary = repair_corrupted_simbad_cache(session)
+    logger.info("backfill_catalog_identity: cache repair %s", repair_summary)
+
+    # Phase 2: distinct unlinked LIGHT OBJECT names.
+    with Session(_sync_engine) as session:
+        rows = session.execute(text("""
+            SELECT raw_headers->>'OBJECT' AS obj, COUNT(*) AS cnt
+            FROM images
+            WHERE resolved_target_id IS NULL
+              AND image_type = 'LIGHT'
+              AND raw_headers->>'OBJECT' IS NOT NULL
+              AND raw_headers->>'OBJECT' != ''
+            GROUP BY raw_headers->>'OBJECT'
+            ORDER BY cnt DESC
+        """)).all()
+
+    total = len(rows)
+    set_rebuild_progress_sync(_redis, f"Linking 0/{total} orphaned names...")
+    linked = 0
+    skipped = 0
+
+    for i, (obj_name, img_count) in enumerate(rows):
+        if is_cancel_requested_sync(_redis):
+            details = {"linked": linked, "skipped": skipped, "total": total, "processed": i}
+            set_rebuild_cancelled_sync(
+                _redis, f"Cancelled after {i}/{total} names", details,
+            )
+            return {"status": "cancelled", **details}
+
+        with Session(_sync_engine) as session:
+            resolved = resolve_target_name_cached(obj_name, session)
+            session.commit()
+            target = match_target_by_identity(resolved, obj_name, session) if resolved else None
+            if target is not None:
+                target_id = target.id
+                session.commit()  # persist alias addition from the matcher
+                session.execute(text("""
+                    UPDATE images
+                    SET resolved_target_id = :tid
+                    WHERE resolved_target_id IS NULL
+                      AND raw_headers->>'OBJECT' = :obj
+                """), {"tid": target_id, "obj": obj_name})
+                session.commit()
+                linked += 1
+                logger.info("backfill: linked %d images for '%s' -> %s",
+                            img_count, obj_name, target_id)
+            else:
+                skipped += 1
+
+        if (i + 1) % 5 == 0 or i + 1 == total:
+            set_rebuild_progress_sync(_redis, f"Linking {i + 1}/{total} orphaned names...")
+        time.sleep(0.1)
+
+    details = {
+        "linked": linked, "skipped": skipped, "total": total,
+        "cache_repaired": repair_summary["repaired"],
+    }
+    set_rebuild_complete_sync(
+        _redis,
+        f"Re-linked {linked} catalog orphans, {skipped} left unresolved "
+        f"({repair_summary['repaired']} cache rows repaired)",
+        details,
+    )
+    logger.info("backfill_catalog_identity: complete %s", details)
     return {"status": "complete", **details}
 
 

--- a/backend/tests/test_api_merges.py
+++ b/backend/tests/test_api_merges.py
@@ -138,6 +138,46 @@ async def test_unmerge_target_not_found_returns_404(admin_user):
 
 
 @pytest.mark.asyncio
+async def test_merge_history_obj_pseudo_target_returns_empty_list(viewer_user):
+    """obj:<name> pseudo-targets have no DB row, so merge-history must return
+    an empty list with HTTP 200 instead of a 422 from UUID path coercion."""
+    mock_session = AsyncMock()
+    # No DB access expected for a non-UUID id; fail loudly if it is attempted.
+    mock_session.get = AsyncMock(side_effect=AssertionError("session.get called"))
+    mock_session.execute = AsyncMock(side_effect=AssertionError("execute called"))
+
+    _override_session(mock_session)
+    app.dependency_overrides[get_current_user] = lambda: viewer_user
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.get("/api/targets/obj:SomeName/merge-history")
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == []
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_merge_history_unknown_uuid_returns_404(viewer_user):
+    """A well-formed UUID with no matching row still returns 404."""
+    mock_session = AsyncMock()
+    mock_session.get = AsyncMock(return_value=None)
+
+    _override_session(mock_session)
+    app.dependency_overrides[get_current_user] = lambda: viewer_user
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.get(f"/api/targets/{uuid.uuid4()}/merge-history")
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
 async def test_merge_candidate_count_returns_count(viewer_user):
     mock_result = MagicMock()
     mock_result.scalar_one.return_value = 7

--- a/backend/tests/test_api_scan.py
+++ b/backend/tests/test_api_scan.py
@@ -184,3 +184,29 @@ async def test_old_scan_activity_routes_removed():
         r2 = await c.delete("/api/scan/activity")
     assert r1.status_code == 404
     assert r2.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_backfill_catalog_identity_queues_task():
+    admin = _admin_user()
+    app.dependency_overrides[require_admin] = lambda: admin
+
+    fake_state = MagicMock()
+    fake_state.state = "idle"
+
+    try:
+        with patch("app.api.scan.get_scan_state", new=AsyncMock(return_value=fake_state)), \
+             patch("app.api.scan.backfill_catalog_identity") as task, \
+             patch("app.api.scan.async_redis") as mock_redis_cm:
+            task.delay.return_value = MagicMock(id="task-xyz")
+            mock_redis = AsyncMock()
+            mock_redis_cm.side_effect = _mock_async_redis(mock_redis)
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.post("/api/scan/backfill-catalog-identity")
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["status"] == "accepted"
+        task.delay.assert_called_once()
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/test_backfill_catalog_identity.py
+++ b/backend/tests/test_backfill_catalog_identity.py
@@ -1,0 +1,65 @@
+"""Tests that backfill_catalog_identity reuses the shared matcher and links."""
+import sys
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+def _bootstrap_tasks():
+    mod = sys.modules.get("app.worker.tasks")
+    if mod is not None and not isinstance(mod, MagicMock):
+        return mod
+    sys.modules.pop("app.worker.tasks", None)
+    with patch("sqlalchemy.create_engine", return_value=MagicMock()):
+        import app.worker.tasks as tasks_mod
+    return tasks_mod
+
+
+class TestBackfillCatalogIdentity:
+    def test_task_is_registered(self):
+        tasks = _bootstrap_tasks()
+        assert hasattr(tasks, "backfill_catalog_identity")
+
+    def test_runs_cache_repair_then_links_matches(self):
+        tasks = _bootstrap_tasks()
+
+        existing = MagicMock()
+        existing.id = "cats-eye"
+        resolved = {"catalog_id": "NGC 6543", "primary_name": "NGC 6543", "aliases": []}
+
+        with patch.object(tasks, "repair_corrupted_simbad_cache",
+                          return_value={"corrupted": 1, "repaired": 1, "failed": 0}) as repair, \
+             patch.object(tasks, "Session") as Session, \
+             patch.object(tasks, "resolve_target_name_cached", return_value=resolved), \
+             patch.object(tasks, "match_target_by_identity", return_value=existing), \
+             patch.object(tasks, "set_rebuild_running_sync"), \
+             patch.object(tasks, "set_rebuild_progress_sync"), \
+             patch.object(tasks, "set_rebuild_complete_sync"), \
+             patch.object(tasks, "is_cancel_requested_sync", return_value=False), \
+             patch.object(tasks, "clear_cancel_sync"), \
+             patch("time.sleep"):
+            db = Session.return_value.__enter__.return_value
+            # One distinct unlinked OBJECT name with 196 images.
+            db.execute.return_value.all.return_value = [("NGC 6543", 196)]
+            result = tasks.backfill_catalog_identity.run()
+
+        repair.assert_called_once()
+        assert result["linked"] == 1
+
+    def test_leaves_unresolvable_orphaned(self):
+        tasks = _bootstrap_tasks()
+        with patch.object(tasks, "repair_corrupted_simbad_cache",
+                          return_value={"corrupted": 0, "repaired": 0, "failed": 0}), \
+             patch.object(tasks, "Session") as Session, \
+             patch.object(tasks, "resolve_target_name_cached", return_value=None), \
+             patch.object(tasks, "match_target_by_identity", return_value=None), \
+             patch.object(tasks, "set_rebuild_running_sync"), \
+             patch.object(tasks, "set_rebuild_progress_sync"), \
+             patch.object(tasks, "set_rebuild_complete_sync"), \
+             patch.object(tasks, "is_cancel_requested_sync", return_value=False), \
+             patch.object(tasks, "clear_cancel_sync"), \
+             patch("time.sleep"):
+            db = Session.return_value.__enter__.return_value
+            db.execute.return_value.all.return_value = [("Comet 12P", 4)]
+            result = tasks.backfill_catalog_identity.run()
+        assert result["linked"] == 0
+        assert result["skipped"] == 1

--- a/backend/tests/test_migration_0007.py
+++ b/backend/tests/test_migration_0007.py
@@ -1,0 +1,42 @@
+"""Structural assertions for migration 0007 (catalog_id_normalized)."""
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_MIG = (
+    Path(__file__).resolve().parent.parent
+    / "alembic" / "versions" / "0007_targets_catalog_id_normalized.py"
+)
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("mig0007", _MIG)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_migration_file_exists():
+    assert _MIG.exists()
+
+
+def test_revision_chains_off_0006():
+    mod = _load()
+    assert mod.revision == "0007"
+    assert mod.down_revision == "0006"
+
+
+def test_has_upgrade_and_downgrade():
+    mod = _load()
+    assert callable(mod.upgrade)
+    assert callable(mod.downgrade)
+
+
+def test_uses_guarded_column_helper():
+    src = _MIG.read_text(encoding="utf-8")
+    assert "_column_exists" in src
+    # Unique index must be guarded so re-running upgrade is safe.
+    assert "CREATE UNIQUE INDEX IF NOT EXISTS uq_targets_catalog_id_normalized" in src
+    # Dedupe must run before the index is created.
+    assert src.index("merged_into_id") < src.index("CREATE UNIQUE INDEX")

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -89,3 +89,21 @@ def test_activity_event_instantiation():
     assert ev.details["completed"] == 5
     assert ev.target_id is None
     assert ev.duration_ms is None
+
+
+class TestTargetCatalogIdNormalized:
+    def test_target_has_catalog_id_normalized_column(self):
+        from app.models.target import Target
+        assert "catalog_id_normalized" in Target.__table__.columns
+
+    def test_catalog_id_normalized_is_nullable(self):
+        from app.models.target import Target
+        assert Target.__table__.columns["catalog_id_normalized"].nullable is True
+
+    def test_unique_index_on_catalog_id_normalized_declared(self):
+        from app.models.target import Target
+        idx_names = {ix.name for ix in Target.__table__.indexes}
+        assert "uq_targets_catalog_id_normalized" in idx_names
+        ux = next(ix for ix in Target.__table__.indexes
+                  if ix.name == "uq_targets_catalog_id_normalized")
+        assert ux.unique is True

--- a/backend/tests/test_simbad_catalog_id.py
+++ b/backend/tests/test_simbad_catalog_id.py
@@ -1,0 +1,32 @@
+"""Tests for normalize_catalog_id: the canonical catalog-identity key."""
+import pytest
+
+from app.services.simbad import normalize_catalog_id
+
+
+class TestNormalizeCatalogId:
+    def test_uppercases_and_collapses_whitespace(self):
+        assert normalize_catalog_id("NGC 6543") == "NGC 6543"
+
+    def test_double_space_collapses_to_single(self):
+        # SIMBAD main_id "NGC  6543" must key the same as "NGC 6543"
+        assert normalize_catalog_id("NGC  6543") == "NGC 6543"
+
+    def test_lowercase_input_uppercased(self):
+        assert normalize_catalog_id("ngc 6543") == "NGC 6543"
+
+    def test_leading_trailing_whitespace_stripped(self):
+        assert normalize_catalog_id("  IC 1396a  ") == "IC 1396A"
+
+    def test_none_input_returns_none(self):
+        assert normalize_catalog_id(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert normalize_catalog_id("") is None
+
+    def test_whitespace_only_returns_none(self):
+        assert normalize_catalog_id("   ") is None
+
+    def test_matches_normalize_object_name_upper(self):
+        from app.services.simbad import normalize_object_name
+        assert normalize_catalog_id("ngc  6543") == normalize_object_name("ngc  6543", upper=True)

--- a/backend/tests/test_simbad_repair.py
+++ b/backend/tests/test_simbad_repair.py
@@ -1,0 +1,70 @@
+"""Tests for corrupted SIMBAD cache detection and repair."""
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+class TestRowIsCorrupted:
+    def test_quote_char_in_alias_is_corrupted(self):
+        from app.services.simbad_repair import _row_is_corrupted
+        row = MagicMock()
+        row.main_id = "NGC  6543"
+        row.raw_aliases = ['"NGC 6543"', '"Cat\'s Eye"']
+        assert _row_is_corrupted(row) is True
+
+    def test_clean_aliases_not_corrupted(self):
+        from app.services.simbad_repair import _row_is_corrupted
+        row = MagicMock()
+        row.main_id = "NGC  6543"
+        row.raw_aliases = ["NGC 6543", "NAME Cat's Eye Nebula"]
+        assert _row_is_corrupted(row) is False
+
+    def test_negative_row_not_corrupted(self):
+        from app.services.simbad_repair import _row_is_corrupted
+        row = MagicMock()
+        row.main_id = None
+        row.raw_aliases = []
+        assert _row_is_corrupted(row) is False
+
+
+class TestRepair:
+    def test_refetches_corrupted_rows(self):
+        from app.services.simbad_repair import repair_corrupted_simbad_cache
+
+        corrupted = MagicMock()
+        corrupted.query_name = "NGC 6543"
+        corrupted.main_id = "NGC  6543"
+        corrupted.raw_aliases = ['"NGC 6543"']
+
+        session = MagicMock()
+        session.execute.return_value.scalars.return_value.all.return_value = [corrupted]
+
+        fresh = {"main_id": "NGC  6543", "raw_aliases": ["NGC 6543", "NAME Cat's Eye Nebula"],
+                 "ra": 269.6, "dec": 66.6, "object_type": "PN"}
+
+        with patch("app.services.simbad_repair._query_simbad_raw_sync", return_value=fresh) as q, \
+             patch("app.services.simbad_repair.save_simbad_cache") as save, \
+             patch("app.services.simbad_repair.time.sleep"):
+            summary = repair_corrupted_simbad_cache(session, limit=100, sleep=0.0)
+
+        q.assert_called_once_with("NGC  6543")
+        save.assert_called_once()
+        assert summary["repaired"] == 1
+
+    def test_skips_when_refetch_fails(self):
+        from app.services.simbad_repair import repair_corrupted_simbad_cache
+
+        corrupted = MagicMock()
+        corrupted.query_name = "NGC 6543"
+        corrupted.main_id = "NGC  6543"
+        corrupted.raw_aliases = ['"NGC 6543"']
+        session = MagicMock()
+        session.execute.return_value.scalars.return_value.all.return_value = [corrupted]
+
+        with patch("app.services.simbad_repair._query_simbad_raw_sync", return_value=None), \
+             patch("app.services.simbad_repair.save_simbad_cache") as save, \
+             patch("app.services.simbad_repair.time.sleep"):
+            summary = repair_corrupted_simbad_cache(session, limit=100, sleep=0.0)
+
+        save.assert_not_called()
+        assert summary["repaired"] == 0
+        assert summary["failed"] == 1

--- a/backend/tests/test_target_resolver.py
+++ b/backend/tests/test_target_resolver.py
@@ -149,7 +149,9 @@ class TestCreateTarget:
             "aliases": ["NGC 7000"],
         }
 
-        result = _create_target(simbad_result, "NGC 7000", mock_session)
+        with patch("app.services.target_resolver.match_target_by_identity", return_value=None), \
+             patch("app.services.target_resolver.enrich_target_from_openngc"):
+            result = _create_target(simbad_result, "NGC 7000", mock_session)
         assert result == "existing-target"
         mock_session.rollback.assert_called_once()
 

--- a/backend/tests/test_target_resolver.py
+++ b/backend/tests/test_target_resolver.py
@@ -70,6 +70,7 @@ class TestResolveTarget:
 
         with patch("app.services.target_resolver.find_target_by_name", return_value=None), \
              patch("app.services.target_resolver.resolve_target_name_cached", return_value=simbad_result), \
+             patch("app.services.target_resolver.match_target_by_identity", return_value=None), \
              patch("app.services.target_resolver._create_target", return_value="new-target-id"):
             result = resolve_target("NGC 7000", mock_session, redis=mock_redis)
         assert result == "new-target-id"
@@ -108,9 +109,11 @@ class TestResolveTarget:
             "ra": 314.0, "dec": 44.0, "object_type": "HII",
         }
 
-        # First call (initial lookup) returns None, second call (re-check) returns target
-        with patch("app.services.target_resolver.find_target_by_name", side_effect=[None, mock_target]), \
+        # Initial lookup misses; the post-SIMBAD re-check now routes through the
+        # shared identity matcher, which finds the concurrently-created target.
+        with patch("app.services.target_resolver.find_target_by_name", return_value=None), \
              patch("app.services.target_resolver.resolve_target_name_cached", return_value=simbad_result), \
+             patch("app.services.target_resolver.match_target_by_identity", return_value=mock_target), \
              patch("app.services.target_resolver._create_target") as mock_create:
             result = resolve_target("NGC 7000", mock_session, redis=mock_redis)
 

--- a/backend/tests/test_target_resolver_identity.py
+++ b/backend/tests/test_target_resolver_identity.py
@@ -1,0 +1,83 @@
+"""Tests for the shared catalog-identity matcher and the reordered creator."""
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+class TestMatchTargetByIdentity:
+    def test_matches_by_normalized_catalog_id(self):
+        from app.services.target_resolver import match_target_by_identity
+
+        existing = MagicMock()
+        existing.id = "cats-eye"
+        session = MagicMock()
+        # First execute (catalog_id_normalized lookup) returns the target
+        session.execute.return_value.scalar_one_or_none.return_value = existing
+
+        resolved = {"catalog_id": "NGC  6543", "primary_name": "NGC 6543",
+                    "aliases": ["NGC 6543"]}
+        result = match_target_by_identity(resolved, "NGC 6543", session)
+        assert result is existing
+
+    def test_double_spaced_catalog_id_still_matches(self):
+        from app.services.target_resolver import match_target_by_identity
+
+        existing = MagicMock()
+        existing.id = "cats-eye"
+        session = MagicMock()
+        session.execute.return_value.scalar_one_or_none.return_value = existing
+
+        resolved = {"catalog_id": "NGC  6543", "primary_name": "NGC 6543", "aliases": []}
+        assert match_target_by_identity(resolved, "NGC  6543", session) is existing
+
+    def test_falls_back_to_name_match_when_no_catalog_id(self):
+        from app.services.target_resolver import match_target_by_identity
+
+        existing = MagicMock()
+        existing.id = "comet"
+        session = MagicMock()
+
+        resolved = {"catalog_id": None, "primary_name": "C/2023 A3", "aliases": []}
+        with patch("app.services.target_resolver.find_target_by_name",
+                   return_value=existing) as fbn:
+            result = match_target_by_identity(resolved, "C/2023 A3", session)
+        assert result is existing
+        fbn.assert_called_once()
+
+    def test_falls_back_to_name_match_when_identity_misses(self):
+        from app.services.target_resolver import match_target_by_identity
+
+        named = MagicMock()
+        named.id = "named-hit"
+        session = MagicMock()
+        # catalog_id_normalized lookup misses
+        session.execute.return_value.scalar_one_or_none.return_value = None
+
+        resolved = {"catalog_id": "NGC 6543", "primary_name": "NGC 6543", "aliases": []}
+        with patch("app.services.target_resolver.find_target_by_name",
+                   return_value=named) as fbn:
+            result = match_target_by_identity(resolved, "NGC 6543", session)
+        assert result is named
+        fbn.assert_called_once()
+
+    def test_returns_none_when_nothing_matches(self):
+        from app.services.target_resolver import match_target_by_identity
+
+        session = MagicMock()
+        session.execute.return_value.scalar_one_or_none.return_value = None
+        resolved = {"catalog_id": "NGC 9999", "primary_name": "NGC 9999", "aliases": []}
+        with patch("app.services.target_resolver.find_target_by_name", return_value=None):
+            assert match_target_by_identity(resolved, "NGC 9999", session) is None
+
+    def test_adds_incoming_object_as_alias_on_identity_match(self):
+        from app.services.target_resolver import match_target_by_identity
+
+        existing = MagicMock()
+        existing.id = "cats-eye"
+        existing.aliases = ["NGC 6543"]
+        session = MagicMock()
+        session.execute.return_value.scalar_one_or_none.return_value = existing
+
+        resolved = {"catalog_id": "NGC 6543", "primary_name": "NGC 6543", "aliases": []}
+        match_target_by_identity(resolved, "Cat's Eye Nebula", session)
+        # Normalized incoming OBJECT recorded so future direct lookups hit
+        assert "CAT'S EYE NEBULA" in existing.aliases

--- a/backend/tests/test_target_resolver_identity.py
+++ b/backend/tests/test_target_resolver_identity.py
@@ -140,3 +140,75 @@ class TestCreateTargetReordered:
 
         assert result == "winner"
         session.rollback.assert_called_once()
+
+
+class TestCreateTargetEnrichmentRenameLinksRealChain:
+    """End-to-end: real OpenNGC rename must feed the identity match and link.
+
+    Pins the literal NGC 6543 scenario: a first-seen 'NGC 6543' resolves to a
+    bare primary_name, the REAL enrich_target_from_openngc renames it to
+    'NGC 6543 - Cat's Eye Nebula', and the REAL match_target_by_identity then
+    links to the pre-existing Cat's Eye target by normalized catalog identity
+    instead of inserting a row that would collide on the unique primary_name.
+    Only lookup_openngc is stubbed (to supply the OpenNGC common name), so the
+    enrich -> match -> link chain runs for real.
+    """
+
+    def test_openngc_rename_links_to_existing_identity(self):
+        from app.services.target_resolver import _create_target
+
+        existing = MagicMock()
+        existing.id = "cats-eye-existing"
+        existing.primary_name = "NGC 6543 - Cat's Eye Nebula"
+        existing.catalog_id = "NGC 6543"
+        existing.catalog_id_normalized = "NGC 6543"
+        existing.aliases = ["NGC 6543"]
+
+        session = MagicMock()
+        # Both the OpenNGC lookup inside enrichment and the identity lookup go
+        # through session.execute; the identity lookup is the one that resolves
+        # to the seeded Cat's Eye target by catalog_id_normalized.
+        session.execute.return_value.scalar_one_or_none.return_value = existing
+
+        # A real OpenNGC entry carrying the common name so the rename happens for
+        # real. The six enrichment fields are None so the axis/mag loop is a
+        # no-op and only the common-name rename fires.
+        ngc_entry = MagicMock()
+        ngc_entry.common_names = "Cat's Eye Nebula"
+        ngc_entry.constellation = None
+        ngc_entry.major_axis = None
+        ngc_entry.minor_axis = None
+        ngc_entry.position_angle = None
+        ngc_entry.v_mag = None
+        ngc_entry.surface_brightness = None
+
+        simbad_result = {
+            "primary_name": "NGC 6543",
+            "catalog_id": "NGC 6543",
+            "common_name": None,
+            "aliases": ["NGC 6543"],
+            "ra": 269.6, "dec": 66.6, "object_type": "PN",
+        }
+
+        # Capture the real Target instance (without replacing the class, which
+        # would break the matcher's select(Target)) to prove the REAL OpenNGC
+        # rename fired before the match.
+        from app.services import target_resolver as tr
+        RealTarget = tr.Target
+        built = {}
+
+        class _CapturingTarget(RealTarget):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                built["instance"] = self
+
+        with patch("app.services.openngc.lookup_openngc", return_value=ngc_entry), \
+             patch("app.services.target_resolver.Target", _CapturingTarget):
+            result = _create_target(simbad_result, "NGC 6543", session)
+
+        # The real enrichment renamed the in-memory target before matching.
+        assert built["instance"].primary_name == "NGC 6543 - Cat's Eye Nebula"
+        assert built["instance"].common_name == "Cat's Eye Nebula"
+        # Linked to the existing target, no insert, never None.
+        assert result == "cats-eye-existing"
+        session.add.assert_not_called()

--- a/backend/tests/test_target_resolver_identity.py
+++ b/backend/tests/test_target_resolver_identity.py
@@ -270,3 +270,28 @@ class TestNegativeCacheCorrectness:
             result = resolve_target("NGC 6543", session, redis=redis)
 
         assert result == "cats-eye"
+
+    def test_recheck_link_commits_session_so_alias_persists(self):
+        """post-SIMBAD recheck: when match_target_by_identity links to an existing
+        target, session.commit() must be called before returning so any alias
+        mutation made by the matcher is not rolled back by the caller.
+        """
+        from app.services.target_resolver import resolve_target
+
+        session = MagicMock()
+        redis = MagicMock()
+        redis.sismember.return_value = False
+        existing = MagicMock()
+        existing.id = "cats-eye"
+
+        with patch("app.services.target_resolver.find_target_by_name", return_value=None), \
+             patch("app.services.target_resolver.resolve_target_name_cached", return_value=self._simbad()), \
+             patch("app.services.target_resolver.match_target_by_identity", return_value=existing), \
+             patch("app.services.target_resolver._create_target") as mock_create:
+            result = resolve_target("NGC 6543", session, redis=redis)
+
+        assert result == "cats-eye"
+        # Alias mutation from match_target_by_identity must be persisted before
+        # returning, consistent with the _create_target link branch.
+        session.commit.assert_called()
+        mock_create.assert_not_called()

--- a/backend/tests/test_target_resolver_identity.py
+++ b/backend/tests/test_target_resolver_identity.py
@@ -81,3 +81,62 @@ class TestMatchTargetByIdentity:
         match_target_by_identity(resolved, "Cat's Eye Nebula", session)
         # Normalized incoming OBJECT recorded so future direct lookups hit
         assert "CAT'S EYE NEBULA" in existing.aliases
+
+
+class TestCreateTargetReordered:
+    def _simbad(self):
+        return {
+            "primary_name": "NGC 6543",
+            "catalog_id": "NGC 6543",
+            "common_name": None,
+            "aliases": ["NGC 6543"],
+            "ra": 269.6, "dec": 66.6, "object_type": "PN",
+        }
+
+    def test_sets_catalog_id_normalized_on_new_target(self):
+        from app.services.target_resolver import _create_target
+
+        session = MagicMock()
+        captured = {}
+
+        def _add(obj):
+            captured["target"] = obj
+        session.add.side_effect = _add
+
+        with patch("app.services.target_resolver.match_target_by_identity", return_value=None), \
+             patch("app.services.target_resolver.enrich_target_from_openngc"), \
+             patch("app.services.target_resolver.enrich_target_from_vizier"), \
+             patch("app.services.target_resolver.enrich_target_from_sac"):
+            _create_target(self._simbad(), "NGC 6543", session)
+
+        assert captured["target"].catalog_id_normalized == "NGC 6543"
+
+    def test_links_to_existing_identity_instead_of_inserting(self):
+        from app.services.target_resolver import _create_target
+
+        existing = MagicMock()
+        existing.id = "cats-eye"
+        session = MagicMock()
+
+        with patch("app.services.target_resolver.match_target_by_identity", return_value=existing):
+            result = _create_target(self._simbad(), "NGC 6543", session)
+
+        assert result == "cats-eye"
+        session.add.assert_not_called()
+
+    def test_integrity_error_requeries_by_post_enrichment_name_and_identity(self):
+        """Collision after enrichment must re-query by catalog identity, never None."""
+        from sqlalchemy.exc import IntegrityError
+        from app.services.target_resolver import _create_target
+
+        session = MagicMock()
+        session.flush.side_effect = IntegrityError("dup", {}, None)
+        existing = MagicMock()
+        existing.id = "winner"
+        session.execute.return_value.scalar_one_or_none.return_value = existing
+
+        with patch("app.services.target_resolver.match_target_by_identity", return_value=None):
+            result = _create_target(self._simbad(), "NGC 6543", session)
+
+        assert result == "winner"
+        session.rollback.assert_called_once()

--- a/backend/tests/test_target_resolver_identity.py
+++ b/backend/tests/test_target_resolver_identity.py
@@ -212,3 +212,61 @@ class TestCreateTargetEnrichmentRenameLinksRealChain:
         # Linked to the existing target, no insert, never None.
         assert result == "cats-eye-existing"
         session.add.assert_not_called()
+
+
+class TestNegativeCacheCorrectness:
+    def _simbad(self):
+        return {
+            "primary_name": "NGC 6543", "catalog_id": "NGC 6543",
+            "common_name": None, "aliases": ["NGC 6543"],
+            "ra": 269.6, "dec": 66.6, "object_type": "PN",
+        }
+
+    def test_resolved_identity_never_writes_negative_cache(self):
+        """A name that resolves to a catalog identity must never be negative-cached,
+        even if _create_target transiently returns None (e.g. a lost create race)."""
+        from app.services.target_resolver import resolve_target
+
+        session = MagicMock()
+        redis = MagicMock()
+        redis.sismember.return_value = False
+
+        with patch("app.services.target_resolver.find_target_by_name", return_value=None), \
+             patch("app.services.target_resolver.resolve_target_name_cached", return_value=self._simbad()), \
+             patch("app.services.target_resolver.match_target_by_identity", return_value=None), \
+             patch("app.services.target_resolver._create_target", return_value=None):
+            result = resolve_target("NGC 6543", session, redis=redis)
+
+        assert result is None
+        redis.sadd.assert_not_called()
+
+    def test_unresolvable_name_still_negative_cached(self):
+        from app.services.target_resolver import resolve_target
+
+        session = MagicMock()
+        redis = MagicMock()
+        redis.sismember.return_value = False
+
+        with patch("app.services.target_resolver.find_target_by_name", return_value=None), \
+             patch("app.services.target_resolver.resolve_target_name_cached", return_value=None), \
+             patch("app.services.target_resolver.resolve_sesame_cached", return_value=None):
+            result = resolve_target("FlatWizard", session, redis=redis)
+
+        assert result is None
+        redis.sadd.assert_called_once()
+
+    def test_resolve_uses_identity_matcher_after_simbad(self):
+        from app.services.target_resolver import resolve_target
+
+        session = MagicMock()
+        redis = MagicMock()
+        redis.sismember.return_value = False
+        existing = MagicMock()
+        existing.id = "cats-eye"
+
+        with patch("app.services.target_resolver.find_target_by_name", return_value=None), \
+             patch("app.services.target_resolver.resolve_target_name_cached", return_value=self._simbad()), \
+             patch("app.services.target_resolver.match_target_by_identity", return_value=existing):
+            result = resolve_target("NGC 6543", session, redis=redis)
+
+        assert result == "cats-eye"

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -358,6 +358,9 @@ export const api = {
   retryUnresolved: () =>
     fetchJson<{ status: string; message: string; task_id?: string }>("/scan/retry-unresolved", { method: "POST" }),
 
+  backfillCatalogIdentity: () =>
+    fetchJson<{ status: string; message: string; task_id?: string }>("/scan/backfill-catalog-identity", { method: "POST" }),
+
   getRebuildStatus: () =>
     fetchJson<import("../types").RebuildStatus>("/scan/rebuild-status"),
 

--- a/frontend/src/components/settings/MaintenanceSection.tsx
+++ b/frontend/src/components/settings/MaintenanceSection.tsx
@@ -143,6 +143,18 @@ const MaintenanceSection: Component<MaintenanceSectionProps> = (props) => {
       600_000,
     );
 
+  const handleBackfillIdentity = () =>
+    runOperation(
+      "backfill",
+      () => api.backfillCatalogIdentity() as Promise<{ task_id: string }>,
+      "Re-linking catalog orphans...",
+      "Catalog orphans re-linked",
+      "Backfill failed",
+      "rebuild",
+      "Re-link Catalog Orphans",
+      1_800_000,
+    );
+
   const handleFullRebuild = () => {
     setShowRebuildConfirm(false);
     runOperation(
@@ -277,6 +289,54 @@ const MaintenanceSection: Component<MaintenanceSectionProps> = (props) => {
             <p class="mt-2 text-xs text-green-400">Retry complete.</p>
           </Show>
           <Show when={isError("retry")}>
+            <p class="mt-2 text-xs text-theme-error">{errorMessage()}</p>
+          </Show>
+        </div>
+
+        {/* ---- Re-link Catalog Orphans ---- */}
+        <div class="p-3 bg-theme-base/50 border border-theme-border rounded-[var(--radius-sm)]">
+          <div class="flex items-start justify-between gap-4">
+            <div class="flex-1">
+              <div class="flex items-center gap-2 mb-1">
+                <p class="text-sm text-theme-text-primary font-medium">Re-link Catalog Orphans</p>
+                <span class="text-xs px-1.5 py-0.5 rounded bg-yellow-500/15 text-yellow-400 border border-yellow-500/20">
+                  Moderate
+                </span>
+              </div>
+              <p class="text-xs text-theme-text-secondary mt-0.5">
+                Repairs SIMBAD cache and re-links unattached frames to existing targets by catalog identity (e.g. NGC 6543). Requires internet for cache repair.
+              </p>
+              <p class="text-xs text-theme-text-tertiary mt-1">
+                Run once after upgrading. Safe to re-run. Frames that match no catalog object stay listed under their object name.
+              </p>
+            </div>
+
+            <Show when={isAdmin() && !isRunning("backfill") && !isComplete("backfill")}>
+              <button
+                onClick={handleBackfillIdentity}
+                disabled={anyRunning()}
+                class="px-3 py-1.5 text-xs border border-theme-border-em text-theme-text-secondary rounded-[var(--radius-sm)] hover:text-theme-text-primary hover:border-theme-accent transition-colors disabled:opacity-50 flex-shrink-0"
+              >
+                Re-link Orphans
+              </button>
+            </Show>
+          </div>
+
+          <Show when={isRunning("backfill")}>
+            <div class="mt-3 flex items-center gap-2">
+              <div class="w-4 h-4 border-2 border-theme-accent border-t-transparent rounded-full animate-spin flex-shrink-0" />
+              <div class="text-xs text-theme-text-secondary">
+                <p>{statusMessage() || "Re-linking catalog orphans..."}</p>
+                <Show when={formatDetails()}>
+                  <p class="text-theme-text-tertiary mt-0.5">{formatDetails()}</p>
+                </Show>
+              </div>
+            </div>
+          </Show>
+          <Show when={isComplete("backfill")}>
+            <p class="mt-2 text-xs text-green-400">Backfill complete.</p>
+          </Show>
+          <Show when={isError("backfill")}>
             <p class="mt-2 text-xs text-theme-error">{errorMessage()}</p>
           </Show>
         </div>

--- a/frontend/src/pages/TargetDetailPage.tsx
+++ b/frontend/src/pages/TargetDetailPage.tsx
@@ -194,7 +194,8 @@ const TargetDetailPage: Component = () => {
 
   const [mergeHistory, { refetch: refetchMergeHistory }] = createResource(
     () => params.targetId,
-    (id) => api.getMergeHistory(id),
+    (id): Promise<MergedTargetResponse[]> | MergedTargetResponse[] =>
+      id.startsWith("obj:") ? [] : api.getMergeHistory(id).catch(() => []),
   );
   const [mergeHistoryExpanded, setMergeHistoryExpanded] = createSignal(false);
   const [undoingMerge, setUndoingMerge] = createSignal<string | null>(null);

--- a/settings-maint.yml
+++ b/settings-maint.yml
@@ -1,0 +1,956 @@
+- generic [ref=e3]:
+  - banner [ref=e4]:
+    - link "GalactiLog logo GalactiLog" [ref=e5] [cursor=pointer]:
+      - /url: /
+      - img "GalactiLog logo" [ref=e6]
+      - heading "GalactiLog" [level=1] [ref=e7]
+    - navigation [ref=e8]:
+      - link "Dashboard" [ref=e9] [cursor=pointer]:
+        - /url: /
+      - link "Mosaics" [ref=e10] [cursor=pointer]:
+        - /url: /mosaics
+      - link "Statistics" [ref=e11] [cursor=pointer]:
+        - /url: /statistics
+      - link "Analysis" [ref=e12] [cursor=pointer]:
+        - /url: /analysis
+      - link "Settings" [ref=e13] [cursor=pointer]:
+        - /url: /settings
+    - generic [ref=e14]:
+      - generic [ref=e22]: chvvkumar
+      - button "Sign out" [ref=e23]
+      - link "snd" [ref=e16] [cursor=pointer]:
+        - /url: https://github.com/chvvkumar/GalactiLog/commit/b1a7e383a2ae97e9545549abbc57c43ea2f75efd
+      - link "GitHub" [ref=e17] [cursor=pointer]:
+        - /url: https://github.com/chvvkumar/GalactiLog
+        - img [ref=e18]
+  - generic [ref=e24]:
+    - heading "Settings" [level=1] [ref=e25]
+    - generic [ref=e26]:
+      - generic [ref=e27]:
+        - button "Library" [ref=e28] [cursor=pointer]
+        - button "Equipment" [ref=e29] [cursor=pointer]
+        - button "Display" [ref=e30] [cursor=pointer]
+        - button "External Tools" [ref=e31] [cursor=pointer]
+        - button "Target Management" [ref=e32] [cursor=pointer]
+        - button "Custom Columns" [ref=e33] [cursor=pointer]
+        - button "Backup & Restore" [ref=e34] [cursor=pointer]
+        - button "Users" [ref=e35] [cursor=pointer]
+        - button "Activity Log" [ref=e36] [cursor=pointer]
+        - button "Metrics" [ref=e37] [cursor=pointer]
+      - button "About this section" [ref=e39] [cursor=pointer]:
+        - img [ref=e40]
+    - generic [ref=e43]:
+      - generic [ref=e44]:
+        - generic [ref=e45]:
+          - generic [ref=e46]:
+            - generic [ref=e47]: 33,237
+            - generic [ref=e48]: Total Images
+          - generic [ref=e49]:
+            - generic [ref=e50]: 31,537
+            - generic [ref=e51]: Light Frames
+          - generic [ref=e52]:
+            - generic [ref=e53]: "117"
+            - generic [ref=e54]: Targets
+          - generic "Light frames whose OBJECT name could not be matched to a known target in SIMBAD." [ref=e55] [cursor=pointer]:
+            - generic [ref=e56]: "670"
+            - generic [ref=e57]: Unresolved
+          - generic [ref=e58]:
+            - generic [ref=e59]: 1,906
+            - generic [ref=e60]: From CSV
+          - generic "On-disk size of raw FITS capture files." [ref=e61]:
+            - generic [ref=e62]: 0 KB
+            - generic [ref=e63]: FITS
+          - generic "On-disk size of generated preview thumbnails." [ref=e64]:
+            - generic [ref=e65]: 8.2 GB
+            - generic [ref=e66]: Thumbnails
+          - generic "On-disk size of the PostgreSQL database." [ref=e67]:
+            - generic [ref=e68]: 215 MB
+            - generic [ref=e69]: Database
+        - generic [ref=e70]:
+          - generic "165 SIMBAD lookups cached locally. 7 returned no match." [ref=e71]: 165 SIMBAD cached (7 negative)
+          - generic "7 SESAME (NED+VizieR) fallback lookups cached locally. 7 returned no match." [ref=e72]: 7 SESAME cached (7 negative)
+          - generic "30 VizieR lookups cached locally. 6 returned no data." [ref=e73]: 30 VizieR cached (6 negative)
+      - generic [ref=e75]:
+        - heading "Capture Activity" [level=3] [ref=e76]
+        - generic [ref=e77]: Frames per capture night (last 30)
+      - generic [ref=e80]:
+        - generic [ref=e81]:
+          - generic [ref=e82]:
+            - generic [ref=e83]:
+              - heading "Library Scanning" [level=3] [ref=e84]
+              - button "About this section" [ref=e86] [cursor=pointer]:
+                - img [ref=e87]
+            - generic [ref=e89]:
+              - generic [ref=e90]:
+                - heading "Auto-scan" [level=4] [ref=e91]
+                - button "About this section" [ref=e93] [cursor=pointer]:
+                  - img [ref=e94]
+              - generic [ref=e96]:
+                - generic [ref=e97]: Enable automatic scanning
+                - button [ref=e98]
+              - generic [ref=e100]:
+                - generic [ref=e101]: Scan interval
+                - combobox [ref=e102]:
+                  - option "1 hour"
+                  - option "2 hours"
+                  - option "4 hours"
+                  - option "8 hours" [selected]
+                  - option "12 hours"
+                  - option "24 hours"
+            - generic [ref=e103]:
+              - generic [ref=e104]:
+                - heading "Observer Location" [level=4] [ref=e105]
+                - button "About this section" [ref=e107] [cursor=pointer]:
+                  - img [ref=e108]
+              - generic [ref=e110]:
+                - generic [ref=e111]:
+                  - text: Name
+                  - textbox [ref=e112]: Home
+                - generic [ref=e113]:
+                  - text: Latitude
+                  - spinbutton [ref=e114]: "38.7582179"
+                - generic [ref=e115]:
+                  - text: Longitude
+                  - spinbutton [ref=e116]: "-90.6893767"
+            - group [ref=e117]:
+              - generic "Path & name rules — 0 include path(s), 3 exclude path(s), 0 name rule(s)" [ref=e118] [cursor=pointer]
+              - generic [ref=e119]:
+                - generic [ref=e120]:
+                  - button "About this section" [ref=e121] [cursor=pointer]:
+                    - img [ref=e122]
+                    - generic [ref=e124]: About this section
+                    - img [ref=e125]
+                  - generic [ref=e128]:
+                    - paragraph [ref=e129]:
+                      - text: Filtering happens in
+                      - strong [ref=e130]: two layers
+                      - text: ", applied in order."
+                    - generic [ref=e131]:
+                      - paragraph [ref=e132]: 1. Paths, which folders to walk
+                      - list [ref=e133]:
+                        - listitem [ref=e134]:
+                          - strong [ref=e135]: Include paths
+                          - text: limit the scan to specific subtrees.
+                          - emphasis [ref=e136]: Empty means scan everything under the data root.
+                        - listitem [ref=e137]:
+                          - strong [ref=e138]: Exclude paths
+                          - text: skip subtrees entirely.
+                          - emphasis [ref=e139]: Exclude always wins over include.
+                    - generic [ref=e140]:
+                      - paragraph [ref=e141]: 2. Name rules, which files and folders to keep
+                      - list [ref=e142]:
+                        - listitem [ref=e143]:
+                          - text: Patterns match against
+                          - strong [ref=e144]: file names
+                          - text: or
+                          - strong [ref=e145]: folder names
+                          - text: ", using"
+                          - strong [ref=e146]: wildcard
+                          - text: ","
+                          - strong [ref=e147]: substring
+                          - text: ", or"
+                          - strong [ref=e148]: regex
+                          - text: .
+                        - listitem [ref=e149]:
+                          - strong [ref=e150]: Exclude rules
+                          - text: are checked first, then
+                          - strong [ref=e151]: include rules
+                          - text: narrow the result.
+                        - listitem [ref=e152]:
+                          - text: If any include rule exists for a target kind (file or folder), that target
+                          - strong [ref=e153]: must
+                          - text: match at least one.
+                    - generic [ref=e154]:
+                      - paragraph [ref=e155]: Example
+                      - generic [ref=e156]: include path /app/data/fits/2025 exclude path /app/data/fits/2025/rejected exclude rule *_bad.fits (wildcard, file) include rule ^M\d+$ (regex, folder)
+                      - paragraph [ref=e157]:
+                        - text: "Result: scans only"
+                        - code [ref=e158]: "2025"
+                        - text: ", skips"
+                        - code [ref=e159]: rejected/
+                        - text: ", drops any file ending in"
+                        - code [ref=e160]: _bad.fits
+                        - text: ", and only keeps files whose parent folder name is an M-catalog designation like"
+                        - code [ref=e161]: M31
+                        - text: or
+                        - code [ref=e162]: M42
+                        - text: .
+                - generic [ref=e163]:
+                  - generic [ref=e164]:
+                    - heading "Include paths" [level=4] [ref=e165]
+                    - button "Browse…" [ref=e166]
+                  - paragraph [ref=e167]: When empty, scans the entire configured data path. When set, scans only these folders (each must resolve inside the data root).
+                  - paragraph [ref=e168]: None
+                  - generic [ref=e169]:
+                    - textbox "/app/data/fits/subfolder" [ref=e170]
+                    - button "Add" [disabled] [ref=e171]
+                - generic [ref=e172]:
+                  - generic [ref=e173]:
+                    - heading "Exclude paths" [level=4] [ref=e174]
+                    - button "Browse…" [ref=e175]
+                  - paragraph [ref=e176]: Subtrees to skip entirely. Exclude always wins over include.
+                  - list [ref=e177]:
+                    - listitem [ref=e178]:
+                      - code [ref=e179]: /app/data/fits/Calibration Frames
+                      - button "Remove" [ref=e180]
+                    - listitem [ref=e181]:
+                      - code [ref=e182]: /app/data/fits/@eaDir
+                      - button "Remove" [ref=e183]
+                    - listitem [ref=e184]:
+                      - code [ref=e185]: /app/data/fits/delete
+                      - button "Remove" [ref=e186]
+                  - generic [ref=e187]:
+                    - textbox "/app/data/fits/subfolder" [ref=e188]
+                    - button "Add" [disabled] [ref=e189]
+                - generic [ref=e190]:
+                  - heading "Name rules" [level=4] [ref=e191]
+                  - generic [ref=e192]:
+                    - button "About this section" [ref=e193] [cursor=pointer]:
+                      - img [ref=e194]
+                      - generic [ref=e196]: About this section
+                      - img [ref=e197]
+                    - paragraph [ref=e200]:
+                      - text: "Pattern syntax:"
+                      - strong [ref=e201]: wildcard
+                      - text: uses
+                      - code [ref=e202]: "*"
+                      - text: for any characters and
+                      - code [ref=e203]: "?"
+                      - text: for a single character (e.g.
+                      - code [ref=e204]: "*_bad.fits"
+                      - text: ","
+                      - code [ref=e205]: "*_calibration"
+                      - text: ).
+                      - strong [ref=e206]: Substring
+                      - text: matches anywhere inside the name, case-insensitive (e.g.
+                      - code [ref=e207]: rejected
+                      - text: ","
+                      - code [ref=e208]: test_
+                      - text: ).
+                      - strong [ref=e209]: Regex
+                      - text: is a full regular expression (e.g.
+                      - code [ref=e210]: ^M\d+$
+                      - text: ","
+                      - code [ref=e211]: .*_v[0-9]+\.fits
+                      - text: ).
+                  - table [ref=e213]:
+                    - rowgroup [ref=e214]:
+                      - row "On Action Type Target Pattern" [ref=e215]:
+                        - columnheader "On" [ref=e216]
+                        - columnheader "Action" [ref=e217]
+                        - columnheader "Type" [ref=e218]
+                        - columnheader "Target" [ref=e219]
+                        - columnheader "Pattern" [ref=e220]
+                        - columnheader [ref=e221]
+                    - rowgroup
+                  - button "Add rule" [ref=e222]
+                - generic [ref=e223]:
+                  - heading "Test a path" [level=4] [ref=e224]
+                  - paragraph [ref=e225]: Paste a file or folder path to see how the current rules would treat it. The path does not need to exist on disk. Unsaved changes are not used; save first to test them.
+                  - generic [ref=e227]:
+                    - textbox "/app/data/fits/2025/M31/frame_bad.fits" [ref=e228]
+                    - combobox "Treat the path as a file, a folder, or auto-detect" [ref=e229]:
+                      - option "auto" [selected]
+                      - option "file"
+                      - option "folder"
+                    - button "Test" [disabled] [ref=e230]
+                - generic [ref=e231]:
+                  - button "Save rules" [disabled] [ref=e232]
+                  - button "Revert" [disabled] [ref=e233]
+                  - button "Apply now" [ref=e234]
+            - generic [ref=e235]:
+              - generic [ref=e236]:
+                - generic [ref=e237]: "Include:"
+                - generic [ref=e238] [cursor=pointer]:
+                  - radio "All frames" [ref=e239]
+                  - generic [ref=e240]: All frames
+                - generic [ref=e241] [cursor=pointer]:
+                  - radio "Light frames only" [checked] [ref=e242]
+                  - generic [ref=e243]: Light frames only
+              - generic [ref=e244]:
+                - button "Stop" [ref=e245]
+                - button "Scan Directory" [ref=e246]
+          - generic [ref=e248]:
+            - heading "Maintenance" [level=3] [ref=e249]
+            - generic [ref=e250]:
+              - button "Fetch Reference Images" [ref=e251]
+              - button "Regenerate Thumbnails" [ref=e252]
+        - generic [ref=e255]:
+          - generic [ref=e256]:
+            - generic [ref=e257]:
+              - heading "Activity" [level=3] [ref=e258]
+              - generic [ref=e259]: 1 live
+            - button "Clear" [ref=e260]
+          - status [ref=e261]:
+            - paragraph [ref=e262]: Now Running
+            - generic [ref=e264]:
+              - generic [ref=e265]:
+                - generic [ref=e266]: Rebuild
+                - generic [ref=e267]: Repairing SIMBAD cache...
+              - generic [ref=e269]: 01:04 ago
+          - generic [ref=e272]:
+            - generic [ref=e273]:
+              - paragraph [ref=e274]: History
+              - generic [ref=e275]:
+                - button "all" [ref=e276]
+                - button "info" [ref=e277]
+                - button "warn" [ref=e278]
+                - button "error" [ref=e279]
+              - generic [ref=e280]:
+                - button "all" [ref=e281]
+                - button "scan" [ref=e282]
+                - button "reb" [ref=e283]
+                - button "thumb" [ref=e284]
+                - button "enrich" [ref=e285]
+                - button "mosaic" [ref=e286]
+                - button "migr" [ref=e287]
+                - button "user" [ref=e288]
+                - button "sys" [ref=e289]
+            - generic [ref=e291]:
+              - generic [ref=e295]:
+                - 'button "10:33 am ▲ enrich Retry Unresolved: enrichment failed for 7 of 7 object names ›" [ref=e296]':
+                  - generic [ref=e297]: 10:33 am
+                  - generic "warning" [ref=e298]: ▲
+                  - generic [ref=e299]: enrich
+                  - generic [ref=e300]: "Retry Unresolved: enrichment failed for 7 of 7 object names"
+                  - generic [ref=e301]: ›
+                - generic [ref=e304]:
+                  - generic [ref=e305]:
+                    - term [ref=e306]: Total
+                    - definition [ref=e307]: "7"
+                  - generic [ref=e308]:
+                    - term [ref=e309]: Failed targets
+                    - definition [ref=e310]: "7"
+              - generic [ref=e314]:
+                - 'button "10:33 am ● reb Retry Unresolved: 0 resolved, 7 still unresolved out of 7 names ›" [ref=e315]':
+                  - generic [ref=e316]: 10:33 am
+                  - generic "info" [ref=e317]: ●
+                  - generic [ref=e318]: reb
+                  - generic [ref=e319]: "Retry Unresolved: 0 resolved, 7 still unresolved out of 7 names"
+                  - generic [ref=e320]: ›
+                - generic [ref=e323]:
+                  - generic [ref=e324]:
+                    - term [ref=e325]: Total
+                    - definition [ref=e326]: "7"
+                  - generic [ref=e327]:
+                    - term [ref=e328]: Failed
+                    - definition [ref=e329]: "7"
+                  - generic [ref=e330]:
+                    - term [ref=e331]: Resolved
+                    - definition [ref=e332]: "0"
+              - generic [ref=e337]:
+                - generic [ref=e338]: 10:33 am
+                - generic "info" [ref=e339]: ●
+                - generic [ref=e340]: mosaic
+                - generic [ref=e341]: "Mosaic detection complete: 0 new suggestions found"
+              - generic [ref=e345]:
+                - 'button "10:33 am ● reb Quick Fix: No issues found ›" [ref=e346]':
+                  - generic [ref=e347]: 10:33 am
+                  - generic "info" [ref=e348]: ●
+                  - generic [ref=e349]: reb
+                  - generic [ref=e350]: "Quick Fix: No issues found"
+                  - generic [ref=e351]: ›
+                - generic [ref=e354]:
+                  - generic [ref=e355]:
+                    - term [ref=e356]: Rederived
+                    - definition [ref=e357]: "0"
+                  - generic [ref=e358]:
+                    - term [ref=e359]: Names rebuilt
+                    - definition [ref=e360]: "0"
+                  - generic [ref=e361]:
+                    - term [ref=e362]: Aliases updated
+                    - definition [ref=e363]: "0"
+                  - generic [ref=e364]:
+                    - term [ref=e365]: Linked unresolved
+                    - definition [ref=e366]: "0"
+                  - generic [ref=e367]:
+                    - term [ref=e368]: Redirected merged
+                    - definition [ref=e369]: "0"
+                  - generic [ref=e370]:
+                    - term [ref=e371]: Stale candidates removed
+                    - definition [ref=e372]: "0"
+              - generic [ref=e377]:
+                - generic [ref=e378]: 10:31 am
+                - generic "info" [ref=e379]: ●
+                - generic [ref=e380]: mosaic
+                - generic [ref=e381]: "Mosaic detection complete: 0 new suggestions found"
+              - generic [ref=e386]:
+                - generic [ref=e387]: 10:31 am
+                - generic "info" [ref=e388]: ●
+                - generic [ref=e389]: mosaic
+                - generic [ref=e390]: "Mosaic detection complete: 0 new suggestions found"
+              - generic [ref=e395]:
+                - generic [ref=e396]: 07:32 am
+                - generic "info" [ref=e397]: ●
+                - generic [ref=e398]: mosaic
+                - generic [ref=e399]: "Mosaic detection complete: 0 new suggestions found"
+              - generic [ref=e404]:
+                - generic [ref=e405]: 07:32 am
+                - generic "info" [ref=e406]: ●
+                - generic [ref=e407]: mosaic
+                - generic [ref=e408]: "Mosaic detection complete: 0 new suggestions found"
+              - generic [ref=e409]:
+                - generic [ref=e410]:
+                  - generic [ref=e412]:
+                    - 'button "06:53 am ● scan Scan complete: no new files found (83633 already cataloged) ›" [ref=e413]':
+                      - generic [ref=e414]: 06:53 am
+                      - generic "info" [ref=e415]: ●
+                      - generic [ref=e416]: scan
+                      - generic [ref=e417]: "Scan complete: no new files found (83633 already cataloged)"
+                      - generic [ref=e418]: ›
+                    - generic [ref=e421]:
+                      - generic [ref=e422]:
+                        - term [ref=e423]: Failed
+                        - definition [ref=e424]: "0"
+                      - generic [ref=e425]:
+                        - term [ref=e426]: Removed
+                        - definition [ref=e427]: "0"
+                      - generic [ref=e428]:
+                        - term [ref=e429]: Completed
+                        - definition [ref=e430]: "0"
+                      - generic [ref=e431]:
+                        - term [ref=e432]: Already known
+                        - definition [ref=e433]: 83,633
+                  - button "1 sub-task ›" [ref=e434]:
+                    - generic [ref=e435]: 1 sub-task
+                    - generic [ref=e436]: ›
+                - generic [ref=e438]:
+                  - 'button "06:53 am ● thumb Reference Thumbnails: fetched 0/0 ›" [ref=e439]':
+                    - generic [ref=e440]: 06:53 am
+                    - generic "info" [ref=e441]: ●
+                    - generic [ref=e442]: thumb
+                    - generic [ref=e443]: "Reference Thumbnails: fetched 0/0"
+                    - generic [ref=e444]: ›
+                  - generic [ref=e447]:
+                    - generic [ref=e448]:
+                      - term [ref=e449]: Total
+                      - definition [ref=e450]: "0"
+                    - generic [ref=e451]:
+                      - term [ref=e452]: Fetched
+                      - definition [ref=e453]: "0"
+              - generic [ref=e454]:
+                - generic [ref=e455]:
+                  - generic [ref=e457]:
+                    - 'button "06:29 am ● scan Scan complete: 283 new files added, 390 calibration frames skipped, 283 CSV enriched ›" [ref=e458]':
+                      - generic [ref=e459]: 06:29 am
+                      - generic "info" [ref=e460]: ●
+                      - generic [ref=e461]: scan
+                      - generic [ref=e462]: "Scan complete: 283 new files added, 390 calibration frames skipped, 283 CSV enriched"
+                      - generic [ref=e463]: ›
+                    - generic [ref=e466]:
+                      - generic [ref=e467]:
+                        - term [ref=e468]: Total
+                        - definition [ref=e469]: "673"
+                      - generic [ref=e470]:
+                        - term [ref=e471]: Failed
+                        - definition [ref=e472]: "0"
+                      - generic [ref=e473]:
+                        - term [ref=e474]: Removed
+                        - definition [ref=e475]: "0"
+                      - generic [ref=e476]:
+                        - term [ref=e477]: Completed
+                        - definition [ref=e478]: "673"
+                      - generic [ref=e479]:
+                        - term [ref=e480]: New files
+                        - definition [ref=e481]: "673"
+                      - generic [ref=e482]:
+                        - term [ref=e483]: Csv enriched
+                        - definition [ref=e484]: "283"
+                      - generic [ref=e485]:
+                        - term [ref=e486]: Changed files
+                        - definition [ref=e487]: "0"
+                      - generic [ref=e488]:
+                        - term [ref=e489]: Skipped calibration
+                        - definition [ref=e490]: "390"
+                  - button "4 sub-tasks ›" [ref=e491]:
+                    - generic [ref=e492]: 4 sub-tasks
+                    - generic [ref=e493]: ›
+                - generic [ref=e494]:
+                  - generic [ref=e495]:
+                    - 'button "06:29 am ● reb Quick Fix: No issues found ›" [ref=e496]':
+                      - generic [ref=e497]: 06:29 am
+                      - generic "info" [ref=e498]: ●
+                      - generic [ref=e499]: reb
+                      - generic [ref=e500]: "Quick Fix: No issues found"
+                      - generic [ref=e501]: ›
+                    - generic [ref=e504]:
+                      - generic [ref=e505]:
+                        - term [ref=e506]: Rederived
+                        - definition [ref=e507]: "0"
+                      - generic [ref=e508]:
+                        - term [ref=e509]: Names rebuilt
+                        - definition [ref=e510]: "0"
+                      - generic [ref=e511]:
+                        - term [ref=e512]: Aliases updated
+                        - definition [ref=e513]: "0"
+                      - generic [ref=e514]:
+                        - term [ref=e515]: Linked unresolved
+                        - definition [ref=e516]: "0"
+                      - generic [ref=e517]:
+                        - term [ref=e518]: Redirected merged
+                        - definition [ref=e519]: "0"
+                      - generic [ref=e520]:
+                        - term [ref=e521]: Stale candidates removed
+                        - definition [ref=e522]: "0"
+                  - generic [ref=e523]:
+                    - 'button "06:29 am ● thumb Reference Thumbnails: fetched 0/0 ›" [ref=e524]':
+                      - generic [ref=e525]: 06:29 am
+                      - generic "info" [ref=e526]: ●
+                      - generic [ref=e527]: thumb
+                      - generic [ref=e528]: "Reference Thumbnails: fetched 0/0"
+                      - generic [ref=e529]: ›
+                    - generic [ref=e532]:
+                      - generic [ref=e533]:
+                        - term [ref=e534]: Total
+                        - definition [ref=e535]: "0"
+                      - generic [ref=e536]:
+                        - term [ref=e537]: Fetched
+                        - definition [ref=e538]: "0"
+                  - generic [ref=e540]:
+                    - generic [ref=e541]: 06:29 am
+                    - generic "info" [ref=e542]: ●
+                    - generic [ref=e543]: mosaic
+                    - generic [ref=e544]: "Mosaic detection complete: 0 new suggestions found"
+                  - generic [ref=e546]:
+                    - generic [ref=e547]: 06:29 am
+                    - generic "info" [ref=e548]: ●
+                    - generic [ref=e549]: mosaic
+                    - generic [ref=e550]: "Mosaic detection complete: 0 new suggestions found"
+              - generic [ref=e555]:
+                - generic [ref=e556]: 06:16 am
+                - generic "info" [ref=e557]: ●
+                - generic [ref=e558]: scan
+                - generic [ref=e559]: Scan stopped by user (0 files discovered before stop)
+              - generic [ref=e560]:
+                - generic [ref=e561]:
+                  - generic [ref=e563]:
+                    - 'button "10:53 pm ● scan Scan complete: no new files found (82960 already cataloged) ›" [ref=e564]':
+                      - generic [ref=e565]: 10:53 pm
+                      - generic "info" [ref=e566]: ●
+                      - generic [ref=e567]: scan
+                      - generic [ref=e568]: "Scan complete: no new files found (82960 already cataloged)"
+                      - generic [ref=e569]: ›
+                    - generic [ref=e572]:
+                      - generic [ref=e573]:
+                        - term [ref=e574]: Failed
+                        - definition [ref=e575]: "0"
+                      - generic [ref=e576]:
+                        - term [ref=e577]: Removed
+                        - definition [ref=e578]: "0"
+                      - generic [ref=e579]:
+                        - term [ref=e580]: Completed
+                        - definition [ref=e581]: "0"
+                      - generic [ref=e582]:
+                        - term [ref=e583]: Already known
+                        - definition [ref=e584]: 82,960
+                  - button "1 sub-task ›" [ref=e585]:
+                    - generic [ref=e586]: 1 sub-task
+                    - generic [ref=e587]: ›
+                - generic [ref=e589]:
+                  - 'button "10:53 pm ● thumb Reference Thumbnails: fetched 0/0 ›" [ref=e590]':
+                    - generic [ref=e591]: 10:53 pm
+                    - generic "info" [ref=e592]: ●
+                    - generic [ref=e593]: thumb
+                    - generic [ref=e594]: "Reference Thumbnails: fetched 0/0"
+                    - generic [ref=e595]: ›
+                  - generic [ref=e598]:
+                    - generic [ref=e599]:
+                      - term [ref=e600]: Total
+                      - definition [ref=e601]: "0"
+                    - generic [ref=e602]:
+                      - term [ref=e603]: Fetched
+                      - definition [ref=e604]: "0"
+              - generic [ref=e605]:
+                - generic [ref=e606]:
+                  - generic [ref=e608]:
+                    - 'button "08:35 pm ● scan Scan complete: no new files found (82960 already cataloged), 18 deleted files purged from catalog ›" [ref=e609]':
+                      - generic [ref=e610]: 08:35 pm
+                      - generic "info" [ref=e611]: ●
+                      - generic [ref=e612]: scan
+                      - generic [ref=e613]: "Scan complete: no new files found (82960 already cataloged), 18 deleted files purged from catalog"
+                      - generic [ref=e614]: ›
+                    - generic [ref=e617]:
+                      - generic [ref=e618]:
+                        - term [ref=e619]: Failed
+                        - definition [ref=e620]: "0"
+                      - generic [ref=e621]:
+                        - term [ref=e622]: Removed
+                        - definition [ref=e623]: "18"
+                      - generic [ref=e624]:
+                        - term [ref=e625]: Completed
+                        - definition [ref=e626]: "0"
+                      - generic [ref=e627]:
+                        - term [ref=e628]: Already known
+                        - definition [ref=e629]: 82,960
+                  - button "1 sub-task ›" [ref=e630]:
+                    - generic [ref=e631]: 1 sub-task
+                    - generic [ref=e632]: ›
+                - generic [ref=e634]:
+                  - 'button "08:35 pm ● thumb Reference Thumbnails: fetched 0/0 ›" [ref=e635]':
+                    - generic [ref=e636]: 08:35 pm
+                    - generic "info" [ref=e637]: ●
+                    - generic [ref=e638]: thumb
+                    - generic [ref=e639]: "Reference Thumbnails: fetched 0/0"
+                    - generic [ref=e640]: ›
+                  - generic [ref=e643]:
+                    - generic [ref=e644]:
+                      - term [ref=e645]: Total
+                      - definition [ref=e646]: "0"
+                    - generic [ref=e647]:
+                      - term [ref=e648]: Fetched
+                      - definition [ref=e649]: "0"
+              - generic [ref=e654]:
+                - generic [ref=e655]: 08:35 pm
+                - generic "info" [ref=e656]: ●
+                - generic [ref=e657]: scan
+                - generic [ref=e658]: Removed 18 deleted files from catalog
+              - generic [ref=e662]:
+                - 'button "07:03 pm ▲ enrich Retry Unresolved: enrichment failed for 8 of 8 object names ›" [ref=e663]':
+                  - generic [ref=e664]: 07:03 pm
+                  - generic "warning" [ref=e665]: ▲
+                  - generic [ref=e666]: enrich
+                  - generic [ref=e667]: "Retry Unresolved: enrichment failed for 8 of 8 object names"
+                  - generic [ref=e668]: ›
+                - generic [ref=e671]:
+                  - generic [ref=e672]:
+                    - term [ref=e673]: Total
+                    - definition [ref=e674]: "8"
+                  - generic [ref=e675]:
+                    - term [ref=e676]: Failed targets
+                    - definition [ref=e677]: "8"
+              - generic [ref=e681]:
+                - 'button "07:03 pm ● reb Retry Unresolved: 0 resolved, 8 still unresolved out of 8 names ›" [ref=e682]':
+                  - generic [ref=e683]: 07:03 pm
+                  - generic "info" [ref=e684]: ●
+                  - generic [ref=e685]: reb
+                  - generic [ref=e686]: "Retry Unresolved: 0 resolved, 8 still unresolved out of 8 names"
+                  - generic [ref=e687]: ›
+                - generic [ref=e690]:
+                  - generic [ref=e691]:
+                    - term [ref=e692]: Total
+                    - definition [ref=e693]: "8"
+                  - generic [ref=e694]:
+                    - term [ref=e695]: Failed
+                    - definition [ref=e696]: "8"
+                  - generic [ref=e697]:
+                    - term [ref=e698]: Resolved
+                    - definition [ref=e699]: "0"
+              - generic [ref=e704]:
+                - generic [ref=e705]: 07:03 pm
+                - generic "info" [ref=e706]: ●
+                - generic [ref=e707]: mosaic
+                - generic [ref=e708]: "Mosaic detection complete: 0 new suggestions found"
+              - generic [ref=e713]:
+                - generic [ref=e714]: 07:03 pm
+                - generic "info" [ref=e715]: ●
+                - generic [ref=e716]: mosaic
+                - generic [ref=e717]: "Mosaic detection complete: 0 new suggestions found"
+              - generic [ref=e722]:
+                - generic [ref=e723]: 07:03 pm
+                - generic "info" [ref=e724]: ●
+                - generic [ref=e725]: mosaic
+                - generic [ref=e726]: "Mosaic detection complete: 0 new suggestions found"
+              - generic [ref=e730]:
+                - 'button "07:03 pm ● migr Data upgrade complete: v11: HyperLEDA: 29 galaxies enriched (32 network queries) ›" [ref=e731]':
+                  - generic [ref=e732]: 07:03 pm
+                  - generic "info" [ref=e733]: ●
+                  - generic [ref=e734]: migr
+                  - generic [ref=e735]: "Data upgrade complete: v11: HyperLEDA: 29 galaxies enriched (32 network queries)"
+                  - generic [ref=e736]: ›
+                - generic [ref=e739]:
+                  - generic [ref=e740]:
+                    - term [ref=e741]: To version
+                    - definition [ref=e742]: "11"
+                  - generic [ref=e743]:
+                    - term [ref=e744]: From version
+                    - definition [ref=e745]: "10"
+              - generic [ref=e749]:
+                - 'button "07:03 pm ● reb Quick Fix: No issues found ›" [ref=e750]':
+                  - generic [ref=e751]: 07:03 pm
+                  - generic "info" [ref=e752]: ●
+                  - generic [ref=e753]: reb
+                  - generic [ref=e754]: "Quick Fix: No issues found"
+                  - generic [ref=e755]: ›
+                - generic [ref=e758]:
+                  - generic [ref=e759]:
+                    - term [ref=e760]: Rederived
+                    - definition [ref=e761]: "0"
+                  - generic [ref=e762]:
+                    - term [ref=e763]: Names rebuilt
+                    - definition [ref=e764]: "0"
+                  - generic [ref=e765]:
+                    - term [ref=e766]: Aliases updated
+                    - definition [ref=e767]: "0"
+                  - generic [ref=e768]:
+                    - term [ref=e769]: Linked unresolved
+                    - definition [ref=e770]: "0"
+                  - generic [ref=e771]:
+                    - term [ref=e772]: Redirected merged
+                    - definition [ref=e773]: "0"
+                  - generic [ref=e774]:
+                    - term [ref=e775]: Stale candidates removed
+                    - definition [ref=e776]: "0"
+              - generic [ref=e777]:
+                - generic [ref=e778]:
+                  - generic [ref=e780]:
+                    - 'button "05:42 pm ● scan Scan complete: no new files found (82978 already cataloged) ›" [ref=e781]':
+                      - generic [ref=e782]: 05:42 pm
+                      - generic "info" [ref=e783]: ●
+                      - generic [ref=e784]: scan
+                      - generic [ref=e785]: "Scan complete: no new files found (82978 already cataloged)"
+                      - generic [ref=e786]: ›
+                    - generic [ref=e789]:
+                      - generic [ref=e790]:
+                        - term [ref=e791]: Failed
+                        - definition [ref=e792]: "0"
+                      - generic [ref=e793]:
+                        - term [ref=e794]: Removed
+                        - definition [ref=e795]: "0"
+                      - generic [ref=e796]:
+                        - term [ref=e797]: Completed
+                        - definition [ref=e798]: "0"
+                      - generic [ref=e799]:
+                        - term [ref=e800]: Already known
+                        - definition [ref=e801]: 82,978
+                  - button "1 sub-task ›" [ref=e802]:
+                    - generic [ref=e803]: 1 sub-task
+                    - generic [ref=e804]: ›
+                - generic [ref=e806]:
+                  - 'button "05:43 pm ● thumb Reference Thumbnails: fetched 0/0 ›" [ref=e807]':
+                    - generic [ref=e808]: 05:43 pm
+                    - generic "info" [ref=e809]: ●
+                    - generic [ref=e810]: thumb
+                    - generic [ref=e811]: "Reference Thumbnails: fetched 0/0"
+                    - generic [ref=e812]: ›
+                  - generic [ref=e815]:
+                    - generic [ref=e816]:
+                      - term [ref=e817]: Total
+                      - definition [ref=e818]: "0"
+                    - generic [ref=e819]:
+                      - term [ref=e820]: Fetched
+                      - definition [ref=e821]: "0"
+              - generic [ref=e825]:
+                - 'button "05:40 pm ▲ enrich Retry Unresolved: enrichment failed for 8 of 8 object names ›" [ref=e826]':
+                  - generic [ref=e827]: 05:40 pm
+                  - generic "warning" [ref=e828]: ▲
+                  - generic [ref=e829]: enrich
+                  - generic [ref=e830]: "Retry Unresolved: enrichment failed for 8 of 8 object names"
+                  - generic [ref=e831]: ›
+                - generic [ref=e834]:
+                  - generic [ref=e835]:
+                    - term [ref=e836]: Total
+                    - definition [ref=e837]: "8"
+                  - generic [ref=e838]:
+                    - term [ref=e839]: Failed targets
+                    - definition [ref=e840]: "8"
+              - generic [ref=e844]:
+                - 'button "05:40 pm ● reb Retry Unresolved: 0 resolved, 8 still unresolved out of 8 names ›" [ref=e845]':
+                  - generic [ref=e846]: 05:40 pm
+                  - generic "info" [ref=e847]: ●
+                  - generic [ref=e848]: reb
+                  - generic [ref=e849]: "Retry Unresolved: 0 resolved, 8 still unresolved out of 8 names"
+                  - generic [ref=e850]: ›
+                - generic [ref=e853]:
+                  - generic [ref=e854]:
+                    - term [ref=e855]: Total
+                    - definition [ref=e856]: "8"
+                  - generic [ref=e857]:
+                    - term [ref=e858]: Failed
+                    - definition [ref=e859]: "8"
+                  - generic [ref=e860]:
+                    - term [ref=e861]: Resolved
+                    - definition [ref=e862]: "0"
+              - generic [ref=e867]:
+                - generic [ref=e868]: 05:40 pm
+                - generic "info" [ref=e869]: ●
+                - generic [ref=e870]: mosaic
+                - generic [ref=e871]: "Mosaic detection complete: 0 new suggestions found"
+              - generic [ref=e875]:
+                - 'button "05:40 pm ● reb Quick Fix: No issues found ›" [ref=e876]':
+                  - generic [ref=e877]: 05:40 pm
+                  - generic "info" [ref=e878]: ●
+                  - generic [ref=e879]: reb
+                  - generic [ref=e880]: "Quick Fix: No issues found"
+                  - generic [ref=e881]: ›
+                - generic [ref=e884]:
+                  - generic [ref=e885]:
+                    - term [ref=e886]: Rederived
+                    - definition [ref=e887]: "0"
+                  - generic [ref=e888]:
+                    - term [ref=e889]: Names rebuilt
+                    - definition [ref=e890]: "0"
+                  - generic [ref=e891]:
+                    - term [ref=e892]: Aliases updated
+                    - definition [ref=e893]: "0"
+                  - generic [ref=e894]:
+                    - term [ref=e895]: Linked unresolved
+                    - definition [ref=e896]: "0"
+                  - generic [ref=e897]:
+                    - term [ref=e898]: Redirected merged
+                    - definition [ref=e899]: "0"
+                  - generic [ref=e900]:
+                    - term [ref=e901]: Stale candidates removed
+                    - definition [ref=e902]: "0"
+              - generic [ref=e907]:
+                - generic [ref=e908]: 05:35 pm
+                - generic "info" [ref=e909]: ●
+                - generic [ref=e910]: mosaic
+                - generic [ref=e911]: "Mosaic detection complete: 0 new suggestions found"
+              - generic [ref=e916]:
+                - generic [ref=e917]: 05:35 pm
+                - generic "info" [ref=e918]: ●
+                - generic [ref=e919]: mosaic
+                - generic [ref=e920]: "Mosaic detection complete: 0 new suggestions found"
+              - generic [ref=e925]:
+                - generic [ref=e926]: 05:29 pm
+                - generic "info" [ref=e927]: ●
+                - generic [ref=e928]: mosaic
+                - generic [ref=e929]: "Mosaic detection complete: 0 new suggestions found"
+              - generic [ref=e934]:
+                - generic [ref=e935]: 05:29 pm
+                - generic "info" [ref=e936]: ●
+                - generic [ref=e937]: mosaic
+                - generic [ref=e938]: "Mosaic detection complete: 0 new suggestions found"
+              - generic [ref=e943]:
+                - generic [ref=e944]: 04:49 pm
+                - generic "info" [ref=e945]: ●
+                - generic [ref=e946]: mosaic
+                - generic [ref=e947]: "Mosaic detection complete: 0 new suggestions found"
+              - generic [ref=e952]:
+                - generic [ref=e953]: 04:49 pm
+                - generic "info" [ref=e954]: ●
+                - generic [ref=e955]: mosaic
+                - generic [ref=e956]: "Mosaic detection complete: 0 new suggestions found"
+              - generic [ref=e960]:
+                - 'button "04:37 pm ▲ enrich Retry Unresolved: enrichment failed for 8 of 8 object names ›" [ref=e961]':
+                  - generic [ref=e962]: 04:37 pm
+                  - generic "warning" [ref=e963]: ▲
+                  - generic [ref=e964]: enrich
+                  - generic [ref=e965]: "Retry Unresolved: enrichment failed for 8 of 8 object names"
+                  - generic [ref=e966]: ›
+                - generic [ref=e969]:
+                  - generic [ref=e970]:
+                    - term [ref=e971]: Total
+                    - definition [ref=e972]: "8"
+                  - generic [ref=e973]:
+                    - term [ref=e974]: Failed targets
+                    - definition [ref=e975]: "8"
+              - generic [ref=e979]:
+                - 'button "04:37 pm ● reb Retry Unresolved: 0 resolved, 8 still unresolved out of 8 names ›" [ref=e980]':
+                  - generic [ref=e981]: 04:37 pm
+                  - generic "info" [ref=e982]: ●
+                  - generic [ref=e983]: reb
+                  - generic [ref=e984]: "Retry Unresolved: 0 resolved, 8 still unresolved out of 8 names"
+                  - generic [ref=e985]: ›
+                - generic [ref=e988]:
+                  - generic [ref=e989]:
+                    - term [ref=e990]: Total
+                    - definition [ref=e991]: "8"
+                  - generic [ref=e992]:
+                    - term [ref=e993]: Failed
+                    - definition [ref=e994]: "8"
+                  - generic [ref=e995]:
+                    - term [ref=e996]: Resolved
+                    - definition [ref=e997]: "0"
+              - generic [ref=e1002]:
+                - generic [ref=e1003]: 04:36 pm
+                - generic "info" [ref=e1004]: ●
+                - generic [ref=e1005]: mosaic
+                - generic [ref=e1006]: "Mosaic detection complete: 0 new suggestions found"
+              - generic [ref=e1010]:
+                - 'button "04:36 pm ● reb Quick Fix: No issues found ›" [ref=e1011]':
+                  - generic [ref=e1012]: 04:36 pm
+                  - generic "info" [ref=e1013]: ●
+                  - generic [ref=e1014]: reb
+                  - generic [ref=e1015]: "Quick Fix: No issues found"
+                  - generic [ref=e1016]: ›
+                - generic [ref=e1019]:
+                  - generic [ref=e1020]:
+                    - term [ref=e1021]: Rederived
+                    - definition [ref=e1022]: "0"
+                  - generic [ref=e1023]:
+                    - term [ref=e1024]: Names rebuilt
+                    - definition [ref=e1025]: "0"
+                  - generic [ref=e1026]:
+                    - term [ref=e1027]: Aliases updated
+                    - definition [ref=e1028]: "0"
+                  - generic [ref=e1029]:
+                    - term [ref=e1030]: Linked unresolved
+                    - definition [ref=e1031]: "0"
+                  - generic [ref=e1032]:
+                    - term [ref=e1033]: Redirected merged
+                    - definition [ref=e1034]: "0"
+                  - generic [ref=e1035]:
+                    - term [ref=e1036]: Stale candidates removed
+                    - definition [ref=e1037]: "0"
+              - generic [ref=e1042]:
+                - generic [ref=e1043]: 04:24 pm
+                - generic "info" [ref=e1044]: ●
+                - generic [ref=e1045]: mosaic
+                - generic [ref=e1046]: "Mosaic detection complete: 0 new suggestions found"
+              - generic [ref=e1051]:
+                - generic [ref=e1052]: 04:24 pm
+                - generic "info" [ref=e1053]: ●
+                - generic [ref=e1054]: mosaic
+                - generic [ref=e1055]: "Mosaic detection complete: 0 new suggestions found"
+              - generic [ref=e1060]:
+                - generic [ref=e1061]: 03:56 pm
+                - generic "info" [ref=e1062]: ●
+                - generic [ref=e1063]: mosaic
+                - generic [ref=e1064]: "Mosaic detection complete: 0 new suggestions found"
+              - generic [ref=e1069]:
+                - generic [ref=e1070]: 03:56 pm
+                - generic "info" [ref=e1071]: ●
+                - generic [ref=e1072]: mosaic
+                - generic [ref=e1073]: "Mosaic detection complete: 0 new suggestions found"
+              - generic [ref=e1078]:
+                - generic [ref=e1079]: 03:21 pm
+                - generic "info" [ref=e1080]: ●
+                - generic [ref=e1081]: mosaic
+                - generic [ref=e1082]: "Mosaic detection complete: 0 new suggestions found"
+              - generic [ref=e1087]:
+                - generic [ref=e1088]: 03:21 pm
+                - generic "info" [ref=e1089]: ●
+                - generic [ref=e1090]: mosaic
+                - generic [ref=e1091]: "Mosaic detection complete: 0 new suggestions found"
+              - generic [ref=e1092]:
+                - generic [ref=e1093]:
+                  - generic [ref=e1095]:
+                    - 'button "02:53 pm ● scan Scan complete: no new files found (82978 already cataloged) ›" [ref=e1096]':
+                      - generic [ref=e1097]: 02:53 pm
+                      - generic "info" [ref=e1098]: ●
+                      - generic [ref=e1099]: scan
+                      - generic [ref=e1100]: "Scan complete: no new files found (82978 already cataloged)"
+                      - generic [ref=e1101]: ›
+                    - generic [ref=e1104]:
+                      - generic [ref=e1105]:
+                        - term [ref=e1106]: Failed
+                        - definition [ref=e1107]: "0"
+                      - generic [ref=e1108]:
+                        - term [ref=e1109]: Removed
+                        - definition [ref=e1110]: "0"
+                      - generic [ref=e1111]:
+                        - term [ref=e1112]: Completed
+                        - definition [ref=e1113]: "0"
+                      - generic [ref=e1114]:
+                        - term [ref=e1115]: Already known
+                        - definition [ref=e1116]: 82,978
+                  - button "1 sub-task ›" [ref=e1117]:
+                    - generic [ref=e1118]: 1 sub-task
+                    - generic [ref=e1119]: ›
+                - generic [ref=e1121]:
+                  - 'button "02:53 pm ● thumb Reference Thumbnails: fetched 0/0 ›" [ref=e1122]':
+                    - generic [ref=e1123]: 02:53 pm
+                    - generic "info" [ref=e1124]: ●
+                    - generic [ref=e1125]: thumb
+                    - generic [ref=e1126]: "Reference Thumbnails: fetched 0/0"
+                    - generic [ref=e1127]: ›
+                  - generic [ref=e1130]:
+                    - generic [ref=e1131]:
+                      - term [ref=e1132]: Total
+                      - definition [ref=e1133]: "0"
+                    - generic [ref=e1134]:
+                      - term [ref=e1135]: Fetched
+                      - definition [ref=e1136]: "0"
+  - status
+  - alert

--- a/settings-targets.yml
+++ b/settings-targets.yml
@@ -1,0 +1,258 @@
+- generic [ref=e3]:
+  - banner [ref=e4]:
+    - link "GalactiLog logo GalactiLog" [ref=e5] [cursor=pointer]:
+      - /url: /
+      - img "GalactiLog logo" [ref=e6]
+      - heading "GalactiLog" [level=1] [ref=e7]
+    - navigation [ref=e8]:
+      - link "Dashboard" [ref=e9] [cursor=pointer]:
+        - /url: /
+      - link "Mosaics" [ref=e10] [cursor=pointer]:
+        - /url: /mosaics
+      - link "Statistics" [ref=e11] [cursor=pointer]:
+        - /url: /statistics
+      - link "Analysis" [ref=e12] [cursor=pointer]:
+        - /url: /analysis
+      - link "Settings" [ref=e13] [cursor=pointer]:
+        - /url: /settings
+    - generic [ref=e14]:
+      - generic [ref=e22]: chvvkumar
+      - button "Sign out" [ref=e23]
+      - link "snd" [ref=e16] [cursor=pointer]:
+        - /url: https://github.com/chvvkumar/GalactiLog/commit/b1a7e383a2ae97e9545549abbc57c43ea2f75efd
+      - link "GitHub" [ref=e17] [cursor=pointer]:
+        - /url: https://github.com/chvvkumar/GalactiLog
+        - img [ref=e18]
+  - generic [ref=e24]:
+    - heading "Settings" [level=1] [ref=e25]
+    - generic [ref=e26]:
+      - generic [ref=e27]:
+        - button "Library" [ref=e28] [cursor=pointer]
+        - button "Equipment" [ref=e29] [cursor=pointer]
+        - button "Display" [ref=e30] [cursor=pointer]
+        - button "External Tools" [ref=e31] [cursor=pointer]
+        - button "Target Management" [active] [ref=e32] [cursor=pointer]
+        - button "Custom Columns" [ref=e33] [cursor=pointer]
+        - button "Backup & Restore" [ref=e34] [cursor=pointer]
+        - button "Users" [ref=e35] [cursor=pointer]
+        - button "Activity Log" [ref=e36] [cursor=pointer]
+        - button "Metrics" [ref=e37] [cursor=pointer]
+      - button "About this section" [ref=e39] [cursor=pointer]:
+        - img [ref=e40]
+    - generic [ref=e1138]:
+      - generic [ref=e1139]:
+        - paragraph [ref=e1140]: Last Scan
+        - generic [ref=e1142]: "Files ingested: 673"
+      - generic [ref=e1143]:
+        - heading "Duplicates (0)" [level=3] [ref=e1144]
+        - paragraph [ref=e1145]: No duplicates found.
+      - generic [ref=e1146]:
+        - heading "Unresolved Names (0)" [level=3] [ref=e1147]
+        - paragraph [ref=e1148]: No unresolved names.
+      - generic [ref=e1149]:
+        - button "Merge History (15)" [ref=e1150] [cursor=pointer]:
+          - heading "Merge History (15)" [level=3] [ref=e1151]
+          - img [ref=e1152]
+        - generic [ref=e1155]:
+          - generic [ref=e1156]:
+            - generic [ref=e1157]:
+              - generic [ref=e1158]:
+                - generic [ref=e1159]: Caldwell 4
+                - generic [ref=e1160]: →
+                - link "NGC 7023 - Iris Nebula" [ref=e1161] [cursor=pointer]:
+                  - /url: /targets/e83503e4-f12b-4df6-b946-59002c0e3110
+              - generic [ref=e1162]:
+                - generic [ref=e1163]: Merged on Apr 12, 2026
+                - generic [ref=e1164]: 60 images
+            - button "Undo Merge" [ref=e1166]
+          - generic [ref=e1167]:
+            - generic [ref=e1168]:
+              - generic [ref=e1169]:
+                - generic [ref=e1170]: Cigar Galaxy
+                - generic [ref=e1171]: →
+                - link "M 82 - Cigar Galaxy" [ref=e1172] [cursor=pointer]:
+                  - /url: /targets/22efe4c7-dbc7-4a5e-ad25-07f6f489ddf8
+              - generic [ref=e1173]:
+                - generic [ref=e1174]: Merged on Apr 12, 2026
+                - generic [ref=e1175]: 158 images
+            - button "Undo Merge" [ref=e1177]
+          - generic [ref=e1178]:
+            - generic [ref=e1179]:
+              - generic [ref=e1180]:
+                - generic [ref=e1181]: NGC 6503
+                - generic [ref=e1182]: →
+                - link "NGC 6503" [ref=e1183] [cursor=pointer]:
+                  - /url: /targets/9d76a01b-e91d-43db-a19b-7923a784430c
+              - generic [ref=e1184]:
+                - generic [ref=e1185]: Merged on Apr 12, 2026
+                - generic [ref=e1186]: 82 images
+            - button "Undo Merge" [ref=e1188]
+          - generic [ref=e1189]:
+            - generic [ref=e1190]:
+              - generic [ref=e1191]:
+                - generic [ref=e1192]: NGC 6543
+                - generic [ref=e1193]: →
+                - link "NGC 6543 - Cat's Eye Nebula" [ref=e1194] [cursor=pointer]:
+                  - /url: /targets/e482bfaf-f08d-4bb6-999e-f268944556fa
+              - generic [ref=e1195]:
+                - generic [ref=e1196]: Merged on Jun 10, 2026
+                - generic [ref=e1197]: 196 images
+            - button "Undo Merge" [ref=e1199]
+          - generic [ref=e1200]:
+            - generic [ref=e1201]:
+              - generic [ref=e1202]:
+                - generic [ref=e1203]: Makarian's Chain
+                - generic [ref=e1204]: →
+                - link "Markarian's Chain" [ref=e1205] [cursor=pointer]:
+                  - /url: /targets/c4937f8d-f103-4bc2-8bcf-6c3a5d34c4b0
+              - generic [ref=e1206]:
+                - generic [ref=e1207]: Merged on Apr 20, 2026
+                - generic [ref=e1208]: 30 images
+            - button "Undo Merge" [ref=e1210]
+          - generic [ref=e1211]:
+            - generic [ref=e1212]:
+              - generic [ref=e1213]:
+                - generic [ref=e1214]: Andromeda Nebula Panel 1
+                - generic [ref=e1215]: →
+                - link "M 31 - Andromeda Nebula" [ref=e1216] [cursor=pointer]:
+                  - /url: /targets/1a52fd1d-6b8e-42f3-9e7c-21983795c2e5
+              - generic [ref=e1217]:
+                - generic [ref=e1218]: Merged on Apr 19, 2026
+                - generic [ref=e1219]: 123 images
+            - button "Undo Merge" [ref=e1221]
+          - generic [ref=e1222]:
+            - generic [ref=e1223]:
+              - generic [ref=e1224]:
+                - generic [ref=e1225]: Andromeda Nebula Panel 3
+                - generic [ref=e1226]: →
+                - link "M 31 - Andromeda Nebula" [ref=e1227] [cursor=pointer]:
+                  - /url: /targets/1a52fd1d-6b8e-42f3-9e7c-21983795c2e5
+              - generic [ref=e1228]:
+                - generic [ref=e1229]: Merged on Apr 19, 2026
+                - generic [ref=e1230]: 61 images
+            - button "Undo Merge" [ref=e1232]
+          - generic [ref=e1233]:
+            - generic [ref=e1234]:
+              - generic [ref=e1235]:
+                - generic [ref=e1236]: Part of Cat's Eye Nebula
+                - generic [ref=e1237]: →
+                - link "NGC 6543 - Cat's Eye Nebula" [ref=e1238] [cursor=pointer]:
+                  - /url: /targets/e482bfaf-f08d-4bb6-999e-f268944556fa
+              - generic [ref=e1239]:
+                - generic [ref=e1240]: Merged on Apr 12, 2026
+                - generic [ref=e1241]: 73 images
+            - button "Undo Merge" [ref=e1243]
+          - generic [ref=e1244]:
+            - generic [ref=e1245]:
+              - generic [ref=e1246]:
+                - generic [ref=e1247]: Andromeda Nebula Panel 2
+                - generic [ref=e1248]: →
+                - link "M 31 - Andromeda Nebula" [ref=e1249] [cursor=pointer]:
+                  - /url: /targets/1a52fd1d-6b8e-42f3-9e7c-21983795c2e5
+              - generic [ref=e1250]:
+                - generic [ref=e1251]: Merged on Apr 19, 2026
+                - generic [ref=e1252]: 74 images
+            - button "Undo Merge" [ref=e1254]
+          - generic [ref=e1255]:
+            - generic [ref=e1256]:
+              - generic [ref=e1257]:
+                - generic [ref=e1258]: NGC 896 Panel 1
+                - generic [ref=e1259]: →
+                - link "NGC 896" [ref=e1260] [cursor=pointer]:
+                  - /url: /targets/be7a0d21-82bf-4c69-8023-955f3e8a6ef7
+              - generic [ref=e1261]:
+                - generic [ref=e1262]: Merged on Apr 12, 2026
+                - generic [ref=e1263]: 19 images
+            - button "Undo Merge" [ref=e1265]
+          - generic [ref=e1266]:
+            - generic [ref=e1267]:
+              - generic [ref=e1268]:
+                - generic [ref=e1269]: NGC 896 Panel 2
+                - generic [ref=e1270]: →
+                - link "NGC 896" [ref=e1271] [cursor=pointer]:
+                  - /url: /targets/be7a0d21-82bf-4c69-8023-955f3e8a6ef7
+              - generic [ref=e1272]:
+                - generic [ref=e1273]: Merged on Apr 12, 2026
+                - generic [ref=e1274]: 15 images
+            - button "Undo Merge" [ref=e1276]
+          - generic [ref=e1277]:
+            - generic [ref=e1278]:
+              - generic [ref=e1279]:
+                - generic [ref=e1280]: NGC 896 Panel 3
+                - generic [ref=e1281]: →
+                - link "NGC 896" [ref=e1282] [cursor=pointer]:
+                  - /url: /targets/be7a0d21-82bf-4c69-8023-955f3e8a6ef7
+              - generic [ref=e1283]:
+                - generic [ref=e1284]: Merged on Apr 12, 2026
+                - generic [ref=e1285]: 11 images
+            - button "Undo Merge" [ref=e1287]
+          - generic [ref=e1288]:
+            - generic [ref=e1289]:
+              - generic [ref=e1290]:
+                - generic [ref=e1291]: NGC 896 Panel 4
+                - generic [ref=e1292]: →
+                - link "NGC 896" [ref=e1293] [cursor=pointer]:
+                  - /url: /targets/be7a0d21-82bf-4c69-8023-955f3e8a6ef7
+              - generic [ref=e1294]:
+                - generic [ref=e1295]: Merged on Apr 12, 2026
+                - generic [ref=e1296]: 27 images
+            - button "Undo Merge" [ref=e1298]
+          - generic [ref=e1299]:
+            - generic [ref=e1300]:
+              - generic [ref=e1301]:
+                - generic [ref=e1302]: Markarian's Chain
+                - generic [ref=e1303]: →
+                - link "Markarian's Chain" [ref=e1304] [cursor=pointer]:
+                  - /url: /targets/c4937f8d-f103-4bc2-8bcf-6c3a5d34c4b0
+              - generic [ref=e1305]:
+                - generic [ref=e1306]: Merged on Apr 20, 2026
+                - generic [ref=e1307]: 146 images
+            - button "Undo Merge" [ref=e1309]
+          - generic [ref=e1310]:
+            - generic [ref=e1311]:
+              - generic [ref=e1312]:
+                - generic [ref=e1313]: Markarian
+                - generic [ref=e1314]: →
+                - link "Markarian's Chain" [ref=e1315] [cursor=pointer]:
+                  - /url: /targets/c4937f8d-f103-4bc2-8bcf-6c3a5d34c4b0
+              - generic [ref=e1316]:
+                - generic [ref=e1317]: Merged on Apr 21, 2026
+                - generic [ref=e1318]: 100 images
+            - button "Undo Merge" [ref=e1320]
+      - generic [ref=e1321]:
+        - heading "Maintenance" [level=3] [ref=e1322]
+        - generic [ref=e1323]:
+          - generic [ref=e1325]:
+            - generic [ref=e1326]:
+              - generic [ref=e1327]:
+                - paragraph [ref=e1328]: Repair Target Links
+                - generic [ref=e1329]: Safe
+              - paragraph [ref=e1330]: Re-links images to targets using cached data. No network calls. Fixes broken links after merges or name changes.
+              - paragraph [ref=e1331]: Run this if images appear under the wrong target or are missing from a target.
+            - button "Run Repair" [ref=e1332]
+          - generic [ref=e1334]:
+            - generic [ref=e1335]:
+              - generic [ref=e1336]:
+                - paragraph [ref=e1337]: Retry Failed Lookups
+                - generic [ref=e1338]: Moderate
+              - paragraph [ref=e1339]: Clears failed lookup caches and re-queries SIMBAD for all unresolved names. Requires internet.
+              - paragraph [ref=e1340]: Run this after correcting FITS headers or if SIMBAD was down during the last scan.
+            - button "Retry Lookups" [ref=e1341]
+          - generic [ref=e1343]:
+            - generic [ref=e1344]:
+              - generic [ref=e1345]:
+                - paragraph [ref=e1346]: Re-link Catalog Orphans
+                - generic [ref=e1347]: Moderate
+              - paragraph [ref=e1348]: Repairs SIMBAD cache and re-links unattached frames to existing targets by catalog identity (e.g. NGC 6543). Requires internet for cache repair.
+              - paragraph [ref=e1349]: Run once after upgrading. Safe to re-run. Frames that match no catalog object stay listed under their object name.
+            - button "Re-link Orphans" [ref=e1350]
+          - generic [ref=e1352]:
+            - generic [ref=e1353]:
+              - generic [ref=e1354]:
+                - paragraph [ref=e1355]: Full Rebuild
+                - generic [ref=e1356]: Destructive
+              - paragraph [ref=e1357]: Deletes all targets and re-resolves every image from scratch via SIMBAD. This is slow and rate-limited.
+              - paragraph [ref=e1358]: Only needed if the target catalog is fundamentally broken. All manual edits (notes, locked names) will be lost.
+            - button "Full Rebuild" [ref=e1359]
+  - status
+  - alert


### PR DESCRIPTION
**What's new**
*   New maintenance action to re-link orphaned catalog entries.

**What's fixed**
*   Target aliases now persist correctly after identity matches.
*   Corrupted SIMBAD cache entries for aliases are repaired.
*   Fixed a regression when renaming targets like NGC 6543.
*   Resolved errors when viewing merge history for pseudo-targets.

**What's changed**
*   Resolved names are no longer negative-cached, preventing lookup failures.
*   Duplicate targets are prevented when renaming existing catalog entries.