### PR TITLE
New Application Log Viewer, Merge Unresolved Groups, and Fixes

### DIFF
--- a/backend/alembic/versions/0009_app_logs.py
+++ b/backend/alembic/versions/0009_app_logs.py
@@ -1,0 +1,44 @@
+"""Add app_logs table for backend log capture.
+
+Raw Python backend logs (api / worker / beat) are buffered to Redis by a
+logging handler and drained into this table by a Celery beat task. DDL is
+defensive per CLAUDE.md: the table may already exist on installs that were
+bootstrapped via create_all then `alembic stamp head`, so creation is guarded.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0009"
+down_revision = "0008"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if "app_logs" in insp.get_table_names():
+        return
+    op.create_table(
+        "app_logs",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("timestamp", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("level", sa.String(length=10), nullable=False),
+        sa.Column("source", sa.String(length=16), nullable=False),
+        sa.Column("logger", sa.String(length=128), nullable=False),
+        sa.Column("message", sa.Text(), nullable=False),
+        sa.Column("traceback", sa.Text(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_app_logs_timestamp", "app_logs", ["timestamp"])
+    op.create_index("ix_app_logs_level_timestamp", "app_logs", ["level", "timestamp"])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if "app_logs" not in insp.get_table_names():
+        return
+    op.drop_index("ix_app_logs_level_timestamp", table_name="app_logs")
+    op.drop_index("ix_app_logs_timestamp", table_name="app_logs")
+    op.drop_table("app_logs")

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -32,6 +32,7 @@ from app.services.auth import (
 )
 from app.api.deps import get_current_user, require_admin
 from app.schemas.common import StatusResponse
+from app.services.activity import emit
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -139,6 +140,12 @@ async def login(
         if not valid or user is None or not user.is_active:
             await _increment_login_failures(redis, body.username, ip)
             audit_log("login", username=body.username, source_ip=ip, success=False, detail="Invalid credentials")
+            await emit(
+                session, category="user_action", severity="warning",
+                event_type="login_failed",
+                message=f"Failed login for '{body.username}'",
+                details={"username": body.username, "source_ip": ip},
+            )
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
 
         # Successful login - clear failure counter
@@ -248,6 +255,12 @@ async def change_password(
     await session.commit()
 
     audit_log("password_change", user_id=user.id, username=user.username, source_ip=ip, success=True)
+    await emit(
+        session, category="user_action", severity="info",
+        event_type="password_changed",
+        message=f"Password changed for '{user.username}'",
+        actor=user.username,
+    )
     return {"status": "ok"}
 
 
@@ -284,6 +297,11 @@ async def create_user(
     await session.refresh(new_user)
 
     audit_log("user_create", user_id=admin.id, username=admin.username, source_ip=ip, success=True, detail=f"Created user {body.username}")
+    await emit(
+        session, category="user_action", severity="info",
+        event_type="user_created",
+        message=f"User '{new_user.username}' created", actor=admin.username,
+    )
     return UserResponse.model_validate(new_user)
 
 
@@ -316,6 +334,12 @@ async def update_user(
     await session.refresh(target_user)
 
     audit_log("user_update", user_id=admin.id, username=admin.username, source_ip=ip, success=True, detail=f"Updated user {target_user.username}")
+    await emit(
+        session, category="user_action", severity="info",
+        event_type="user_updated",
+        message=f"User '{target_user.username}' updated", actor=admin.username,
+        details={"role": target_user.role.value, "is_active": target_user.is_active},
+    )
     return UserResponse.model_validate(target_user)
 
 
@@ -335,7 +359,13 @@ async def delete_user(
     if target_user is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
+    deleted_username = target_user.username
     await session.delete(target_user)
     await session.commit()
 
-    audit_log("user_delete", user_id=admin.id, username=admin.username, source_ip=ip, success=True, detail=f"Deleted user {target_user.username}")
+    audit_log("user_delete", user_id=admin.id, username=admin.username, source_ip=ip, success=True, detail=f"Deleted user {deleted_username}")
+    await emit(
+        session, category="user_action", severity="warning",
+        event_type="user_deleted",
+        message=f"User '{deleted_username}' deleted", actor=admin.username,
+    )

--- a/backend/app/api/logs.py
+++ b/backend/app/api/logs.py
@@ -15,6 +15,7 @@ from app.models.app_log import AppLog
 from app.models.user import User
 from app.schemas.app_log import AppLogItem, PaginatedAppLogResponse
 from app.schemas.common import StatusResponse
+from app.services.activity import emit
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/logs", tags=["logs"])
@@ -123,4 +124,11 @@ async def clear_logs(
 ):
     await session.execute(delete(AppLog))
     await session.commit()
+    # Audit trail: record who cleared the application logs.
+    await emit(
+        session, category="system", severity="warning",
+        event_type="app_logs_cleared",
+        message="Application logs cleared",
+        actor=user.username,
+    )
     return {"status": "cleared"}

--- a/backend/app/api/logs.py
+++ b/backend/app/api/logs.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import base64
+import logging
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import PlainTextResponse
+from sqlalchemy import delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import require_admin
+from app.database import get_session
+from app.models.app_log import AppLog
+from app.models.user import User
+from app.schemas.app_log import AppLogItem, PaginatedAppLogResponse
+from app.schemas.common import StatusResponse
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/logs", tags=["logs"])
+
+_VALID_LEVELS = {"debug", "info", "warning", "error", "critical"}
+_VALID_SOURCES = {"api", "worker", "beat"}
+_DOWNLOAD_CAP = 50000
+
+
+def _encode_cursor(ts: datetime, _id: int) -> str:
+    return base64.urlsafe_b64encode(f"{ts.isoformat()}|{_id}".encode()).decode()
+
+
+def _decode_cursor(cursor: str):
+    try:
+        raw = base64.urlsafe_b64decode(cursor.encode()).decode()
+        ts_str, id_str = raw.rsplit("|", 1)
+        return datetime.fromisoformat(ts_str), int(id_str)
+    except Exception:
+        return None
+
+
+def _apply_filters(q, level, source, qtext, since):
+    valid_lvl = [lv for lv in level if lv in _VALID_LEVELS]
+    if valid_lvl:
+        q = q.where(AppLog.level.in_(valid_lvl))
+    valid_src = [s for s in source if s in _VALID_SOURCES]
+    if valid_src:
+        q = q.where(AppLog.source.in_(valid_src))
+    if qtext:
+        q = q.where(AppLog.message.ilike(f"%{qtext}%"))
+    if since is not None:
+        q = q.where(AppLog.timestamp > since)
+    return q
+
+
+@router.get("", response_model=PaginatedAppLogResponse)
+async def list_logs(
+    level: list[str] = Query(default=[]),
+    source: list[str] = Query(default=[]),
+    q: str | None = Query(default=None),
+    since: datetime | None = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=200),
+    cursor: str | None = Query(default=None),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_admin),
+):
+    count_q = _apply_filters(select(func.count(AppLog.id)), level, source, q, since)
+    total = (await session.execute(count_q)).scalar_one()
+
+    items_q = _apply_filters(select(AppLog), level, source, q, since)
+    if cursor:
+        decoded = _decode_cursor(cursor)
+        if decoded:
+            cts, cid = decoded
+            items_q = items_q.where(
+                (AppLog.timestamp < cts) | ((AppLog.timestamp == cts) & (AppLog.id < cid))
+            )
+    items_q = items_q.order_by(AppLog.timestamp.desc(), AppLog.id.desc()).limit(limit)
+    rows = (await session.execute(items_q)).scalars().all()
+
+    next_cursor = None
+    if len(rows) == limit:
+        next_cursor = _encode_cursor(rows[-1].timestamp, rows[-1].id)
+
+    return PaginatedAppLogResponse(
+        items=[AppLogItem.model_validate(r) for r in rows],
+        next_cursor=next_cursor,
+        total=total,
+    )
+
+
+@router.get("/download")
+async def download_logs(
+    level: list[str] = Query(default=[]),
+    source: list[str] = Query(default=[]),
+    q: str | None = Query(default=None),
+    since: datetime | None = Query(default=None),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_admin),
+):
+    items_q = _apply_filters(select(AppLog), level, source, q, since)
+    items_q = items_q.order_by(AppLog.timestamp.desc(), AppLog.id.desc()).limit(_DOWNLOAD_CAP + 1)
+    rows = (await session.execute(items_q)).scalars().all()
+    truncated = len(rows) > _DOWNLOAD_CAP
+    rows = rows[:_DOWNLOAD_CAP]
+
+    lines = []
+    for r in reversed(rows):  # oldest first in the file
+        lines.append(f"{r.timestamp.isoformat()} [{r.level.upper()}] ({r.source}) {r.logger}: {r.message}")
+        if r.traceback:
+            lines.append(r.traceback)
+    if truncated:
+        lines.append(f"# NOTE: output truncated to newest {_DOWNLOAD_CAP} rows")
+    content = "\n".join(lines) + "\n"
+    return PlainTextResponse(
+        content,
+        headers={"Content-Disposition": "attachment; filename=galactilog-app.log"},
+    )
+
+
+@router.delete("", response_model=StatusResponse)
+async def clear_logs(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_admin),
+):
+    await session.execute(delete(AppLog))
+    await session.commit()
+    return {"status": "cleared"}

--- a/backend/app/api/merges.py
+++ b/backend/app/api/merges.py
@@ -567,7 +567,10 @@ async def revert_merge_candidate(
         remaining = await session.execute(
             select(func.count(Image.id)).where(Image.resolved_target_id == winner.id)
         )
-        if remaining.scalar_one() == 0:
+        # An empty winner is deleted only when it is a disposable creation from
+        # the orphan flow. A user-defined target the orphan was merged INTO must
+        # survive the revert even with zero images left.
+        if remaining.scalar_one() == 0 and not winner.user_defined:
             await session.delete(winner)
         candidate.suggested_target_id = None
         candidate.status = "pending"

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -24,6 +24,7 @@ from .planning import router as planning_router
 from .bootstrap import router as bootstrap_router
 from .preview import router as preview_router
 from .activity import router as activity_router
+from .logs import router as logs_router
 from .integrations import router as integrations_router
 from .wbpp import router as wbpp_router
 from app.database import async_session
@@ -53,6 +54,7 @@ api_router.include_router(planning_router)
 api_router.include_router(bootstrap_router)
 api_router.include_router(preview_router)
 api_router.include_router(activity_router)
+api_router.include_router(logs_router)
 api_router.include_router(integrations_router)
 api_router.include_router(wbpp_router)
 

--- a/backend/app/api/settings.py
+++ b/backend/app/api/settings.py
@@ -21,7 +21,9 @@ from app.schemas.settings import (
     DisplaySettings, default_display_settings,
     GraphSettings, default_graph_settings,
     ColumnVisibility,
+    ActivitySettingsResponse, ActivitySettingsUpdate,
 )
+from app.services.activity import emit
 
 router = APIRouter(prefix="/settings", tags=["settings"])
 
@@ -236,6 +238,80 @@ async def update_general(
             pass  # Worker may not be available in dev
 
     return _row_to_response(row)
+
+
+def _activity_settings_payload(general: dict) -> dict:
+    """Build the activity-settings response dict from a stored general dict."""
+    return {
+        "activity_retention_days": int(general.get("activity_retention_days", 90)),
+        "app_log_capture_level": general.get("app_log_capture_level", "warning"),
+        "app_log_retention_days": int(general.get("app_log_retention_days", 14)),
+        "app_log_max_rows": int(general.get("app_log_max_rows", 50000)),
+    }
+
+
+@router.get("/activity", response_model=ActivitySettingsResponse)
+async def get_activity_settings(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(get_current_user),
+):
+    """Return activity-event and application-log retention/capture settings."""
+    row = await _get_or_create_settings(session)
+    return _activity_settings_payload(row.general or {})
+
+
+@router.put("/activity", response_model=ActivitySettingsResponse)
+async def update_activity_settings(
+    payload: ActivitySettingsUpdate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(require_admin),
+):
+    """Update activity-event and application-log retention/capture settings.
+
+    Accepts the legacy ``retention_days`` key (activity retention) as well as
+    the explicit field names. On a capture-level change the Redis key is updated
+    so log handlers in every process pick it up without a DB read.
+    """
+    row = await _get_or_create_settings(session)
+    old_general = dict(row.general or {})
+
+    changed: dict = {}
+    # Activity retention: accept either key, prefer the explicit one.
+    if payload.activity_retention_days is not None:
+        changed["activity_retention_days"] = payload.activity_retention_days
+    elif payload.retention_days is not None:
+        changed["activity_retention_days"] = payload.retention_days
+    if payload.app_log_capture_level is not None:
+        changed["app_log_capture_level"] = payload.app_log_capture_level
+    if payload.app_log_retention_days is not None:
+        changed["app_log_retention_days"] = payload.app_log_retention_days
+    if payload.app_log_max_rows is not None:
+        changed["app_log_max_rows"] = payload.app_log_max_rows
+
+    row.general = {**old_general, **changed, "_migrated": True}
+    await session.commit()
+    await session.refresh(row)
+
+    # Mirror capture level so log handlers in all processes see it without a DB read.
+    if "app_log_capture_level" in changed:
+        try:
+            from app.services.log_capture import CAPTURE_LEVEL_KEY
+            async with async_redis() as r:
+                await r.set(CAPTURE_LEVEL_KEY, changed["app_log_capture_level"])
+        except Exception:
+            pass
+
+    # Emit a curated event listing the changed keys (no secrets here).
+    changed_keys = [k for k in changed if old_general.get(k) != changed[k]]
+    if changed_keys:
+        await emit(
+            session, category="user_action", severity="info",
+            event_type="settings_changed",
+            message=f"Activity settings updated: {', '.join(changed_keys)}",
+            details={"keys": changed_keys}, actor=user.username,
+        )
+
+    return _activity_settings_payload(row.general)
 
 
 @router.put("/filters", response_model=SettingsResponse)

--- a/backend/app/api/settings.py
+++ b/backend/app/api/settings.py
@@ -217,13 +217,24 @@ async def update_general(
     """Update general settings and return the full settings object."""
     row = await _get_or_create_settings(session)
     old_general = row.general or {}
+    new_values = payload.model_dump()
     row.general = {
         **old_general,
-        **payload.model_dump(),
+        **new_values,
         "_migrated": True,
     }
     await session.commit()
     await session.refresh(row)
+
+    # Emit a curated event listing which keys changed (no secrets in GeneralSettings).
+    changed_keys = [k for k, v in new_values.items() if old_general.get(k) != v]
+    if changed_keys:
+        await emit(
+            session, category="user_action", severity="info",
+            event_type="settings_changed",
+            message=f"Settings updated: {', '.join(changed_keys)}",
+            details={"keys": changed_keys}, actor=user.username,
+        )
 
     # Trigger session_date recompute if imaging night setting changed
     old_night = old_general.get("use_imaging_night", False)

--- a/backend/app/api/targets.py
+++ b/backend/app/api/targets.py
@@ -45,11 +45,19 @@ _SIMBAD_CATEGORY_MAP = SIMBAD_CATEGORY_MAP
 async def search_targets(
     q: str = Query(..., min_length=1),
     limit: int = Query(10, ge=1, le=50),
+    include_unresolved: bool = Query(False),
     session: AsyncSession = Depends(get_session),
     user: User = Depends(get_current_user),
 ):
-    """Search targets by name or alias with fuzzy trigram matching."""
-    return await target_aggregation.search_targets(q, limit, session)
+    """Search targets by name or alias with fuzzy trigram matching.
+
+    With include_unresolved=true, unlinked OBJECT-name groups matching the
+    query are appended as pseudo entries (unresolved=true) so merge flows can
+    offer them as merge sources.
+    """
+    return await target_aggregation.search_targets(
+        q, limit, session, include_unresolved=include_unresolved,
+    )
 
 
 # --- 2. Equipment (SECOND - before path-parameter routes) ---

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -33,6 +33,12 @@ async def lifespan(app: FastAPI):
             settings.jwt_secret_file,
         )
 
+    # Install the backend log capture handler (pushes to Redis, drained by Celery)
+    from app.services.log_capture import RedisLogHandler
+    root_logger = logging.getLogger()
+    if not any(isinstance(h, RedisLogHandler) for h in root_logger.handlers):
+        root_logger.addHandler(RedisLogHandler(source="api"))
+
     # Ensure required PostgreSQL extensions exist (idempotent)
     from sqlalchemy import text
     async with async_session() as session:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -192,6 +192,28 @@ def create_app() -> FastAPI:
             request.method,
             request.url.path,
         )
+        # Emit a curated api_error event on a fresh session so it commits
+        # independently of the request that failed. The full traceback is
+        # captured separately into app_logs by the root-logger handler above.
+        try:
+            from app.services.activity import emit
+            actor = None
+            user = getattr(request.state, "user", None)
+            if user is not None:
+                actor = getattr(user, "username", None)
+            async with async_session() as s:
+                await emit(
+                    s, category="system", severity="error", event_type="api_error",
+                    message=f"{request.method} {request.url.path} failed: {type(exc).__name__}",
+                    details={
+                        "method": request.method,
+                        "path": str(request.url.path),
+                        "exception": str(exc)[:500],
+                    },
+                    actor=actor,
+                )
+        except Exception:
+            logger.warning("Failed to emit api_error activity event", exc_info=True)
         return JSONResponse(
             status_code=500,
             content=ErrorEnvelope(detail="Internal server error").model_dump(),

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -34,10 +34,34 @@ async def lifespan(app: FastAPI):
         )
 
     # Install the backend log capture handler (pushes to Redis, drained by Celery)
-    from app.services.log_capture import RedisLogHandler
+    from app.services.log_capture import (
+        RedisLogHandler,
+        CAPTURE_LEVEL_KEY,
+        DEFAULT_LEVEL,
+    )
     root_logger = logging.getLogger()
     if not any(isinstance(h, RedisLogHandler) for h in root_logger.handlers):
         root_logger.addHandler(RedisLogHandler(source="api"))
+    # Lower the app logger so debug/info records reach the handler; the handler's
+    # runtime capture floor decides what is actually recorded. The default root
+    # level (WARNING) would otherwise drop debug/info at the call site, making the
+    # capture-level setting below WARNING ineffective.
+    logging.getLogger("app").setLevel(logging.DEBUG)
+    # Seed the capture-level Redis key from stored settings so the configured
+    # level survives Redis restarts and is visible to the worker/beat handlers
+    # (which only read it from Redis).
+    try:
+        from sqlalchemy import select
+        from app.models.user_settings import UserSettings, SETTINGS_ROW_ID
+        async with async_session() as session:
+            general = await session.scalar(
+                select(UserSettings.general).where(UserSettings.id == SETTINGS_ROW_ID)
+            )
+        level = (general or {}).get("app_log_capture_level", DEFAULT_LEVEL)
+        async with async_redis() as r:
+            await r.set(CAPTURE_LEVEL_KEY, level)
+    except Exception:
+        logger.warning("Failed to seed app_logs capture level from settings", exc_info=True)
 
     # Ensure required PostgreSQL extensions exist (idempotent)
     from sqlalchemy import text

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -27,5 +27,6 @@ from .arp_catalog import ArpEntry
 from .abell_catalog import AbellEntry
 from .catalog_membership import TargetCatalogMembership
 from .activity_event import ActivityEvent
+from .app_log import AppLog
 
-__all__ = ["Base", "Target", "Image", "UserSettings", "SETTINGS_ROW_ID", "MergeCandidate", "SimbadCache", "SesameCache", "User", "UserRole", "RefreshToken", "AppMetadata", "OpenNGCEntry", "VizierCache", "HyperLEDACache", "SiteDarkHours", "SessionNote", "Mosaic", "MosaicPanel", "MosaicSuggestion", "MosaicPanelSession", "CustomColumn", "CustomColumnValue", "ColumnType", "AppliesTo", "FilenameCandidate", "GaiaCache", "SACEntry", "CaldwellEntry", "Herschel400Entry", "ArpEntry", "AbellEntry", "TargetCatalogMembership", "ActivityEvent"]
+__all__ = ["Base", "Target", "Image", "UserSettings", "SETTINGS_ROW_ID", "MergeCandidate", "SimbadCache", "SesameCache", "User", "UserRole", "RefreshToken", "AppMetadata", "OpenNGCEntry", "VizierCache", "HyperLEDACache", "SiteDarkHours", "SessionNote", "Mosaic", "MosaicPanel", "MosaicSuggestion", "MosaicPanelSession", "CustomColumn", "CustomColumnValue", "ColumnType", "AppliesTo", "FilenameCandidate", "GaiaCache", "SACEntry", "CaldwellEntry", "Herschel400Entry", "ArpEntry", "AbellEntry", "TargetCatalogMembership", "ActivityEvent", "AppLog"]

--- a/backend/app/models/app_log.py
+++ b/backend/app/models/app_log.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import BigInteger, DateTime, Index, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import Base
+
+
+class AppLog(Base):
+    __tablename__ = "app_logs"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    timestamp: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+        index=True,
+    )
+    level: Mapped[str] = mapped_column(String(10), nullable=False)
+    source: Mapped[str] = mapped_column(String(16), nullable=False)
+    logger: Mapped[str] = mapped_column(String(128), nullable=False)
+    message: Mapped[str] = mapped_column(Text, nullable=False)
+    traceback: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    __table_args__ = (
+        Index("ix_app_logs_level_timestamp", "level", "timestamp"),
+    )

--- a/backend/app/schemas/app_log.py
+++ b/backend/app/schemas/app_log.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class AppLogItem(BaseModel):
+    id: int
+    timestamp: datetime
+    level: str
+    source: str
+    logger: str
+    message: str
+    traceback: str | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class PaginatedAppLogResponse(BaseModel):
+    items: list[AppLogItem]
+    next_cursor: str | None = None
+    total: int

--- a/backend/app/schemas/settings.py
+++ b/backend/app/schemas/settings.py
@@ -41,6 +41,23 @@ class GeneralSettings(BaseModel):
     )
 
 
+class ActivitySettingsResponse(BaseModel):
+    activity_retention_days: int
+    app_log_capture_level: str
+    app_log_retention_days: int
+    app_log_max_rows: int
+
+
+class ActivitySettingsUpdate(BaseModel):
+    # `retention_days` is the legacy key the frontend currently sends for the
+    # activity-event retention; `activity_retention_days` is accepted too.
+    retention_days: int | None = Field(default=None, ge=1, le=3650)
+    activity_retention_days: int | None = Field(default=None, ge=1, le=3650)
+    app_log_capture_level: str | None = Field(default=None, pattern="^(debug|info|warning|error)$")
+    app_log_retention_days: int | None = Field(default=None, ge=1, le=3650)
+    app_log_max_rows: int | None = Field(default=None, ge=1000, le=5000000)
+
+
 class FilterConfig(BaseModel):
     color: str = "#808080"
     aliases: list[str] = Field(default_factory=list)

--- a/backend/app/schemas/settings.py
+++ b/backend/app/schemas/settings.py
@@ -24,6 +24,9 @@ class GeneralSettings(BaseModel):
     preview_resolution: int = 2400  # 0 means native full resolution
     preview_cache_mb: int = 2048
     activity_retention_days: int = Field(default=90, ge=1, le=3650)
+    app_log_capture_level: str = Field(default="warning", pattern="^(debug|info|warning|error)$")
+    app_log_retention_days: int = Field(default=14, ge=1, le=3650)
+    app_log_max_rows: int = Field(default=50000, ge=1000, le=5000000)
     nina_instances: list[dict] = Field(default_factory=list)
     stellarium_instances: list[dict] = Field(default_factory=list)
     # WBPP export preferences

--- a/backend/app/schemas/target.py
+++ b/backend/app/schemas/target.py
@@ -286,12 +286,16 @@ class EquipmentResponse(BaseModel):
 
 
 class TargetSearchResultFuzzy(BaseModel):
-    id: uuid.UUID
+    # Real targets carry their UUID; unresolved OBJECT-name groups (no target
+    # row) carry the "obj:<name>" pseudo id used by the dashboard.
+    id: uuid.UUID | str
     primary_name: str
     object_type: str | None = None
     aliases: list[str] = []
     match_source: str | None = None
     similarity_score: float = 1.0
+    unresolved: bool = False
+    image_count: int | None = None
 
 
 class ObjectTypeCount(BaseModel):

--- a/backend/app/services/log_capture.py
+++ b/backend/app/services/log_capture.py
@@ -52,8 +52,15 @@ _FORMATTER = logging.Formatter()
 
 # Always excluded (noisy / recursion risk)
 _ALWAYS_EXCLUDE = {"uvicorn.access", __name__}
-# Excluded unless WARNING+
-_NOISY_PREFIXES = ("sqlalchemy.engine", "asyncio", "aiormq", "urllib3", "celery.utils")
+# Excluded unless WARNING+. Includes Celery's per-tick operational loggers
+# (beat scheduler, task trace, worker lifecycle): at an info/debug capture floor
+# the every-5s drain task would otherwise flood the log with "sending due task"
+# and "task succeeded" noise. WARNING+ from these (e.g. a task-failure traceback
+# from celery.app.trace) is still captured.
+_NOISY_PREFIXES = (
+    "sqlalchemy.engine", "asyncio", "aiormq", "urllib3",
+    "celery.utils", "celery.beat", "celery.app.trace", "celery.worker",
+)
 
 
 class RedisLogHandler(logging.Handler):

--- a/backend/app/services/log_capture.py
+++ b/backend/app/services/log_capture.py
@@ -1,0 +1,91 @@
+"""Backend log capture handler.
+
+A logging.Handler that serializes log records to JSON and pushes them onto a
+capped Redis list (app_logs:buffer). A Celery beat task drains the buffer into
+the app_logs table. This keeps the logging hot path off the DB connection pool
+and works identically across uvicorn, Celery worker, and beat processes.
+
+The effective capture floor is read at runtime from a Redis key
+(app_logs:capture_level), cached briefly so toggling the level on the Activity
+Log settings tab takes effect within a few seconds without a process restart.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import time
+from datetime import datetime, timezone
+
+from app.config import get_sync_redis
+
+BUFFER_KEY = "app_logs:buffer"
+CAPTURE_LEVEL_KEY = "app_logs:capture_level"
+BUFFER_MAX = 10000
+DEFAULT_LEVEL = "warning"
+
+LEVEL_ORDER = {"debug": 10, "info": 20, "warning": 30, "error": 40, "critical": 50}
+
+# logging.Handler has no formatException; that lives on Formatter. Use a shared
+# default formatter to render exc_info into a traceback string.
+_FORMATTER = logging.Formatter()
+
+# Always excluded (noisy / recursion risk)
+_ALWAYS_EXCLUDE = {"uvicorn.access", __name__}
+# Excluded unless WARNING+
+_NOISY_PREFIXES = ("sqlalchemy.engine", "asyncio", "aiormq", "urllib3", "celery.utils")
+
+
+class RedisLogHandler(logging.Handler):
+    def __init__(self, source: str, redis_factory=get_sync_redis, cache_ttl: float = 5.0):
+        super().__init__(level=logging.DEBUG)
+        self.source = source
+        self._redis_factory = redis_factory
+        self._redis = None
+        self._cache_ttl = cache_ttl
+        self._level_cache = (DEFAULT_LEVEL, 0.0)
+
+    def _redis_client(self):
+        if self._redis is None:
+            self._redis = self._redis_factory()
+        return self._redis
+
+    def _capture_floor(self) -> int:
+        value, ts = self._level_cache
+        if time.monotonic() - ts > self._cache_ttl:
+            try:
+                raw = self._redis_client().get(CAPTURE_LEVEL_KEY)
+                value = raw if raw in LEVEL_ORDER else DEFAULT_LEVEL
+            except Exception:
+                value = DEFAULT_LEVEL
+            self._level_cache = (value, time.monotonic())
+        return LEVEL_ORDER[value]
+
+    def _excluded(self, record: logging.LogRecord) -> bool:
+        if record.name in _ALWAYS_EXCLUDE:
+            return True
+        if record.levelno < logging.WARNING and record.name.startswith(_NOISY_PREFIXES):
+            return True
+        return False
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            if self._excluded(record):
+                return
+            level = record.levelname.lower()
+            if LEVEL_ORDER.get(level, 100) < self._capture_floor():
+                return
+            tb = _FORMATTER.formatException(record.exc_info) if record.exc_info else None
+            payload = json.dumps({
+                "timestamp": datetime.fromtimestamp(record.created, timezone.utc).isoformat(),
+                "level": level,
+                "source": self.source,
+                "logger": record.name,
+                "message": record.getMessage(),
+                "traceback": tb,
+            })
+            r = self._redis_client()
+            r.lpush(BUFFER_KEY, payload)
+            r.ltrim(BUFFER_KEY, 0, BUFFER_MAX - 1)
+        except Exception:
+            # Logging must never raise.
+            pass

--- a/backend/app/services/log_capture.py
+++ b/backend/app/services/log_capture.py
@@ -16,12 +16,33 @@ import logging
 import time
 from datetime import datetime, timezone
 
-from app.config import get_sync_redis
+import redis as sync_redis
+
+from app.config import settings
 
 BUFFER_KEY = "app_logs:buffer"
 CAPTURE_LEVEL_KEY = "app_logs:capture_level"
 BUFFER_MAX = 10000
 DEFAULT_LEVEL = "warning"
+
+# Short socket timeouts so a slow/down Redis cannot stall the request handling
+# (or worker) thread that emitted the log. The handler buffers logs as a
+# best-effort side channel; dropping a few records is preferable to blocking.
+_REDIS_SOCKET_TIMEOUT = 0.15
+
+
+def _default_redis_factory() -> sync_redis.Redis:
+    """Build a Redis client local to the log handler with short socket timeouts.
+
+    Intentionally separate from the shared get_sync_redis() so the aggressive
+    timeouts here do not affect other call sites.
+    """
+    return sync_redis.from_url(
+        settings.redis_url,
+        decode_responses=True,
+        socket_connect_timeout=_REDIS_SOCKET_TIMEOUT,
+        socket_timeout=_REDIS_SOCKET_TIMEOUT,
+    )
 
 LEVEL_ORDER = {"debug": 10, "info": 20, "warning": 30, "error": 40, "critical": 50}
 
@@ -36,7 +57,7 @@ _NOISY_PREFIXES = ("sqlalchemy.engine", "asyncio", "aiormq", "urllib3", "celery.
 
 
 class RedisLogHandler(logging.Handler):
-    def __init__(self, source: str, redis_factory=get_sync_redis, cache_ttl: float = 5.0):
+    def __init__(self, source: str, redis_factory=_default_redis_factory, cache_ttl: float = 5.0):
         super().__init__(level=logging.DEBUG)
         self.source = source
         self._redis_factory = redis_factory
@@ -56,6 +77,8 @@ class RedisLogHandler(logging.Handler):
                 raw = self._redis_client().get(CAPTURE_LEVEL_KEY)
                 value = raw if raw in LEVEL_ORDER else DEFAULT_LEVEL
             except Exception:
+                # Drop a possibly-broken client so the next call rebuilds it.
+                self._redis = None
                 value = DEFAULT_LEVEL
             self._level_cache = (value, time.monotonic())
         return LEVEL_ORDER[value]
@@ -87,5 +110,6 @@ class RedisLogHandler(logging.Handler):
             r.lpush(BUFFER_KEY, payload)
             r.ltrim(BUFFER_KEY, 0, BUFFER_MAX - 1)
         except Exception:
-            # Logging must never raise.
-            pass
+            # Logging must never raise. Drop a possibly-broken client so the
+            # next emit rebuilds it instead of staying broken until restart.
+            self._redis = None

--- a/backend/app/services/log_capture.py
+++ b/backend/app/services/log_capture.py
@@ -52,15 +52,14 @@ _FORMATTER = logging.Formatter()
 
 # Always excluded (noisy / recursion risk)
 _ALWAYS_EXCLUDE = {"uvicorn.access", __name__}
-# Excluded unless WARNING+. Includes Celery's per-tick operational loggers
-# (beat scheduler, task trace, worker lifecycle): at an info/debug capture floor
-# the every-5s drain task would otherwise flood the log with "sending due task"
-# and "task succeeded" noise. WARNING+ from these (e.g. a task-failure traceback
-# from celery.app.trace) is still captured.
-_NOISY_PREFIXES = (
-    "sqlalchemy.engine", "asyncio", "aiormq", "urllib3",
-    "celery.utils", "celery.beat", "celery.app.trace", "celery.worker",
-)
+# Excluded unless WARNING+.
+_NOISY_PREFIXES = ("sqlalchemy.engine", "asyncio", "aiormq", "urllib3", "celery.utils")
+
+# The drain task runs every 5s. Its own beat-scheduler and task-lifecycle log
+# lines would flood the log at an info/debug capture floor, so they are dropped
+# below WARNING. Matched by the task name appearing in the message; other task
+# activity (scans, thumbnails, enrichment) is kept so the log stays useful.
+_DRAIN_TASK_MARKER = "drain_app_logs"
 
 
 class RedisLogHandler(logging.Handler):
@@ -93,8 +92,14 @@ class RedisLogHandler(logging.Handler):
     def _excluded(self, record: logging.LogRecord) -> bool:
         if record.name in _ALWAYS_EXCLUDE:
             return True
-        if record.levelno < logging.WARNING and record.name.startswith(_NOISY_PREFIXES):
-            return True
+        if record.levelno < logging.WARNING:
+            if record.name.startswith(_NOISY_PREFIXES):
+                return True
+            try:
+                if _DRAIN_TASK_MARKER in record.getMessage():
+                    return True
+            except Exception:
+                pass
         return False
 
     def emit(self, record: logging.LogRecord) -> None:

--- a/backend/app/services/target_aggregation.py
+++ b/backend/app/services/target_aggregation.py
@@ -319,8 +319,15 @@ def compute_insights(
     return insights
 
 
-async def search_targets(q: str, limit: int, session: AsyncSession) -> list[TargetSearchResultFuzzy]:
-    """Search targets by name or alias with fuzzy trigram matching."""
+async def search_targets(
+    q: str, limit: int, session: AsyncSession, *, include_unresolved: bool = False,
+) -> list[TargetSearchResultFuzzy]:
+    """Search targets by name or alias with fuzzy trigram matching.
+
+    With include_unresolved, distinct unlinked OBJECT header names matching the
+    query are appended as "obj:<name>" pseudo entries so merge flows can offer
+    unresolved image groups as merge sources.
+    """
     escaped = q.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
     pattern = f"%{escaped}%"
 
@@ -442,6 +449,28 @@ async def search_targets(q: str, limit: int, session: AsyncSession) -> list[Targ
                 aliases=target.aliases or [],
                 match_source=best_alias,
                 similarity_score=float(score),
+            ))
+
+    if include_unresolved:
+        unresolved_rows = (await session.execute(
+            text("""
+                SELECT raw_headers->>'OBJECT' AS obj, COUNT(*) AS cnt
+                FROM images
+                WHERE resolved_target_id IS NULL
+                  AND raw_headers->>'OBJECT' IS NOT NULL
+                  AND raw_headers->>'OBJECT' != ''
+                  AND raw_headers->>'OBJECT' ILIKE :pattern
+                GROUP BY raw_headers->>'OBJECT'
+                ORDER BY cnt DESC
+                LIMIT :lim
+            """).bindparams(pattern=pattern, lim=limit)
+        )).all()
+        for obj_name, cnt in unresolved_rows:
+            results.append(TargetSearchResultFuzzy(
+                id=f"obj:{obj_name}",
+                primary_name=obj_name,
+                unresolved=True,
+                image_count=cnt,
             ))
 
     return results

--- a/backend/app/worker/celery_app.py
+++ b/backend/app/worker/celery_app.py
@@ -47,6 +47,14 @@ celery_app.conf.update(
 
 celery_app.autodiscover_tasks(["app.worker"])
 
+# autodiscover_tasks only imports each package's `tasks` module. Tasks defined in
+# sibling modules are only registered when those modules are imported, so import
+# them explicitly here -- otherwise beat dispatches them by name and the worker
+# rejects them as "unregistered task". celery_app is already bound above, so these
+# imports do not create a circular-import problem.
+from app.worker import prune_activity as _prune_activity  # noqa: E402,F401
+from app.worker import drain_logs as _drain_logs  # noqa: E402,F401
+
 from app.metrics import register_celery_signals
 register_celery_signals()
 
@@ -63,6 +71,12 @@ def _install_log_handler(source: str):
     root = logging.getLogger()
     if not any(isinstance(h, RedisLogHandler) for h in root.handlers):
         root.addHandler(RedisLogHandler(source=source))
+    # Lower the app logger so debug/info records reach the handler; the handler's
+    # runtime capture floor decides what is actually recorded. Without this, the
+    # default root level (WARNING) drops debug/info at the call site and the
+    # capture-level setting below WARNING would have no effect. Library loggers
+    # stay at root level, keeping their debug noise out.
+    logging.getLogger("app").setLevel(logging.DEBUG)
 
 
 @worker_process_init.connect

--- a/backend/app/worker/celery_app.py
+++ b/backend/app/worker/celery_app.py
@@ -38,6 +38,10 @@ celery_app.conf.update(
             "task": "app.worker.prune_activity.prune_activity_events",
             "schedule": crontab(hour=3, minute=0),
         },
+        "drain-app-logs": {
+            "task": "app.worker.drain_logs.drain_app_logs",
+            "schedule": 5.0,
+        },
     },
 )
 

--- a/backend/app/worker/celery_app.py
+++ b/backend/app/worker/celery_app.py
@@ -73,3 +73,50 @@ def _worker_log_handler(**_kwargs):
 @beat_init.connect
 def _beat_log_handler(**_kwargs):
     _install_log_handler("beat")
+
+
+# ---------------------------------------------------------------------------
+# Curated activity events for Celery task failures and retries.
+# ---------------------------------------------------------------------------
+from celery.signals import task_failure, task_retry
+
+
+def _emit_task_event(event_type, severity, task_name, task_id, exc):
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import Session
+    from app.config import settings, get_sync_redis
+    from app.services.activity import emit_sync
+    url = settings.database_url.replace("+asyncpg", "+psycopg2")
+    engine = create_engine(url, pool_pre_ping=True, pool_size=1, max_overflow=1)
+    redis = get_sync_redis()
+    verb = "failed" if event_type == "task_failure" else "retrying"
+    try:
+        with Session(engine) as s:
+            emit_sync(
+                s, redis=redis, category="system", severity=severity,
+                event_type=event_type,
+                message=f"Task {task_name} {verb}: {type(exc).__name__}",
+                details={"task": task_name, "task_id": str(task_id), "error": str(exc)[:500]},
+                actor="system",
+            )
+    except Exception:
+        pass
+    finally:
+        try:
+            redis.close()
+        except Exception:
+            pass
+        engine.dispose()
+
+
+@task_failure.connect
+def _on_task_failure(sender=None, task_id=None, exception=None, **_):
+    name = getattr(sender, "name", "unknown")
+    _emit_task_event("task_failure", "error", name, task_id, exception or Exception("unknown"))
+
+
+@task_retry.connect
+def _on_task_retry(sender=None, request=None, reason=None, **_):
+    name = getattr(sender, "name", "unknown")
+    tid = getattr(request, "id", None)
+    _emit_task_event("task_retry", "warning", name, tid, reason or Exception("retry"))

--- a/backend/app/worker/celery_app.py
+++ b/backend/app/worker/celery_app.py
@@ -45,3 +45,27 @@ celery_app.autodiscover_tasks(["app.worker"])
 
 from app.metrics import register_celery_signals
 register_celery_signals()
+
+
+# ---------------------------------------------------------------------------
+# Backend log capture: install RedisLogHandler in worker and beat processes.
+# ---------------------------------------------------------------------------
+from celery.signals import worker_process_init, beat_init
+
+
+def _install_log_handler(source: str):
+    import logging
+    from app.services.log_capture import RedisLogHandler
+    root = logging.getLogger()
+    if not any(isinstance(h, RedisLogHandler) for h in root.handlers):
+        root.addHandler(RedisLogHandler(source=source))
+
+
+@worker_process_init.connect
+def _worker_log_handler(**_kwargs):
+    _install_log_handler("worker")
+
+
+@beat_init.connect
+def _beat_log_handler(**_kwargs):
+    _install_log_handler("beat")

--- a/backend/app/worker/celery_app.py
+++ b/backend/app/worker/celery_app.py
@@ -80,18 +80,30 @@ def _beat_log_handler(**_kwargs):
 # ---------------------------------------------------------------------------
 from celery.signals import task_failure, task_retry
 
+# Lazily-built module-level sync engine, reused across task-failure/retry signals
+# (mirrors drain_logs.py / prune_activity.py) to avoid per-call FD churn during a
+# task-failure storm.
+_task_event_engine = None
+
+
+def _get_task_event_engine():
+    global _task_event_engine
+    if _task_event_engine is None:
+        from sqlalchemy import create_engine
+        from app.config import settings
+        url = settings.database_url.replace("+asyncpg", "+psycopg2")
+        _task_event_engine = create_engine(url, pool_pre_ping=True, pool_size=1, max_overflow=1, pool_recycle=1800)
+    return _task_event_engine
+
 
 def _emit_task_event(event_type, severity, task_name, task_id, exc):
-    from sqlalchemy import create_engine
     from sqlalchemy.orm import Session
-    from app.config import settings, get_sync_redis
+    from app.config import get_sync_redis
     from app.services.activity import emit_sync
-    url = settings.database_url.replace("+asyncpg", "+psycopg2")
-    engine = create_engine(url, pool_pre_ping=True, pool_size=1, max_overflow=1)
     redis = get_sync_redis()
     verb = "failed" if event_type == "task_failure" else "retrying"
     try:
-        with Session(engine) as s:
+        with Session(_get_task_event_engine()) as s:
             emit_sync(
                 s, redis=redis, category="system", severity=severity,
                 event_type=event_type,
@@ -106,7 +118,6 @@ def _emit_task_event(event_type, severity, task_name, task_id, exc):
             redis.close()
         except Exception:
             pass
-        engine.dispose()
 
 
 @task_failure.connect

--- a/backend/app/worker/drain_logs.py
+++ b/backend/app/worker/drain_logs.py
@@ -1,0 +1,87 @@
+"""Celery task: drain buffered log records from Redis into app_logs."""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from app.config import settings, get_sync_redis
+from app.models.app_log import AppLog
+from app.services.log_capture import BUFFER_KEY
+from app.worker.celery_app import celery_app
+
+logger = logging.getLogger(__name__)
+
+_sync_url = settings.database_url.replace("+asyncpg", "+psycopg2")
+_sync_engine = create_engine(_sync_url, pool_pre_ping=True, pool_size=2, max_overflow=2, pool_recycle=1800)
+
+_BATCH = 500
+_MAX_ITERATIONS = 40  # cap one run at ~20k rows
+
+
+def _drain_once(redis, batch: int = _BATCH) -> list[dict]:
+    """RPOP up to ``batch`` oldest entries, return parsed dicts (malformed skipped)."""
+    raw = redis.rpop(BUFFER_KEY, batch)
+    if raw is None:
+        return []
+    if isinstance(raw, (str, bytes)):
+        raw = [raw]
+    rows = []
+    for item in raw:
+        try:
+            rows.append(json.loads(item))
+        except (ValueError, TypeError):
+            continue
+    return rows
+
+
+def _parse_ts(value):
+    """Parse an ISO timestamp string; return None on failure so the DB default applies."""
+    if value is None:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except (ValueError, TypeError):
+        return None
+
+
+@celery_app.task(name="app.worker.drain_logs.drain_app_logs")
+def drain_app_logs() -> dict:
+    redis = get_sync_redis()
+    total = 0
+    try:
+        for _ in range(_MAX_ITERATIONS):
+            rows = _drain_once(redis, _BATCH)
+            if not rows:
+                break
+            mappings = []
+            for r in rows:
+                mapping = {
+                    "level": r.get("level", "info"),
+                    "source": r.get("source", "api"),
+                    "logger": (r.get("logger") or "")[:128],
+                    "message": r.get("message", ""),
+                    "traceback": r.get("traceback"),
+                }
+                ts = _parse_ts(r.get("timestamp"))
+                if ts is not None:
+                    mapping["timestamp"] = ts
+                mappings.append(mapping)
+            with Session(_sync_engine) as session:
+                session.bulk_insert_mappings(AppLog, mappings)
+                session.commit()
+            total += len(rows)
+            if len(rows) < _BATCH:
+                break
+        return {"status": "complete", "drained": total}
+    except Exception as exc:
+        logger.exception("drain_app_logs failed: %s", exc)
+        return {"status": "error", "error": str(exc)}
+    finally:
+        try:
+            redis.close()
+        except Exception:
+            pass

--- a/backend/app/worker/prune_activity.py
+++ b/backend/app/worker/prune_activity.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from app.config import settings, get_sync_redis
 from app.models.user_settings import UserSettings, SETTINGS_ROW_ID
+from app.models.app_log import AppLog  # noqa: F401  (registers the model / table)
 from app.services.activity import emit_sync
 from app.worker.celery_app import celery_app
 
@@ -16,6 +17,73 @@ _sync_url = settings.database_url.replace("+asyncpg", "+psycopg2")
 _sync_engine = create_engine(_sync_url, pool_pre_ping=True, pool_size=2, max_overflow=2, pool_recycle=1800)
 
 _DEFAULT_RETENTION_DAYS = 90
+_DEFAULT_APP_LOG_RETENTION_DAYS = 14
+_DEFAULT_APP_LOG_MAX_ROWS = 50000
+
+
+def _compute_app_log_deletes(total_rows: int, max_rows: int) -> dict:
+    """Return how many of the oldest rows to delete to honour the max-rows cap."""
+    excess = max(0, total_rows - max_rows)
+    return {"excess_rows": excess}
+
+
+def _prune_app_logs(redis) -> dict:
+    """Prune app_logs by retention days and a max-row cap (whichever hits first).
+
+    Runs independently of the activity-event prune so a failure here does not
+    block activity pruning. Emits a system activity event when rows are removed.
+    """
+    with Session(_sync_engine) as session:
+        row = session.execute(
+            select(UserSettings).where(UserSettings.id == SETTINGS_ROW_ID)
+        ).scalar_one_or_none()
+        general = (row.general or {}) if row else {}
+        al_days = max(1, min(3650, int(general.get("app_log_retention_days", _DEFAULT_APP_LOG_RETENTION_DAYS))))
+        al_max = max(1000, int(general.get("app_log_max_rows", _DEFAULT_APP_LOG_MAX_ROWS)))
+
+        by_age = session.execute(
+            text(f"DELETE FROM app_logs WHERE timestamp < now() - interval '{al_days} days'")
+        ).rowcount
+        session.commit()
+
+        total_rows = session.execute(text("SELECT count(*) FROM app_logs")).scalar() or 0
+        excess = _compute_app_log_deletes(total_rows, al_max)["excess_rows"]
+        by_count = 0
+        if excess > 0:
+            by_count = session.execute(
+                text(
+                    "DELETE FROM app_logs WHERE id IN ("
+                    "SELECT id FROM app_logs ORDER BY timestamp ASC, id ASC LIMIT :n)"
+                ),
+                {"n": excess},
+            ).rowcount
+            session.commit()
+
+    total_deleted = (by_age or 0) + (by_count or 0)
+    logger.info("prune app_logs: %d by age, %d by count", by_age or 0, by_count or 0)
+
+    if total_deleted > 0:
+        with Session(_sync_engine) as emit_session:
+            emit_sync(
+                emit_session,
+                redis=redis,
+                category="system",
+                severity="info",
+                event_type="app_logs_pruned",
+                message=(
+                    f"Application log pruned: {total_deleted} "
+                    f"entr{'ies' if total_deleted != 1 else 'y'} removed "
+                    f"({by_age or 0} by age, {by_count or 0} by row cap)"
+                ),
+                details={
+                    "deleted_by_age": by_age or 0,
+                    "deleted_by_count": by_count or 0,
+                    "retention_days": al_days,
+                    "max_rows": al_max,
+                },
+                actor="system",
+            )
+    return {"deleted_by_age": by_age or 0, "deleted_by_count": by_count or 0}
 
 
 @celery_app.task(name="app.worker.prune_activity.prune_activity_events")
@@ -68,7 +136,20 @@ def prune_activity_events() -> dict:
                     actor="system",
                 )
 
-        return {"status": "complete", "deleted": deleted, "retention_days": retention_days}
+        # Prune raw application logs independently so a failure here does not
+        # affect the activity-event prune result above.
+        app_log_result = {"deleted_by_age": 0, "deleted_by_count": 0}
+        try:
+            app_log_result = _prune_app_logs(redis)
+        except Exception as exc:
+            logger.exception("prune app_logs: failed - %s", exc)
+
+        return {
+            "status": "complete",
+            "deleted": deleted,
+            "retention_days": retention_days,
+            "app_logs": app_log_result,
+        }
 
     except Exception as exc:
         logger.exception("prune_activity_events: failed - %s", exc)

--- a/backend/tests/test_api_activity_settings.py
+++ b/backend/tests/test_api_activity_settings.py
@@ -1,0 +1,146 @@
+import os
+import sys
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+os.environ.setdefault("GALACTILOG_DATABASE_URL", "postgresql+asyncpg://test:test@localhost:5432/test_catalog")
+os.environ.setdefault("GALACTILOG_REDIS_URL", "redis://localhost:6379/1")
+os.environ.setdefault("GALACTILOG_JWT_SECRET", "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
+os.environ.setdefault("GALACTILOG_HTTPS", "false")
+for _mod in ("fitsio",):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+sys.modules.setdefault("app.worker.tasks", MagicMock())
+
+from app.main import app  # noqa: E402
+from app.database import get_session  # noqa: E402
+from app.api.deps import get_current_user, require_admin  # noqa: E402
+from app.models.user import User, UserRole  # noqa: E402
+from app.models.user_settings import SETTINGS_ROW_ID  # noqa: E402
+
+
+def _admin_user():
+    u = MagicMock(spec=User)
+    u.id = uuid.uuid4()
+    u.username = "admin"
+    u.role = UserRole.admin
+    u.is_active = True
+    return u
+
+
+def _settings_row(general=None):
+    row = MagicMock()
+    row.id = SETTINGS_ROW_ID
+    row.general = general if general is not None else {}
+    return row
+
+
+def _session_returning(row):
+    """AsyncMock session whose execute always returns a result with the row."""
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = row
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=result)
+    session.commit = AsyncMock()
+    session.refresh = AsyncMock()
+    session.flush = AsyncMock()
+    session.add = MagicMock()
+    return session
+
+
+@pytest.mark.asyncio
+async def test_get_activity_settings_defaults():
+    row = _settings_row({"_migrated": True})
+    session = _session_returning(row)
+
+    async def override():
+        yield session
+
+    app.dependency_overrides[get_session] = override
+    app.dependency_overrides[get_current_user] = lambda: _admin_user()
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.get("/api/settings/activity")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["activity_retention_days"] == 90
+    assert body["app_log_capture_level"] == "warning"
+    assert body["app_log_retention_days"] == 14
+    assert body["app_log_max_rows"] == 50000
+
+
+@pytest.mark.asyncio
+async def test_put_activity_settings_updates_and_returns_shape():
+    # Row mutates in place; the handler writes row.general then reads it back.
+    row = _settings_row({"_migrated": True})
+    session = _session_returning(row)
+
+    async def override():
+        yield session
+
+    app.dependency_overrides[get_session] = override
+    admin = _admin_user()
+    app.dependency_overrides[get_current_user] = lambda: admin
+    app.dependency_overrides[require_admin] = lambda: admin
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.put(
+                "/api/settings/activity",
+                json={"app_log_capture_level": "debug", "app_log_max_rows": 12000},
+            )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["app_log_capture_level"] == "debug"
+    assert body["app_log_max_rows"] == 12000
+
+
+@pytest.mark.asyncio
+async def test_put_activity_settings_rejects_bad_capture_level():
+    row = _settings_row({"_migrated": True})
+    session = _session_returning(row)
+
+    async def override():
+        yield session
+
+    app.dependency_overrides[get_session] = override
+    admin = _admin_user()
+    app.dependency_overrides[get_current_user] = lambda: admin
+    app.dependency_overrides[require_admin] = lambda: admin
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.put("/api/settings/activity", json={"app_log_capture_level": "bogus"})
+    finally:
+        app.dependency_overrides.clear()
+
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_put_activity_settings_legacy_retention_days():
+    row = _settings_row({"_migrated": True})
+    session = _session_returning(row)
+
+    async def override():
+        yield session
+
+    app.dependency_overrides[get_session] = override
+    admin = _admin_user()
+    app.dependency_overrides[get_current_user] = lambda: admin
+    app.dependency_overrides[require_admin] = lambda: admin
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.put("/api/settings/activity", json={"retention_days": 30})
+    finally:
+        app.dependency_overrides.clear()
+
+    assert resp.status_code == 200
+    assert resp.json()["activity_retention_days"] == 30

--- a/backend/tests/test_api_custom_targets.py
+++ b/backend/tests/test_api_custom_targets.py
@@ -302,3 +302,66 @@ async def test_orphan_create_integrity_error_maps_to_409(admin_user):
         mock_session.rollback.assert_awaited()
     finally:
         app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_revert_orphan_keeps_empty_user_defined_winner(admin_user):
+    """Reverting an orphan merge must never delete a user-defined winner.
+
+    Regression: reverting a Moon orphan merged into a custom Moon target
+    hard-deleted the custom target because it was left with zero images.
+    """
+    candidate = MagicMock(spec=MergeCandidate)
+    candidate.status = "accepted"
+    candidate.method = "orphan"
+    candidate.source_name = "Moon"
+    candidate.suggested_target_id = uuid.uuid4()
+
+    winner = MagicMock(spec=Target)
+    winner.id = candidate.suggested_target_id
+    winner.user_defined = True
+
+    mock_session = AsyncMock()
+    mock_session.get = AsyncMock(side_effect=[candidate, winner])
+    zero_images = MagicMock()
+    zero_images.scalar_one.return_value = 0
+    mock_session.execute = AsyncMock(return_value=zero_images)
+    _override_session(mock_session)
+    app.dependency_overrides[require_admin] = lambda: admin_user
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(f"/api/targets/merge-candidates/{uuid.uuid4()}/revert")
+        assert resp.status_code == 200, resp.text
+        mock_session.delete.assert_not_called()
+        assert candidate.status == "pending"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_revert_orphan_still_deletes_empty_created_winner(admin_user):
+    """The disposable orphan-created winner (not user-defined) is still removed."""
+    candidate = MagicMock(spec=MergeCandidate)
+    candidate.status = "accepted"
+    candidate.method = "orphan"
+    candidate.source_name = "PGC 99999"
+    candidate.suggested_target_id = uuid.uuid4()
+
+    winner = MagicMock(spec=Target)
+    winner.id = candidate.suggested_target_id
+    winner.user_defined = False
+
+    mock_session = AsyncMock()
+    mock_session.get = AsyncMock(side_effect=[candidate, winner])
+    zero_images = MagicMock()
+    zero_images.scalar_one.return_value = 0
+    mock_session.execute = AsyncMock(return_value=zero_images)
+    _override_session(mock_session)
+    app.dependency_overrides[require_admin] = lambda: admin_user
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(f"/api/targets/merge-candidates/{uuid.uuid4()}/revert")
+        assert resp.status_code == 200, resp.text
+        mock_session.delete.assert_called_once_with(winner)
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/test_app_logs_api.py
+++ b/backend/tests/test_app_logs_api.py
@@ -1,0 +1,203 @@
+import os
+import sys
+import uuid
+from datetime import datetime, timezone, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+os.environ.setdefault("GALACTILOG_DATABASE_URL", "postgresql+asyncpg://test:test@localhost:5432/test_catalog")
+os.environ.setdefault("GALACTILOG_REDIS_URL", "redis://localhost:6379/1")
+os.environ.setdefault("GALACTILOG_JWT_SECRET", "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
+os.environ.setdefault("GALACTILOG_HTTPS", "false")
+for _mod in ("fitsio",):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+sys.modules.setdefault("app.worker.tasks", MagicMock())
+
+from app.main import app  # noqa: E402
+from app.database import get_session  # noqa: E402
+from app.api.deps import require_admin  # noqa: E402
+from app.api.logs import _encode_cursor, _decode_cursor  # noqa: E402
+from app.models.user import User, UserRole  # noqa: E402
+
+
+def _admin():
+    u = MagicMock(spec=User)
+    u.id = uuid.uuid4()
+    u.username = "admin"
+    u.role = UserRole.admin
+    u.is_active = True
+    return u
+
+
+def _make_logs(n=5):
+    from app.models.app_log import AppLog
+    base = datetime(2026, 6, 11, tzinfo=timezone.utc)
+    rows = []
+    for i in range(n):
+        r = AppLog(
+            level="warning" if i % 2 else "error",
+            source="api",
+            logger="app.x",
+            message=f"msg{i}",
+            traceback="Traceback (most recent call last)..." if i == 0 else None,
+        )
+        r.id = n - i  # newest first => highest id first
+        r.timestamp = base - timedelta(minutes=i)
+        rows.append(r)
+    return rows
+
+
+def _list_session(rows, total):
+    """AsyncMock session: first execute -> count, second -> items scalars."""
+    count_result = MagicMock()
+    count_result.scalar_one.return_value = total
+    scalars_result = MagicMock()
+    scalars_result.all.return_value = rows
+    call = [0]
+
+    async def _execute(stmt, *a, **kw):
+        call[0] += 1
+        if call[0] == 1:
+            return count_result
+        r = MagicMock()
+        r.scalars.return_value = scalars_result
+        return r
+
+    session = AsyncMock()
+    session.execute = _execute
+    return session
+
+
+def _download_session(rows):
+    scalars_result = MagicMock()
+    scalars_result.all.return_value = rows
+
+    async def _execute(stmt, *a, **kw):
+        r = MagicMock()
+        r.scalars.return_value = scalars_result
+        return r
+
+    session = AsyncMock()
+    session.execute = _execute
+    return session
+
+
+@pytest.mark.asyncio
+async def test_list_logs_admin():
+    rows = _make_logs(5)
+    session = _list_session(rows, total=5)
+
+    async def override():
+        yield session
+
+    app.dependency_overrides[get_session] = override
+    app.dependency_overrides[require_admin] = lambda: _admin()
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.get("/api/logs?limit=10")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 5
+    assert len(body["items"]) == 5
+    assert body["items"][0]["message"] == "msg0"  # newest first
+    assert body["items"][0]["traceback"] is not None
+    assert body["next_cursor"] is None  # fewer rows than limit
+
+
+@pytest.mark.asyncio
+async def test_list_logs_next_cursor_when_full_page():
+    rows = _make_logs(2)
+    session = _list_session(rows, total=10)
+
+    async def override():
+        yield session
+
+    app.dependency_overrides[get_session] = override
+    app.dependency_overrides[require_admin] = lambda: _admin()
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.get("/api/logs?limit=2")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert resp.status_code == 200
+    assert resp.json()["next_cursor"] is not None
+
+
+@pytest.mark.asyncio
+async def test_clear_requires_admin():
+    from fastapi import HTTPException
+
+    async def _deny():
+        raise HTTPException(status_code=403, detail="Forbidden")
+
+    app.dependency_overrides[require_admin] = _deny
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.delete("/api/logs")
+    finally:
+        app.dependency_overrides.clear()
+    assert resp.status_code in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_clear_logs_admin():
+    session = AsyncMock()
+    session.execute = AsyncMock()
+    session.commit = AsyncMock()
+
+    async def override():
+        yield session
+
+    app.dependency_overrides[get_session] = override
+    app.dependency_overrides[require_admin] = lambda: _admin()
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.delete("/api/logs")
+    finally:
+        app.dependency_overrides.clear()
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "cleared"
+
+
+@pytest.mark.asyncio
+async def test_download_returns_text():
+    rows = _make_logs(5)
+    session = _download_session(rows)
+
+    async def override():
+        yield session
+
+    app.dependency_overrides[get_session] = override
+    app.dependency_overrides[require_admin] = lambda: _admin()
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.get("/api/logs/download")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/plain")
+    assert "msg0" in resp.text
+    assert "[ERROR]" in resp.text
+    assert resp.headers["content-disposition"].endswith("galactilog-app.log")
+
+
+def test_cursor_round_trip():
+    ts = datetime(2026, 6, 11, 12, 0, 0, tzinfo=timezone.utc)
+    cur = _encode_cursor(ts, 42)
+    decoded = _decode_cursor(cur)
+    assert decoded is not None
+    dts, did = decoded
+    assert did == 42
+    assert dts == ts
+
+
+def test_cursor_decode_garbage():
+    assert _decode_cursor("not-a-cursor!!!") is None

--- a/backend/tests/test_celery_task_registration.py
+++ b/backend/tests/test_celery_task_registration.py
@@ -1,0 +1,26 @@
+"""Regression test: every task referenced by beat_schedule must be registered.
+
+celery_app.autodiscover_tasks(["app.worker"]) only imports each package's
+`tasks` module. Tasks defined in sibling modules (prune_activity, drain_logs)
+are only registered if those modules are imported when the Celery app loads.
+If they are not, beat dispatches the task by name and the worker rejects it with
+"Received unregistered task of type ...", so the task never runs.
+"""
+from app.worker.celery_app import celery_app
+
+
+def test_sibling_module_beat_tasks_are_registered():
+    # These beat-scheduled tasks live in modules NOT named `tasks`, so
+    # autodiscover_tasks(["app.worker"]) never imports them. celery_app must
+    # import them explicitly, or beat dispatches the task by name and the worker
+    # rejects it as "unregistered task". Importing celery_app alone must register
+    # them. (auto_scan_tick lives in app.worker.tasks, which autodiscover imports
+    # at worker boot; it is excluded here because importing tasks.py pulls in the
+    # FITS stack, which is unavailable in the test environment.)
+    registered = set(celery_app.tasks.keys())
+    expected = {
+        "app.worker.prune_activity.prune_activity_events",
+        "app.worker.drain_logs.drain_app_logs",
+    }
+    missing = expected - registered
+    assert not missing, f"Sibling-module beat tasks not registered: {sorted(missing)}"

--- a/backend/tests/test_curated_events.py
+++ b/backend/tests/test_curated_events.py
@@ -1,0 +1,144 @@
+"""Tests for curated emit() points added for the application log feature.
+
+Covers the api_error 5xx handler (Task 9) and the Celery task_failure /
+task_retry signal emits (Task 12). Auth and settings emit points (Tasks 10-11)
+are exercised by their own API tests; here we assert the lower-level builders /
+handlers that can be tested in isolation without a live DB.
+"""
+import os
+import sys
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+os.environ.setdefault("GALACTILOG_DATABASE_URL", "postgresql+asyncpg://test:test@localhost:5432/test_catalog")
+os.environ.setdefault("GALACTILOG_REDIS_URL", "redis://localhost:6379/1")
+os.environ.setdefault("GALACTILOG_JWT_SECRET", "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
+os.environ.setdefault("GALACTILOG_HTTPS", "false")
+for _mod in ("fitsio",):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+sys.modules.setdefault("app.worker.tasks", MagicMock())
+
+
+# ---------------------------------------------------------------------------
+# Task 9: api_error on unhandled 5xx
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_5xx_handler_emits_api_error(monkeypatch):
+    from app.main import create_app
+
+    application = create_app()
+    handler = application.exception_handlers.get(Exception)
+    assert handler is not None
+
+    captured = {}
+
+    async def fake_emit(session, *, category, severity, event_type, message, **kw):
+        captured.update(
+            category=category, severity=severity, event_type=event_type,
+            message=message, details=kw.get("details"), actor=kw.get("actor"),
+        )
+        return 1
+
+    # Stub the fresh-session context manager and the emit helper.
+    @asynccontextmanager
+    async def fake_session():
+        yield AsyncMock()
+
+    monkeypatch.setattr("app.services.activity.emit", fake_emit)
+    monkeypatch.setattr("app.main.async_session", fake_session)
+
+    request = MagicMock()
+    request.method = "POST"
+    request.url.path = "/api/targets"
+    request.state.user = None  # no authenticated user
+
+    resp = await handler(request, ValueError("boom"))
+
+    assert resp.status_code == 500
+    assert captured["event_type"] == "api_error"
+    assert captured["category"] == "system"
+    assert captured["severity"] == "error"
+    assert "POST /api/targets failed: ValueError" in captured["message"]
+    assert captured["details"]["path"] == "/api/targets"
+    assert captured["details"]["method"] == "POST"
+
+
+@pytest.mark.asyncio
+async def test_5xx_handler_still_returns_500_when_emit_fails(monkeypatch):
+    from app.main import create_app
+
+    application = create_app()
+    handler = application.exception_handlers.get(Exception)
+
+    async def boom_emit(*a, **kw):
+        raise RuntimeError("db down")
+
+    @asynccontextmanager
+    async def fake_session():
+        yield AsyncMock()
+
+    monkeypatch.setattr("app.services.activity.emit", boom_emit)
+    monkeypatch.setattr("app.main.async_session", fake_session)
+
+    request = MagicMock()
+    request.method = "GET"
+    request.url.path = "/api/x"
+    request.state.user = None
+
+    resp = await handler(request, RuntimeError("kaboom"))
+    assert resp.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# Task 12: Celery task_failure / task_retry signal emits
+# ---------------------------------------------------------------------------
+
+def test_emit_task_event_writes_event(monkeypatch):
+    import app.worker.celery_app as cmod
+
+    captured = {}
+
+    def fake_emit_sync(session, *, redis, category, severity, event_type, message, **kw):
+        captured.update(
+            category=category, severity=severity, event_type=event_type,
+            message=message, details=kw.get("details"), actor=kw.get("actor"),
+        )
+        return 1
+
+    fake_engine = MagicMock()
+    monkeypatch.setattr("app.services.activity.emit_sync", fake_emit_sync)
+    monkeypatch.setattr("sqlalchemy.create_engine", lambda *a, **kw: fake_engine)
+    monkeypatch.setattr(cmod, "get_sync_redis", lambda: MagicMock(), raising=False)
+    # get_sync_redis is imported lazily inside the function from app.config
+    monkeypatch.setattr("app.config.get_sync_redis", lambda: MagicMock())
+
+    cmod._emit_task_event("task_failure", "error", "app.worker.tasks.ingest_file", "abc123", ValueError("boom"))
+
+    assert captured["event_type"] == "task_failure"
+    assert captured["severity"] == "error"
+    assert captured["category"] == "system"
+    assert captured["details"]["task"] == "app.worker.tasks.ingest_file"
+    assert captured["details"]["task_id"] == "abc123"
+
+
+def test_emit_task_event_retry(monkeypatch):
+    import app.worker.celery_app as cmod
+
+    captured = {}
+
+    def fake_emit_sync(session, *, redis, category, severity, event_type, message, **kw):
+        captured.update(event_type=event_type, severity=severity)
+        return 1
+
+    monkeypatch.setattr("app.services.activity.emit_sync", fake_emit_sync)
+    monkeypatch.setattr("sqlalchemy.create_engine", lambda *a, **kw: MagicMock())
+    monkeypatch.setattr("app.config.get_sync_redis", lambda: MagicMock())
+
+    cmod._emit_task_event("task_retry", "warning", "app.worker.tasks.x", "id1", Exception("retry"))
+
+    assert captured["event_type"] == "task_retry"
+    assert captured["severity"] == "warning"

--- a/backend/tests/test_curated_events.py
+++ b/backend/tests/test_curated_events.py
@@ -112,9 +112,10 @@ def test_emit_task_event_writes_event(monkeypatch):
     fake_engine = MagicMock()
     monkeypatch.setattr("app.services.activity.emit_sync", fake_emit_sync)
     monkeypatch.setattr("sqlalchemy.create_engine", lambda *a, **kw: fake_engine)
-    monkeypatch.setattr(cmod, "get_sync_redis", lambda: MagicMock(), raising=False)
     # get_sync_redis is imported lazily inside the function from app.config
     monkeypatch.setattr("app.config.get_sync_redis", lambda: MagicMock())
+    # Reset the lazily-built module-level engine so the patched create_engine runs.
+    monkeypatch.setattr(cmod, "_task_event_engine", None, raising=False)
 
     cmod._emit_task_event("task_failure", "error", "app.worker.tasks.ingest_file", "abc123", ValueError("boom"))
 
@@ -137,6 +138,7 @@ def test_emit_task_event_retry(monkeypatch):
     monkeypatch.setattr("app.services.activity.emit_sync", fake_emit_sync)
     monkeypatch.setattr("sqlalchemy.create_engine", lambda *a, **kw: MagicMock())
     monkeypatch.setattr("app.config.get_sync_redis", lambda: MagicMock())
+    monkeypatch.setattr(cmod, "_task_event_engine", None, raising=False)
 
     cmod._emit_task_event("task_retry", "warning", "app.worker.tasks.x", "id1", Exception("retry"))
 

--- a/backend/tests/test_drain_logs.py
+++ b/backend/tests/test_drain_logs.py
@@ -1,0 +1,62 @@
+import json
+import os
+import sys
+from unittest.mock import MagicMock
+
+os.environ.setdefault("GALACTILOG_DATABASE_URL", "postgresql+asyncpg://test:test@localhost:5432/test_catalog")
+os.environ.setdefault("GALACTILOG_REDIS_URL", "redis://localhost:6379/1")
+os.environ.setdefault("GALACTILOG_JWT_SECRET", "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
+os.environ.setdefault("GALACTILOG_HTTPS", "false")
+for _mod in ("fitsio",):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+sys.modules.setdefault("app.worker.tasks", MagicMock())
+
+from app.worker.drain_logs import _drain_once  # noqa: E402
+
+
+class FakeRedis:
+    def __init__(self, entries):
+        self.lists = {"app_logs:buffer": list(entries)}
+
+    def rpop(self, key, count=None):
+        lst = self.lists.get(key, [])
+        if not lst:
+            return None
+        if count is None:
+            return lst.pop()
+        out = []
+        for _ in range(min(count, len(lst))):
+            out.append(lst.pop())
+        return out
+
+
+def _entry(level="warning", msg="m"):
+    return json.dumps({
+        "timestamp": "2026-06-11T00:00:00+00:00",
+        "level": level, "source": "api", "logger": "app.x",
+        "message": msg, "traceback": None,
+    })
+
+
+def test_drain_once_returns_parsed_rows():
+    fake = FakeRedis([_entry(msg="a"), _entry(msg="b"), "not-json"])
+    rows = _drain_once(fake, batch=500)
+    # malformed entry skipped, two valid rows
+    assert len(rows) == 2
+    msgs = {r["message"] for r in rows}
+    assert msgs == {"a", "b"}
+
+
+def test_drain_once_empty():
+    fake = FakeRedis([])
+    assert _drain_once(fake, batch=500) == []
+
+
+def test_drain_task_in_beat_schedule():
+    from app.worker.celery_app import celery_app
+    schedule = celery_app.conf.beat_schedule
+    assert "drain-app-logs" in schedule
+    entry = schedule["drain-app-logs"]
+    assert entry["task"] == "app.worker.drain_logs.drain_app_logs"
+    assert entry["schedule"] == 5.0

--- a/backend/tests/test_log_capture.py
+++ b/backend/tests/test_log_capture.py
@@ -95,3 +95,39 @@ def test_handler_never_raises():
 
 def test_level_order_constant():
     assert LEVEL_ORDER["debug"] < LEVEL_ORDER["warning"] < LEVEL_ORDER["error"]
+
+
+def test_handler_self_heals_after_failure():
+    # First client raises on lpush; the handler should reset and rebuild on the
+    # next emit, succeeding with a healthy client.
+    healthy = FakeRedis()
+    healthy.kv["app_logs:capture_level"] = "warning"
+
+    class Flaky:
+        def get(self, key):
+            return "warning"
+
+        def lpush(self, *a):
+            raise RuntimeError("redis down")
+
+        def ltrim(self, *a):
+            pass
+
+    clients = [Flaky(), healthy]
+
+    def factory():
+        return clients.pop(0)
+
+    h = RedisLogHandler(source="api", redis_factory=factory)
+    h.emit(make_record(level=logging.WARNING, msg="first"))  # fails, resets client
+    assert h._redis is None
+    h.emit(make_record(level=logging.WARNING, msg="second"))  # rebuilds -> healthy
+    assert len(healthy.lists["app_logs:buffer"]) == 1
+
+
+def test_default_factory_uses_short_socket_timeouts():
+    from app.services.log_capture import _default_redis_factory, _REDIS_SOCKET_TIMEOUT
+    client = _default_redis_factory()
+    kwargs = client.connection_pool.connection_kwargs
+    assert kwargs.get("socket_connect_timeout") == _REDIS_SOCKET_TIMEOUT
+    assert kwargs.get("socket_timeout") == _REDIS_SOCKET_TIMEOUT

--- a/backend/tests/test_log_capture.py
+++ b/backend/tests/test_log_capture.py
@@ -1,0 +1,97 @@
+import json
+import logging
+import os
+import sys
+from unittest.mock import MagicMock
+
+os.environ.setdefault("GALACTILOG_DATABASE_URL", "postgresql+asyncpg://test:test@localhost:5432/test_catalog")
+os.environ.setdefault("GALACTILOG_REDIS_URL", "redis://localhost:6379/1")
+os.environ.setdefault("GALACTILOG_JWT_SECRET", "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
+os.environ.setdefault("GALACTILOG_HTTPS", "false")
+for _mod in ("fitsio",):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+sys.modules.setdefault("app.worker.tasks", MagicMock())
+
+from app.services.log_capture import RedisLogHandler, LEVEL_ORDER  # noqa: E402
+
+
+class FakeRedis:
+    def __init__(self):
+        self.lists = {}
+        self.kv = {}
+
+    def lpush(self, key, value):
+        self.lists.setdefault(key, []).insert(0, value)
+
+    def ltrim(self, key, start, end):
+        self.lists[key] = self.lists.get(key, [])[start:end + 1]
+
+    def get(self, key):
+        return self.kv.get(key)
+
+
+def make_record(name="app.test", level=logging.WARNING, msg="hello"):
+    return logging.LogRecord(name, level, "f.py", 1, msg, None, None)
+
+
+def test_handler_pushes_warning_when_floor_is_warning():
+    fake = FakeRedis()
+    fake.kv["app_logs:capture_level"] = "warning"
+    h = RedisLogHandler(source="api", redis_factory=lambda: fake)
+    h.emit(make_record(level=logging.WARNING, msg="warn!"))
+    assert len(fake.lists["app_logs:buffer"]) == 1
+    payload = json.loads(fake.lists["app_logs:buffer"][0])
+    assert payload["level"] == "warning"
+    assert payload["source"] == "api"
+    assert payload["logger"] == "app.test"
+    assert payload["message"] == "warn!"
+    assert payload["traceback"] is None
+
+
+def test_handler_drops_below_floor():
+    fake = FakeRedis()
+    fake.kv["app_logs:capture_level"] = "warning"
+    h = RedisLogHandler(source="api", redis_factory=lambda: fake)
+    h.emit(make_record(level=logging.INFO))
+    assert "app_logs:buffer" not in fake.lists
+
+
+def test_handler_excludes_uvicorn_access():
+    fake = FakeRedis()
+    fake.kv["app_logs:capture_level"] = "debug"
+    h = RedisLogHandler(source="api", redis_factory=lambda: fake)
+    h.emit(make_record(name="uvicorn.access", level=logging.INFO))
+    assert "app_logs:buffer" not in fake.lists
+
+
+def test_handler_captures_traceback():
+    fake = FakeRedis()
+    fake.kv["app_logs:capture_level"] = "error"
+    h = RedisLogHandler(source="worker", redis_factory=lambda: fake)
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        rec = logging.LogRecord("app.x", logging.ERROR, "f.py", 1, "failed", None, sys.exc_info())
+    h.emit(rec)
+    payload = json.loads(fake.lists["app_logs:buffer"][0])
+    assert "ValueError: boom" in payload["traceback"]
+
+
+def test_handler_never_raises():
+    class Broken:
+        def get(self, key):
+            return "warning"
+
+        def lpush(self, *a):
+            raise RuntimeError("redis down")
+
+        def ltrim(self, *a):
+            pass
+
+    h = RedisLogHandler(source="api", redis_factory=lambda: Broken())
+    h.emit(make_record())  # must not raise
+
+
+def test_level_order_constant():
+    assert LEVEL_ORDER["debug"] < LEVEL_ORDER["warning"] < LEVEL_ORDER["error"]

--- a/backend/tests/test_log_capture.py
+++ b/backend/tests/test_log_capture.py
@@ -57,6 +57,34 @@ def test_handler_drops_below_floor():
     assert "app_logs:buffer" not in fake.lists
 
 
+def test_handler_drops_drain_task_noise_below_warning():
+    fake = FakeRedis()
+    fake.kv["app_logs:capture_level"] = "debug"
+    h = RedisLogHandler(source="beat", redis_factory=lambda: fake)
+    # Beat scheduler / task-trace lines for the every-5s drain task are noise.
+    h.emit(make_record(
+        name="celery.beat", level=logging.INFO,
+        msg="Scheduler: Sending due task drain-app-logs (app.worker.drain_logs.drain_app_logs)",
+    ))
+    h.emit(make_record(
+        name="celery.app.trace", level=logging.INFO,
+        msg="Task app.worker.drain_logs.drain_app_logs[abc] succeeded in 0.004s",
+    ))
+    assert "app_logs:buffer" not in fake.lists
+
+
+def test_handler_keeps_other_celery_task_logs_at_debug():
+    fake = FakeRedis()
+    fake.kv["app_logs:capture_level"] = "debug"
+    h = RedisLogHandler(source="worker", redis_factory=lambda: fake)
+    # Real task activity (scans etc.) must still be captured at info/debug.
+    h.emit(make_record(
+        name="celery.app.trace", level=logging.INFO,
+        msg="Task app.worker.tasks.run_scan[xyz] succeeded in 8.7s",
+    ))
+    assert len(fake.lists["app_logs:buffer"]) == 1
+
+
 def test_handler_excludes_uvicorn_access():
     fake = FakeRedis()
     fake.kv["app_logs:capture_level"] = "debug"

--- a/backend/tests/test_log_prune.py
+++ b/backend/tests/test_log_prune.py
@@ -1,0 +1,25 @@
+import os
+import sys
+from unittest.mock import MagicMock
+
+os.environ.setdefault("GALACTILOG_DATABASE_URL", "postgresql+asyncpg://test:test@localhost:5432/test_catalog")
+os.environ.setdefault("GALACTILOG_REDIS_URL", "redis://localhost:6379/1")
+os.environ.setdefault("GALACTILOG_JWT_SECRET", "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
+os.environ.setdefault("GALACTILOG_HTTPS", "false")
+for _mod in ("fitsio",):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+sys.modules.setdefault("app.worker.tasks", MagicMock())
+
+from app.worker.prune_activity import _compute_app_log_deletes  # noqa: E402
+
+
+def test_keeps_within_limits():
+    # 100 rows, max_rows above count -> nothing deleted
+    plan = _compute_app_log_deletes(total_rows=100, max_rows=50000)
+    assert plan["excess_rows"] == 0
+
+
+def test_max_rows_excess():
+    plan = _compute_app_log_deletes(total_rows=60000, max_rows=50000)
+    assert plan["excess_rows"] == 10000

--- a/backend/tests/test_targets_aggregation.py
+++ b/backend/tests/test_targets_aggregation.py
@@ -476,3 +476,19 @@ async def test_null_session_date_does_not_inflate_normal_targets(seeded_db):
     # M31 has frames on two distinct dates, none NULL -> total_sessions == 2.
     assert m31["total_sessions"] == 2
     assert m31["matched_sessions"] <= m31["total_sessions"]
+
+
+@pytest.mark.asyncio
+async def test_search_includes_unresolved_groups(seeded_db):
+    """include_unresolved appends unlinked OBJECT-name groups as pseudo entries."""
+    plain = await _get("/search?q=NGC%207000")
+    assert all(not r.get("unresolved") for r in plain)
+
+    data = await _get("/search?q=NGC%207000&include_unresolved=true")
+    pseudo = [r for r in data if r.get("unresolved")]
+    assert len(pseudo) == 1
+    assert pseudo[0]["id"] == "obj:NGC 7000"
+    assert pseudo[0]["primary_name"] == "NGC 7000"
+    assert pseudo[0]["image_count"] == 1
+    # Frames without an OBJECT header never appear as a mergeable group.
+    assert all(r["id"] != "obj:__uncategorized__" for r in data)

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -66,6 +66,34 @@ export interface RestoreResponse {
   error: string | null;
 }
 
+export type AppLogLevel = "debug" | "info" | "warning" | "error" | "critical";
+export type AppLogSource = "api" | "worker" | "beat";
+
+export interface AppLogItem {
+  id: number;
+  timestamp: string;
+  level: AppLogLevel;
+  source: AppLogSource;
+  logger: string;
+  message: string;
+  traceback: string | null;
+}
+
+export interface AppLogPageResponse {
+  items: AppLogItem[];
+  next_cursor: string | null;
+  total: number;
+}
+
+export interface LogQueryParams {
+  level?: AppLogLevel | AppLogLevel[];
+  source?: AppLogSource | AppLogSource[];
+  q?: string;
+  since?: string;
+  limit?: number;
+  cursor?: string;
+}
+
 export class ApiError extends Error {
   constructor(public status: number, message: string) {
     super(message);
@@ -344,11 +372,70 @@ export const api = {
   clearActivityLog: () =>
     fetchJson<{ status: string }>("/activity", { method: "DELETE" }),
 
-  getActivitySettings: () =>
-    fetchJson<{ activity_retention_days: number }>("/settings/activity"),
+  fetchLogs: (params: LogQueryParams = {}) => {
+    const qs = new URLSearchParams();
+    const levels = Array.isArray(params.level)
+      ? params.level
+      : params.level
+      ? [params.level]
+      : [];
+    levels.forEach((l) => qs.append("level", l));
+    const sources = Array.isArray(params.source)
+      ? params.source
+      : params.source
+      ? [params.source]
+      : [];
+    sources.forEach((s) => qs.append("source", s));
+    if (params.q) qs.set("q", params.q);
+    if (params.since) qs.set("since", params.since);
+    if (params.limit !== undefined) qs.set("limit", String(params.limit));
+    if (params.cursor) qs.set("cursor", params.cursor);
+    const q = qs.toString();
+    return fetchJson<AppLogPageResponse>(`/logs${q ? `?${q}` : ""}`);
+  },
 
-  setActivitySettings: (body: { retention_days: number }) =>
-    fetchJson<{ activity_retention_days: number }>("/settings/activity", {
+  clearLogs: () =>
+    fetchJson<{ status: string }>("/logs", { method: "DELETE" }),
+
+  logsDownloadUrl: (params: LogQueryParams = {}) => {
+    const qs = new URLSearchParams();
+    const levels = Array.isArray(params.level)
+      ? params.level
+      : params.level
+      ? [params.level]
+      : [];
+    levels.forEach((l) => qs.append("level", l));
+    const sources = Array.isArray(params.source)
+      ? params.source
+      : params.source
+      ? [params.source]
+      : [];
+    sources.forEach((s) => qs.append("source", s));
+    if (params.q) qs.set("q", params.q);
+    const q = qs.toString();
+    return `${API_BASE}/logs/download${q ? `?${q}` : ""}`;
+  },
+
+  getActivitySettings: () =>
+    fetchJson<{
+      activity_retention_days: number;
+      app_log_capture_level: AppLogLevel;
+      app_log_retention_days: number;
+      app_log_max_rows: number;
+    }>("/settings/activity"),
+
+  setActivitySettings: (body: {
+    retention_days?: number;
+    app_log_capture_level?: AppLogLevel;
+    app_log_retention_days?: number;
+    app_log_max_rows?: number;
+  }) =>
+    fetchJson<{
+      activity_retention_days: number;
+      app_log_capture_level: AppLogLevel;
+      app_log_retention_days: number;
+      app_log_max_rows: number;
+    }>("/settings/activity", {
       method: "PUT",
       body: JSON.stringify(body),
     }),

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -276,8 +276,10 @@ export const api = {
   getFitsKeys: () =>
     fetchJson<string[]>("/targets/fits-keys"),
 
-  searchTargets: (query: string) =>
-    fetchJson<TargetSearchResultFuzzy[]>(`/targets/search?q=${encodeURIComponent(query)}`),
+  searchTargets: (query: string, includeUnresolved = false) =>
+    fetchJson<TargetSearchResultFuzzy[]>(
+      `/targets/search?q=${encodeURIComponent(query)}${includeUnresolved ? "&include_unresolved=true" : ""}`,
+    ),
 
   getStats: () =>
     fetchJson<StatsResponse>("/stats"),

--- a/frontend/src/components/ScanManager.tsx
+++ b/frontend/src/components/ScanManager.tsx
@@ -178,7 +178,7 @@ const ScanManager: Component = () => {
         {(data) => <CaptureActivity history={data().ingest_history} />}
       </Show>
 
-      <div class="grid grid-cols-1 lg:grid-cols-[minmax(0,3fr)_minmax(0,2fr)] gap-4 items-start">
+      <div class="grid grid-cols-1 lg:grid-cols-[minmax(0,3fr)_minmax(0,2fr)] gap-4 items-stretch">
         {/* Left column: controls */}
         <div class="space-y-4 min-w-0">
           <ScanFiltersOnboarding
@@ -377,9 +377,9 @@ const ScanManager: Component = () => {
           </Show>
         </div>
 
-        {/* Right column: sticky activity feed */}
-        <div class="lg:sticky lg:top-4 lg:self-start min-w-0">
-          <div class="lg:max-h-[calc(100vh-2rem)] lg:overflow-hidden lg:flex lg:flex-col">
+        {/* Right column: activity feed matches left column height */}
+        <div class="relative min-w-0 min-h-[24rem] lg:min-h-0">
+          <div class="lg:absolute lg:inset-0 lg:flex lg:flex-col">
             <ActivityFeed />
           </div>
         </div>

--- a/frontend/src/components/settings/ActivityLogTab.tsx
+++ b/frontend/src/components/settings/ActivityLogTab.tsx
@@ -1,128 +1,567 @@
-import { Component, createSignal, onMount, Show } from "solid-js";
-import { api } from "../../api/client";
+import {
+  Component,
+  For,
+  Show,
+  batch,
+  createEffect,
+  createSignal,
+  onCleanup,
+  onMount,
+} from "solid-js";
+import {
+  api,
+  type AppLogItem,
+  type AppLogLevel,
+  type AppLogSource,
+  type LogQueryParams,
+} from "../../api/client";
 import { useAuth } from "../AuthProvider";
 import { showToast } from "../Toast";
 
+const LEVELS: AppLogLevel[] = ["debug", "info", "warning", "error", "critical"];
+const CAPTURE_LEVELS: AppLogLevel[] = ["debug", "info", "warning", "error"];
+const SOURCES: ("all" | AppLogSource)[] = ["all", "api", "worker", "beat"];
+
+const FilterPill: Component<{
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}> = (props) => (
+  <button
+    onClick={props.onClick}
+    class={`px-2 py-0.5 text-xs rounded-full border transition-colors ${
+      props.active
+        ? "bg-[var(--color-accent)]/20 text-[var(--color-accent)] border-[var(--color-accent)]/40"
+        : "border-theme-border text-theme-text-secondary hover:text-theme-text-primary hover:border-theme-border-em"
+    }`}
+  >
+    {props.label}
+  </button>
+);
+
+const LevelBadge: Component<{ level: AppLogLevel }> = (props) => {
+  const cls = () => {
+    switch (props.level) {
+      case "error":
+      case "critical":
+        return "text-theme-error";
+      case "warning":
+        return "text-theme-warning";
+      default:
+        return "text-theme-text-secondary";
+    }
+  };
+  return (
+    <span class={`flex-shrink-0 w-[4rem] uppercase ${cls()}`}>{props.level}</span>
+  );
+};
+
 const ActivityLogTab: Component = () => {
   const { isAdmin } = useAuth();
+
+  // Settings strip state
   const [retentionDays, setRetentionDays] = createSignal(90);
-  const [saving, setSaving] = createSignal(false);
-  const [clearing, setClearing] = createSignal(false);
-  const [showClearConfirm, setShowClearConfirm] = createSignal(false);
-  const [loading, setLoading] = createSignal(true);
+  const [captureLevel, setCaptureLevel] = createSignal<AppLogLevel>("warning");
+  const [logRetentionDays, setLogRetentionDays] = createSignal(14);
+  const [logMaxRows, setLogMaxRows] = createSignal(50000);
+  const [savingSettings, setSavingSettings] = createSignal(false);
+  const [settingsLoaded, setSettingsLoaded] = createSignal(false);
+
+  // Clear confirmations
+  const [clearingActivity, setClearingActivity] = createSignal(false);
+  const [showClearActivityConfirm, setShowClearActivityConfirm] =
+    createSignal(false);
+  const [clearingLogs, setClearingLogs] = createSignal(false);
+  const [showClearLogsConfirm, setShowClearLogsConfirm] = createSignal(false);
+
+  // Log viewer state
+  const [levels, setLevels] = createSignal<AppLogLevel[]>([]);
+  const [source, setSource] = createSignal<"all" | AppLogSource>("all");
+  const [searchInput, setSearchInput] = createSignal("");
+  const [search, setSearch] = createSignal("");
+  const [logs, setLogs] = createSignal<AppLogItem[]>([]);
+  const [nextCursor, setNextCursor] = createSignal<string | null>(null);
+  const [total, setTotal] = createSignal(0);
+  const [loadingLogs, setLoadingLogs] = createSignal(false);
+  const [loadingMore, setLoadingMore] = createSignal(false);
+  const [expanded, setExpanded] = createSignal<Set<number>>(new Set());
+  const [liveTail, setLiveTail] = createSignal(false);
 
   onMount(async () => {
     try {
       const s = await api.getActivitySettings();
-      setRetentionDays(s.activity_retention_days);
-    } catch { /* ignore */ } finally {
-      setLoading(false);
+      batch(() => {
+        setRetentionDays(s.activity_retention_days);
+        setCaptureLevel(s.app_log_capture_level);
+        setLogRetentionDays(s.app_log_retention_days);
+        setLogMaxRows(s.app_log_max_rows);
+      });
+    } catch {
+      /* ignore */
+    } finally {
+      setSettingsLoaded(true);
     }
   });
 
-  const handleSave = async () => {
-    if (saving()) return;
-    setSaving(true);
+  // Debounce the search input into `search` (~300ms)
+  createEffect(() => {
+    const value = searchInput();
+    const handle = setTimeout(() => setSearch(value), 300);
+    onCleanup(() => clearTimeout(handle));
+  });
+
+  const buildParams = (extra: Partial<LogQueryParams> = {}): LogQueryParams => {
+    const p: LogQueryParams = { limit: 50, ...extra };
+    if (levels().length) p.level = levels();
+    if (source() !== "all") p.source = source() as AppLogSource;
+    if (search().trim()) p.q = search().trim();
+    return p;
+  };
+
+  const loadInitial = async () => {
+    setLoadingLogs(true);
     try {
-      const res = await api.setActivitySettings({ retention_days: retentionDays() });
-      setRetentionDays(res.activity_retention_days);
-      showToast("Retention setting saved", "success", 3000);
+      const res = await api.fetchLogs(buildParams());
+      batch(() => {
+        setLogs(res.items);
+        setNextCursor(res.next_cursor);
+        setTotal(res.total);
+      });
     } catch {
-      showToast("Failed to save retention setting", "error", 0);
+      /* non-blocking */
     } finally {
-      setSaving(false);
+      setLoadingLogs(false);
     }
   };
 
-  const handleClear = async () => {
-    if (clearing()) return;
-    setShowClearConfirm(false);
-    setClearing(true);
+  const loadMore = async () => {
+    const cur = nextCursor();
+    if (!cur || loadingMore()) return;
+    setLoadingMore(true);
+    try {
+      const res = await api.fetchLogs(buildParams({ cursor: cur }));
+      batch(() => {
+        setLogs((prev) => [...prev, ...res.items]);
+        setNextCursor(res.next_cursor);
+      });
+    } catch {
+      /* ignore */
+    } finally {
+      setLoadingMore(false);
+    }
+  };
+
+  // Reload when filters change
+  createEffect(() => {
+    levels();
+    source();
+    search();
+    loadInitial();
+  });
+
+  // Live tail: poll for rows newer than the newest loaded
+  let timer: ReturnType<typeof setInterval> | undefined;
+  createEffect(() => {
+    if (timer) {
+      clearInterval(timer);
+      timer = undefined;
+    }
+    if (liveTail()) {
+      timer = setInterval(async () => {
+        const newest = logs()[0]?.timestamp;
+        if (!newest) {
+          await loadInitial();
+          return;
+        }
+        try {
+          const res = await api.fetchLogs(buildParams({ since: newest, limit: 100 }));
+          if (res.items.length) {
+            batch(() => {
+              setLogs((prev) => [...res.items, ...prev]);
+              setTotal(res.total);
+            });
+          }
+        } catch {
+          /* ignore */
+        }
+      }, 5000);
+    }
+  });
+  onCleanup(() => {
+    if (timer) clearInterval(timer);
+  });
+
+  const toggleLevel = (level: AppLogLevel) => {
+    setLevels((prev) =>
+      prev.includes(level)
+        ? prev.filter((l) => l !== level)
+        : [...prev, level],
+    );
+  };
+
+  const toggleExpanded = (id: number) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const handleCaptureLevelChange = async (level: AppLogLevel) => {
+    if (!isAdmin()) return;
+    const previous = captureLevel();
+    setCaptureLevel(level);
+    try {
+      const res = await api.setActivitySettings({ app_log_capture_level: level });
+      setCaptureLevel(res.app_log_capture_level);
+      showToast(`Capture level set to ${level}`, "success", 3000);
+    } catch {
+      setCaptureLevel(previous);
+      showToast("Failed to update capture level", "error", 0);
+    }
+  };
+
+  const handleSaveSettings = async () => {
+    if (savingSettings() || !isAdmin()) return;
+    setSavingSettings(true);
+    try {
+      const res = await api.setActivitySettings({
+        retention_days: retentionDays(),
+        app_log_retention_days: logRetentionDays(),
+        app_log_max_rows: logMaxRows(),
+      });
+      batch(() => {
+        setRetentionDays(res.activity_retention_days);
+        setLogRetentionDays(res.app_log_retention_days);
+        setLogMaxRows(res.app_log_max_rows);
+      });
+      showToast("Retention settings saved", "success", 3000);
+    } catch {
+      showToast("Failed to save retention settings", "error", 0);
+    } finally {
+      setSavingSettings(false);
+    }
+  };
+
+  const handleClearActivity = async () => {
+    if (clearingActivity()) return;
+    setShowClearActivityConfirm(false);
+    setClearingActivity(true);
     try {
       await api.clearActivityLog();
       showToast("Activity log cleared", "success", 3000);
     } catch {
       showToast("Failed to clear activity log", "error", 0);
     } finally {
-      setClearing(false);
+      setClearingActivity(false);
+    }
+  };
+
+  const handleClearLogs = async () => {
+    if (clearingLogs()) return;
+    setShowClearLogsConfirm(false);
+    setClearingLogs(true);
+    try {
+      await api.clearLogs();
+      batch(() => {
+        setLogs([]);
+        setNextCursor(null);
+        setTotal(0);
+      });
+      showToast("Application logs cleared", "success", 3000);
+    } catch {
+      showToast("Failed to clear application logs", "error", 0);
+    } finally {
+      setClearingLogs(false);
     }
   };
 
   return (
     <div class="space-y-4">
+      {/* Settings strip */}
       <div class="bg-theme-surface border border-theme-border rounded-[var(--radius-md)] shadow-[var(--shadow-sm)] p-4 space-y-4">
-        <h3 class="text-theme-text-primary font-medium">Activity Log</h3>
+        <h3 class="text-theme-text-primary font-medium">Application Log</h3>
 
-        <Show when={loading()}>
+        <Show when={settingsLoaded()} fallback={
           <p class="text-xs text-theme-text-secondary">Loading...</p>
-        </Show>
-
-        <Show when={!loading()}>
+        }>
           <div class="space-y-3">
-            <div class="flex items-center gap-3">
-              <label class="text-sm text-theme-text-secondary w-40 flex-shrink-0">
-                Retention (days)
-              </label>
-              <input
-                type="number"
-                min={1}
-                max={3650}
-                value={retentionDays()}
-                onInput={(e) => {
-                  const v = parseInt(e.currentTarget.value, 10);
-                  if (!isNaN(v) && v >= 1 && v <= 3650) setRetentionDays(v);
-                }}
-                class="w-24 px-2 py-1 text-sm bg-theme-base border border-theme-border rounded text-theme-text-primary focus:outline-none focus:border-theme-accent tabular-nums"
-              />
+            <div class="flex flex-wrap items-end gap-4">
+              <div class="space-y-1">
+                <label class="block text-xs text-theme-text-secondary">
+                  Capture level
+                </label>
+                <select
+                  value={captureLevel()}
+                  disabled={!isAdmin()}
+                  onChange={(e) =>
+                    handleCaptureLevelChange(e.currentTarget.value as AppLogLevel)
+                  }
+                  class="px-2 py-1 text-sm bg-theme-base border border-theme-border rounded text-theme-text-primary focus:outline-none focus:border-theme-accent disabled:opacity-50"
+                >
+                  <For each={CAPTURE_LEVELS}>
+                    {(lvl) => <option value={lvl}>{lvl}</option>}
+                  </For>
+                </select>
+              </div>
+
+              <div class="space-y-1">
+                <label class="block text-xs text-theme-text-secondary">
+                  Activity retention (days)
+                </label>
+                <input
+                  type="number"
+                  min={1}
+                  max={3650}
+                  value={retentionDays()}
+                  disabled={!isAdmin()}
+                  onInput={(e) => {
+                    const v = parseInt(e.currentTarget.value, 10);
+                    if (!isNaN(v) && v >= 1 && v <= 3650) setRetentionDays(v);
+                  }}
+                  class="w-24 px-2 py-1 text-sm bg-theme-base border border-theme-border rounded text-theme-text-primary focus:outline-none focus:border-theme-accent tabular-nums disabled:opacity-50"
+                />
+              </div>
+
+              <div class="space-y-1">
+                <label class="block text-xs text-theme-text-secondary">
+                  Log retention (days)
+                </label>
+                <input
+                  type="number"
+                  min={1}
+                  max={3650}
+                  value={logRetentionDays()}
+                  disabled={!isAdmin()}
+                  onInput={(e) => {
+                    const v = parseInt(e.currentTarget.value, 10);
+                    if (!isNaN(v) && v >= 1 && v <= 3650) setLogRetentionDays(v);
+                  }}
+                  class="w-24 px-2 py-1 text-sm bg-theme-base border border-theme-border rounded text-theme-text-primary focus:outline-none focus:border-theme-accent tabular-nums disabled:opacity-50"
+                />
+              </div>
+
+              <div class="space-y-1">
+                <label class="block text-xs text-theme-text-secondary">
+                  Log max rows
+                </label>
+                <input
+                  type="number"
+                  min={1000}
+                  step={1000}
+                  value={logMaxRows()}
+                  disabled={!isAdmin()}
+                  onInput={(e) => {
+                    const v = parseInt(e.currentTarget.value, 10);
+                    if (!isNaN(v) && v >= 1000) setLogMaxRows(v);
+                  }}
+                  class="w-28 px-2 py-1 text-sm bg-theme-base border border-theme-border rounded text-theme-text-primary focus:outline-none focus:border-theme-accent tabular-nums disabled:opacity-50"
+                />
+              </div>
+
               <button
-                onClick={handleSave}
-                disabled={saving() || !isAdmin()}
+                onClick={handleSaveSettings}
+                disabled={savingSettings() || !isAdmin()}
                 class="px-3 py-1.5 bg-theme-accent/15 text-theme-accent border border-theme-accent/30 rounded text-sm disabled:opacity-50 hover:bg-theme-accent/25 transition-colors"
               >
-                {saving() ? "Saving..." : "Save"}
+                {savingSettings() ? "Saving..." : "Save"}
               </button>
             </div>
+
             <p class="text-xs text-theme-text-secondary">
-              Events older than this many days are deleted by the nightly pruner. Min 1, max 3650.
+              The nightly pruner deletes activity events older than the activity
+              retention, and application logs older than the log retention or beyond
+              the max-row cap. Capture level controls the minimum severity recorded.
             </p>
+
+            <Show when={isAdmin()}>
+              <div class="flex flex-wrap items-center gap-2 border-t border-theme-border pt-3">
+                {/* Clear activity log */}
+                <Show
+                  when={!showClearActivityConfirm()}
+                  fallback={
+                    <div class="flex items-center gap-1.5">
+                      <span class="text-xs text-theme-error">Clear activity log?</span>
+                      <button
+                        onClick={handleClearActivity}
+                        class="px-2 py-1 text-xs bg-theme-error text-theme-text-primary rounded hover:opacity-90 transition-colors"
+                      >
+                        Yes
+                      </button>
+                      <button
+                        onClick={() => setShowClearActivityConfirm(false)}
+                        class="px-2 py-1 text-xs border border-theme-border-em text-theme-text-secondary rounded hover:text-theme-text-primary transition-colors"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  }
+                >
+                  <button
+                    onClick={() => setShowClearActivityConfirm(true)}
+                    disabled={clearingActivity()}
+                    class="px-3 py-1.5 border border-theme-error/50 text-theme-error rounded text-sm disabled:opacity-50 hover:bg-theme-error/20 transition-colors"
+                  >
+                    Clear activity log
+                  </button>
+                </Show>
+
+                {/* Clear application logs */}
+                <Show
+                  when={!showClearLogsConfirm()}
+                  fallback={
+                    <div class="flex items-center gap-1.5">
+                      <span class="text-xs text-theme-error">Clear application logs?</span>
+                      <button
+                        onClick={handleClearLogs}
+                        class="px-2 py-1 text-xs bg-theme-error text-theme-text-primary rounded hover:opacity-90 transition-colors"
+                      >
+                        Yes
+                      </button>
+                      <button
+                        onClick={() => setShowClearLogsConfirm(false)}
+                        class="px-2 py-1 text-xs border border-theme-border-em text-theme-text-secondary rounded hover:text-theme-text-primary transition-colors"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  }
+                >
+                  <button
+                    onClick={() => setShowClearLogsConfirm(true)}
+                    disabled={clearingLogs()}
+                    class="px-3 py-1.5 border border-theme-error/50 text-theme-error rounded text-sm disabled:opacity-50 hover:bg-theme-error/20 transition-colors"
+                  >
+                    Clear application logs
+                  </button>
+                </Show>
+
+                <a
+                  href={api.logsDownloadUrl(buildParams())}
+                  class="px-3 py-1.5 border border-theme-border-em text-theme-text-secondary rounded text-sm hover:text-theme-text-primary hover:border-theme-accent transition-colors"
+                >
+                  Download
+                </a>
+              </div>
+            </Show>
+          </div>
+        </Show>
+      </div>
+
+      {/* Log viewer */}
+      <div class="bg-theme-surface border border-theme-border rounded-[var(--radius-md)] shadow-[var(--shadow-sm)]">
+        <div class="px-4 py-3 space-y-3 border-b border-theme-border">
+          <div class="flex items-center justify-between gap-2">
+            <span class="text-xs text-theme-text-secondary tabular-nums">
+              {total()} {total() === 1 ? "entry" : "entries"}
+            </span>
+            <label class="flex items-center gap-2 text-xs text-theme-text-secondary cursor-pointer select-none">
+              <input
+                type="checkbox"
+                checked={liveTail()}
+                onChange={(e) => setLiveTail(e.currentTarget.checked)}
+                class="accent-[var(--color-accent)]"
+              />
+              Live tail
+            </label>
           </div>
 
-          <Show when={isAdmin()}>
-            <div class="border-t border-theme-border pt-4 space-y-2">
-              <Show when={!showClearConfirm()}>
-                <button
-                  onClick={() => setShowClearConfirm(true)}
-                  disabled={clearing()}
-                  class="px-3 py-1.5 border border-theme-error/50 text-theme-error rounded text-sm disabled:opacity-50 hover:bg-theme-error/20 transition-colors"
-                >
-                  Clear activity log
-                </button>
-              </Show>
-              <Show when={showClearConfirm()}>
-                <div class="bg-theme-error/10 border border-theme-error/40 rounded-[var(--radius-md)] p-3 space-y-2">
-                  <p class="text-sm text-theme-error font-medium">Clear all activity?</p>
-                  <p class="text-xs text-theme-error/70">
-                    This permanently deletes all activity log entries. The action cannot be undone.
-                  </p>
-                  <div class="flex gap-2 pt-1">
-                    <button
-                      onClick={handleClear}
-                      class="px-3 py-1.5 bg-theme-error text-theme-text-primary rounded text-xs font-medium hover:opacity-90 transition-colors"
-                    >
-                      Yes, clear all
-                    </button>
-                    <button
-                      onClick={() => setShowClearConfirm(false)}
-                      class="px-3 py-1.5 border border-theme-border-em text-theme-text-secondary rounded text-xs hover:text-theme-text-primary transition-colors"
-                    >
-                      Cancel
-                    </button>
-                  </div>
-                </div>
-              </Show>
+          <div class="flex flex-wrap items-center gap-3">
+            <div class="flex flex-wrap gap-1">
+              <For each={LEVELS}>
+                {(lvl) => (
+                  <FilterPill
+                    label={lvl}
+                    active={levels().includes(lvl)}
+                    onClick={() => toggleLevel(lvl)}
+                  />
+                )}
+              </For>
             </div>
+
+            <select
+              value={source()}
+              onChange={(e) =>
+                setSource(e.currentTarget.value as "all" | AppLogSource)
+              }
+              class="px-2 py-1 text-xs bg-theme-base border border-theme-border rounded text-theme-text-primary focus:outline-none focus:border-theme-accent"
+            >
+              <For each={SOURCES}>
+                {(src) => <option value={src}>{src}</option>}
+              </For>
+            </select>
+
+            <input
+              type="text"
+              value={searchInput()}
+              onInput={(e) => setSearchInput(e.currentTarget.value)}
+              placeholder="Search messages..."
+              class="flex-1 min-w-[12rem] px-2 py-1 text-xs bg-theme-base border border-theme-border rounded text-theme-text-primary focus:outline-none focus:border-theme-accent"
+            />
+          </div>
+        </div>
+
+        <div class="max-h-[32rem] overflow-y-auto">
+          <Show when={loadingLogs() && logs().length === 0}>
+            <p class="text-xs text-theme-text-secondary py-6 text-center">
+              Loading...
+            </p>
           </Show>
-        </Show>
+
+          <Show when={!loadingLogs() && logs().length === 0}>
+            <p class="text-xs text-theme-text-secondary py-6 text-center">
+              No log entries match the current filters.
+            </p>
+          </Show>
+
+          <For each={logs()}>
+            {(row) => (
+              <div
+                class={`px-3 py-1.5 border-b border-theme-border text-xs font-mono ${
+                  row.traceback ? "cursor-pointer hover:bg-theme-base/40" : ""
+                }`}
+                onClick={() => row.traceback && toggleExpanded(row.id)}
+              >
+                <div class="flex gap-2 items-baseline">
+                  <span class="text-theme-text-secondary tabular-nums whitespace-nowrap flex-shrink-0">
+                    {new Date(row.timestamp).toLocaleString()}
+                  </span>
+                  <LevelBadge level={row.level} />
+                  <span class="text-theme-text-secondary flex-shrink-0 w-[3.5rem]">
+                    {row.source}
+                  </span>
+                  <span class="text-theme-text-secondary truncate max-w-[12rem] flex-shrink-0">
+                    {row.logger}
+                  </span>
+                  <span class="text-theme-text-primary flex-1 break-all">
+                    {row.message}
+                  </span>
+                  <Show when={row.traceback}>
+                    <span class="text-theme-accent flex-shrink-0">
+                      {expanded().has(row.id) ? "−" : "+"}
+                    </span>
+                  </Show>
+                </div>
+                <Show when={row.traceback && expanded().has(row.id)}>
+                  <pre class="mt-1 p-2 bg-theme-base rounded text-[11px] overflow-x-auto whitespace-pre">
+                    {row.traceback}
+                  </pre>
+                </Show>
+              </div>
+            )}
+          </For>
+
+          <Show when={nextCursor()}>
+            <button
+              onClick={loadMore}
+              disabled={loadingMore()}
+              class="w-full py-2 text-xs text-theme-accent hover:underline disabled:opacity-50"
+            >
+              {loadingMore() ? "Loading..." : "Load more"}
+            </button>
+          </Show>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/settings/ActivityLogTab.tsx
+++ b/frontend/src/components/settings/ActivityLogTab.tsx
@@ -118,6 +118,9 @@ const ActivityLogTab: Component = () => {
     return p;
   };
 
+  // Reactive so the href tracks the current level/source/search filters
+  const downloadUrl = () => api.logsDownloadUrl(buildParams());
+
   const loadInitial = async () => {
     setLoadingLogs(true);
     try {
@@ -143,6 +146,7 @@ const ActivityLogTab: Component = () => {
       batch(() => {
         setLogs((prev) => [...prev, ...res.items]);
         setNextCursor(res.next_cursor);
+        setTotal(res.total);
       });
     } catch {
       /* ignore */
@@ -185,10 +189,13 @@ const ActivityLogTab: Component = () => {
           /* ignore */
         }
       }, 5000);
+      onCleanup(() => {
+        if (timer) {
+          clearInterval(timer);
+          timer = undefined;
+        }
+      });
     }
-  });
-  onCleanup(() => {
-    if (timer) clearInterval(timer);
   });
 
   const toggleLevel = (level: AppLogLevel) => {
@@ -438,7 +445,7 @@ const ActivityLogTab: Component = () => {
                 </Show>
 
                 <a
-                  href={api.logsDownloadUrl(buildParams())}
+                  href={downloadUrl()}
                   class="px-3 py-1.5 border border-theme-border-em text-theme-text-secondary rounded text-sm hover:text-theme-text-primary hover:border-theme-accent transition-colors"
                 >
                   Download

--- a/frontend/src/components/settings/ActivityLogTab.tsx
+++ b/frontend/src/components/settings/ActivityLogTab.tsx
@@ -39,11 +39,14 @@ const LS_SOURCE = "galactilog.applog.source";
 // two stay consistent.
 const levelTextClass = (level: AppLogLevel): string => {
   switch (level) {
-    case "error":
     case "critical":
+      return "text-theme-error font-semibold";
+    case "error":
       return "text-theme-error";
     case "warning":
       return "text-theme-warning";
+    case "info":
+      return "text-theme-info";
     default:
       return "text-theme-text-secondary";
   }
@@ -57,6 +60,8 @@ const levelActiveClass = (level: AppLogLevel): string => {
       return "bg-theme-error/20 border-theme-error/50 text-theme-error";
     case "warning":
       return "bg-theme-warning/20 border-theme-warning/50 text-theme-warning";
+    case "info":
+      return "bg-theme-info/20 border-theme-info/50 text-theme-info";
     default:
       return "bg-theme-text-primary/10 border-theme-border-em text-theme-text-primary";
   }

--- a/frontend/src/components/settings/ActivityLogTab.tsx
+++ b/frontend/src/components/settings/ActivityLogTab.tsx
@@ -75,14 +75,21 @@ const levelActiveClass = (level: AppLogLevel): string => {
 const LevelPill: Component<{
   level: AppLogLevel;
   active: boolean;
+  disabled?: boolean;
+  title?: string;
   onClick: () => void;
 }> = (props) => (
   <button
+    type="button"
     onClick={props.onClick}
+    disabled={props.disabled}
+    title={props.title}
     class={`px-2 py-0.5 text-xs rounded-full border transition-colors ${
-      props.active
-        ? levelActiveClass(props.level)
-        : `border-theme-border opacity-60 hover:opacity-100 ${levelTextClass(props.level)}`
+      props.disabled
+        ? "border-theme-border text-theme-text-tertiary opacity-40 cursor-not-allowed"
+        : props.active
+          ? levelActiveClass(props.level)
+          : `border-theme-border opacity-60 hover:opacity-100 ${levelTextClass(props.level)}`
     }`}
   >
     {props.level}
@@ -167,11 +174,18 @@ const ActivityLogTab: Component = () => {
     onCleanup(() => clearTimeout(handle));
   });
 
+  // The capture level bounds what is recorded; the view filter can only narrow to
+  // that level or above, since nothing below it exists. Effective minimum is the
+  // higher of the view filter and the capture level.
+  const captureOrder = () => LEVEL_ORDER[captureLevel()];
+  const effectiveMinOrder = () =>
+    Math.max(LEVEL_ORDER[minLevel()], captureOrder());
+
   const buildParams = (extra: Partial<LogQueryParams> = {}): LogQueryParams => {
     const p: LogQueryParams = { limit: 50, ...extra };
     // Minimum-severity filter: include the selected level and everything above
     // it. Omit the param entirely when showing everything (debug and above).
-    const threshold = LEVEL_ORDER[minLevel()];
+    const threshold = effectiveMinOrder();
     const included = LEVELS.filter((l) => LEVEL_ORDER[l] >= threshold);
     if (included.length < LEVELS.length) p.level = included;
     if (source() !== "all") p.source = source() as AppLogSource;
@@ -216,9 +230,11 @@ const ActivityLogTab: Component = () => {
     }
   };
 
-  // Reload when filters change
+  // Reload when filters change. captureLevel() participates because it raises the
+  // effective minimum severity and changes which levels exist.
   createEffect(() => {
     minLevel();
+    captureLevel();
     source();
     search();
     loadInitial();
@@ -553,15 +569,24 @@ const ActivityLogTab: Component = () => {
           </div>
 
           <div class="flex flex-wrap items-center gap-3">
-            <div class="flex flex-wrap gap-1" title="Show this level and above">
+            <div class="flex flex-wrap gap-1">
               <For each={LEVELS}>
-                {(lvl) => (
-                  <LevelPill
-                    level={lvl}
-                    active={LEVEL_ORDER[lvl] >= LEVEL_ORDER[minLevel()]}
-                    onClick={() => setMinLevel(lvl)}
-                  />
-                )}
+                {(lvl) => {
+                  const isDisabled = () => LEVEL_ORDER[lvl] < captureOrder();
+                  return (
+                    <LevelPill
+                      level={lvl}
+                      active={LEVEL_ORDER[lvl] >= effectiveMinOrder()}
+                      disabled={isDisabled()}
+                      title={
+                        isDisabled()
+                          ? `No ${lvl} logs are recorded while the Capture level is "${captureLevel()}". Lower the Capture level (top of this card) to record and view ${lvl} entries.`
+                          : "Filter: show this level and above"
+                      }
+                      onClick={() => setMinLevel(lvl)}
+                    />
+                  );
+                }}
               </For>
             </div>
 

--- a/frontend/src/components/settings/ActivityLogTab.tsx
+++ b/frontend/src/components/settings/ActivityLogTab.tsx
@@ -85,7 +85,7 @@ const ActivityLogTab: Component = () => {
   const [loadingLogs, setLoadingLogs] = createSignal(false);
   const [loadingMore, setLoadingMore] = createSignal(false);
   const [expanded, setExpanded] = createSignal<Set<number>>(new Set());
-  const [liveTail, setLiveTail] = createSignal(false);
+  const [liveTail, setLiveTail] = createSignal(true);
 
   onMount(async () => {
     try {

--- a/frontend/src/components/settings/ActivityLogTab.tsx
+++ b/frontend/src/components/settings/ActivityLogTab.tsx
@@ -22,8 +22,48 @@ const LEVELS: AppLogLevel[] = ["debug", "info", "warning", "error", "critical"];
 const CAPTURE_LEVELS: AppLogLevel[] = ["debug", "info", "warning", "error"];
 const SOURCES: ("all" | AppLogSource)[] = ["all", "api", "worker", "beat"];
 
-const FilterPill: Component<{
-  label: string;
+// Severity ranking, low to high. Drives the minimum-severity view filter.
+const LEVEL_ORDER: Record<AppLogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warning: 30,
+  error: 40,
+  critical: 50,
+};
+
+// localStorage keys so the view filter persists across reloads.
+const LS_MIN_LEVEL = "galactilog.applog.minLevel";
+const LS_SOURCE = "galactilog.applog.source";
+
+// Severity text color, shared by the level column and the level selector so the
+// two stay consistent.
+const levelTextClass = (level: AppLogLevel): string => {
+  switch (level) {
+    case "error":
+    case "critical":
+      return "text-theme-error";
+    case "warning":
+      return "text-theme-warning";
+    default:
+      return "text-theme-text-secondary";
+  }
+};
+
+// Filled style for an active (included) level pill, tinted by severity.
+const levelActiveClass = (level: AppLogLevel): string => {
+  switch (level) {
+    case "error":
+    case "critical":
+      return "bg-theme-error/20 border-theme-error/50 text-theme-error";
+    case "warning":
+      return "bg-theme-warning/20 border-theme-warning/50 text-theme-warning";
+    default:
+      return "bg-theme-text-primary/10 border-theme-border-em text-theme-text-primary";
+  }
+};
+
+const LevelPill: Component<{
+  level: AppLogLevel;
   active: boolean;
   onClick: () => void;
 }> = (props) => (
@@ -31,30 +71,19 @@ const FilterPill: Component<{
     onClick={props.onClick}
     class={`px-2 py-0.5 text-xs rounded-full border transition-colors ${
       props.active
-        ? "bg-[var(--color-accent)]/20 text-[var(--color-accent)] border-[var(--color-accent)]/40"
-        : "border-theme-border text-theme-text-secondary hover:text-theme-text-primary hover:border-theme-border-em"
+        ? levelActiveClass(props.level)
+        : `border-theme-border opacity-60 hover:opacity-100 ${levelTextClass(props.level)}`
     }`}
   >
-    {props.label}
+    {props.level}
   </button>
 );
 
-const LevelBadge: Component<{ level: AppLogLevel }> = (props) => {
-  const cls = () => {
-    switch (props.level) {
-      case "error":
-      case "critical":
-        return "text-theme-error";
-      case "warning":
-        return "text-theme-warning";
-      default:
-        return "text-theme-text-secondary";
-    }
-  };
-  return (
-    <span class={`flex-shrink-0 w-[4rem] uppercase ${cls()}`}>{props.level}</span>
-  );
-};
+const LevelBadge: Component<{ level: AppLogLevel }> = (props) => (
+  <span class={`flex-shrink-0 w-[4rem] uppercase ${levelTextClass(props.level)}`}>
+    {props.level}
+  </span>
+);
 
 const ActivityLogTab: Component = () => {
   const { isAdmin } = useAuth();
@@ -74,9 +103,27 @@ const ActivityLogTab: Component = () => {
   const [clearingLogs, setClearingLogs] = createSignal(false);
   const [showClearLogsConfirm, setShowClearLogsConfirm] = createSignal(false);
 
-  // Log viewer state
-  const [levels, setLevels] = createSignal<AppLogLevel[]>([]);
-  const [source, setSource] = createSignal<"all" | AppLogSource>("all");
+  // Log viewer state. Minimum-severity threshold + source persist across reload.
+  const [minLevel, setMinLevel] = createSignal<AppLogLevel>(
+    (() => {
+      try {
+        const v = localStorage.getItem(LS_MIN_LEVEL);
+        return v && v in LEVEL_ORDER ? (v as AppLogLevel) : "debug";
+      } catch {
+        return "debug";
+      }
+    })(),
+  );
+  const [source, setSource] = createSignal<"all" | AppLogSource>(
+    (() => {
+      try {
+        const v = localStorage.getItem(LS_SOURCE);
+        return v === "api" || v === "worker" || v === "beat" ? v : "all";
+      } catch {
+        return "all";
+      }
+    })(),
+  );
   const [searchInput, setSearchInput] = createSignal("");
   const [search, setSearch] = createSignal("");
   const [logs, setLogs] = createSignal<AppLogItem[]>([]);
@@ -112,7 +159,11 @@ const ActivityLogTab: Component = () => {
 
   const buildParams = (extra: Partial<LogQueryParams> = {}): LogQueryParams => {
     const p: LogQueryParams = { limit: 50, ...extra };
-    if (levels().length) p.level = levels();
+    // Minimum-severity filter: include the selected level and everything above
+    // it. Omit the param entirely when showing everything (debug and above).
+    const threshold = LEVEL_ORDER[minLevel()];
+    const included = LEVELS.filter((l) => LEVEL_ORDER[l] >= threshold);
+    if (included.length < LEVELS.length) p.level = included;
     if (source() !== "all") p.source = source() as AppLogSource;
     if (search().trim()) p.q = search().trim();
     return p;
@@ -157,10 +208,20 @@ const ActivityLogTab: Component = () => {
 
   // Reload when filters change
   createEffect(() => {
-    levels();
+    minLevel();
     source();
     search();
     loadInitial();
+  });
+
+  // Persist the view filter so it survives a page reload.
+  createEffect(() => {
+    try {
+      localStorage.setItem(LS_MIN_LEVEL, minLevel());
+      localStorage.setItem(LS_SOURCE, source());
+    } catch {
+      /* ignore */
+    }
   });
 
   // Live tail: poll for rows newer than the newest loaded
@@ -182,7 +243,9 @@ const ActivityLogTab: Component = () => {
           if (res.items.length) {
             batch(() => {
               setLogs((prev) => [...res.items, ...prev]);
-              setTotal(res.total);
+              // res.total here is filtered by `since` (only the new rows), so
+              // add them to the running total instead of overwriting it.
+              setTotal((t) => t + res.items.length);
             });
           }
         } catch {
@@ -197,14 +260,6 @@ const ActivityLogTab: Component = () => {
       });
     }
   });
-
-  const toggleLevel = (level: AppLogLevel) => {
-    setLevels((prev) =>
-      prev.includes(level)
-        ? prev.filter((l) => l !== level)
-        : [...prev, level],
-    );
-  };
 
   const toggleExpanded = (id: number) => {
     setExpanded((prev) => {
@@ -475,13 +530,13 @@ const ActivityLogTab: Component = () => {
           </div>
 
           <div class="flex flex-wrap items-center gap-3">
-            <div class="flex flex-wrap gap-1">
+            <div class="flex flex-wrap gap-1" title="Show this level and above">
               <For each={LEVELS}>
                 {(lvl) => (
-                  <FilterPill
-                    label={lvl}
-                    active={levels().includes(lvl)}
-                    onClick={() => toggleLevel(lvl)}
+                  <LevelPill
+                    level={lvl}
+                    active={LEVEL_ORDER[lvl] >= LEVEL_ORDER[minLevel()]}
+                    onClick={() => setMinLevel(lvl)}
                   />
                 )}
               </For>

--- a/frontend/src/components/settings/ActivityLogTab.tsx
+++ b/frontend/src/components/settings/ActivityLogTab.tsx
@@ -17,6 +17,7 @@ import {
 } from "../../api/client";
 import { useAuth } from "../AuthProvider";
 import { showToast } from "../Toast";
+import HelpPopover from "../HelpPopover";
 
 const LEVELS: AppLogLevel[] = ["debug", "info", "warning", "error", "critical"];
 const CAPTURE_LEVELS: AppLogLevel[] = ["debug", "info", "warning", "error"];
@@ -352,7 +353,15 @@ const ActivityLogTab: Component = () => {
     <div class="space-y-4">
       {/* Settings strip */}
       <div class="bg-theme-surface border border-theme-border rounded-[var(--radius-md)] shadow-[var(--shadow-sm)] p-4 space-y-4">
-        <h3 class="text-theme-text-primary font-medium">Application Log</h3>
+        <div class="flex items-center gap-2">
+          <h3 class="text-theme-text-primary font-medium">Application Log</h3>
+          <HelpPopover title="Application Log">
+            <p>Captures the backend's own log records (from the web, worker, and scheduler processes) into the database so they survive restarts and can be filtered, searched, and downloaded here.</p>
+            <p><strong>Capture level</strong> sets the minimum severity that gets recorded. Leave it at <em>warning</em> for normal use; switch to <em>info</em> or <em>debug</em> to collect detailed logs while troubleshooting, then turn it back down. It takes effect within a few seconds, no restart needed.</p>
+            <p><strong>Activity retention</strong> is how long activity events (scans, merges, enrichment) are kept. <strong>Log retention</strong> and <strong>Log max rows</strong> bound the application log: the nightly pruner deletes records older than the retention or beyond the row cap, whichever comes first.</p>
+            <p><strong>Clear activity log</strong> and <strong>Clear application logs</strong> permanently delete those tables. <strong>Download</strong> exports the currently filtered log view as a plain-text file for sharing in a bug report.</p>
+          </HelpPopover>
+        </div>
 
         <Show when={settingsLoaded()} fallback={
           <p class="text-xs text-theme-text-secondary">Loading...</p>
@@ -521,9 +530,17 @@ const ActivityLogTab: Component = () => {
       <div class="bg-theme-surface border border-theme-border rounded-[var(--radius-md)] shadow-[var(--shadow-sm)]">
         <div class="px-4 py-3 space-y-3 border-b border-theme-border">
           <div class="flex items-center justify-between gap-2">
-            <span class="text-xs text-theme-text-secondary tabular-nums">
-              {total()} {total() === 1 ? "entry" : "entries"}
-            </span>
+            <div class="flex items-center gap-2">
+              <span class="text-xs text-theme-text-secondary tabular-nums">
+                {total()} {total() === 1 ? "entry" : "entries"}
+              </span>
+              <HelpPopover title="Log viewer">
+                <p>Shows recorded log entries, newest first, with a color-coded severity column: debug (gray), info (blue), warning (amber), error and critical (red).</p>
+                <p>The <strong>level pills</strong> filter by minimum severity: pick a level to show it and everything more severe (for example, <em>warning</em> shows warning, error, and critical). The selected level and those above it are highlighted, and the choice persists across reloads.</p>
+                <p>Use the <strong>source</strong> dropdown to limit to the web (api), worker, or scheduler (beat) process, and the <strong>search</strong> box to match message text. Rows with a traceback expand when clicked.</p>
+                <p><strong>Live tail</strong> polls for new entries every few seconds and prepends them. This filters what is displayed, not what is recorded; the capture level above controls recording.</p>
+              </HelpPopover>
+            </div>
             <label class="flex items-center gap-2 text-xs text-theme-text-secondary cursor-pointer select-none">
               <input
                 type="checkbox"

--- a/frontend/src/components/settings/ActivityLogTab.tsx
+++ b/frontend/src/components/settings/ActivityLogTab.tsx
@@ -22,6 +22,10 @@ const LEVELS: AppLogLevel[] = ["debug", "info", "warning", "error", "critical"];
 const CAPTURE_LEVELS: AppLogLevel[] = ["debug", "info", "warning", "error"];
 const SOURCES: ("all" | AppLogSource)[] = ["all", "api", "worker", "beat"];
 
+// Shared style for the action buttons in the settings strip (Save, Clear, Download).
+const ACTION_BTN_CLASS =
+  "px-3 py-1.5 bg-theme-accent/15 text-theme-accent border border-theme-accent/30 rounded text-sm disabled:opacity-50 hover:bg-theme-accent/25 transition-colors";
+
 // Severity ranking, low to high. Drives the minimum-severity view filter.
 const LEVEL_ORDER: Record<AppLogLevel, number> = {
   debug: 10,
@@ -430,7 +434,7 @@ const ActivityLogTab: Component = () => {
               <button
                 onClick={handleSaveSettings}
                 disabled={savingSettings() || !isAdmin()}
-                class="px-3 py-1.5 bg-theme-accent/15 text-theme-accent border border-theme-accent/30 rounded text-sm disabled:opacity-50 hover:bg-theme-accent/25 transition-colors"
+                class={ACTION_BTN_CLASS}
               >
                 {savingSettings() ? "Saving..." : "Save"}
               </button>
@@ -468,7 +472,7 @@ const ActivityLogTab: Component = () => {
                   <button
                     onClick={() => setShowClearActivityConfirm(true)}
                     disabled={clearingActivity()}
-                    class="px-3 py-1.5 border border-theme-error/50 text-theme-error rounded text-sm disabled:opacity-50 hover:bg-theme-error/20 transition-colors"
+                    class={ACTION_BTN_CLASS}
                   >
                     Clear activity log
                   </button>
@@ -498,16 +502,13 @@ const ActivityLogTab: Component = () => {
                   <button
                     onClick={() => setShowClearLogsConfirm(true)}
                     disabled={clearingLogs()}
-                    class="px-3 py-1.5 border border-theme-error/50 text-theme-error rounded text-sm disabled:opacity-50 hover:bg-theme-error/20 transition-colors"
+                    class={ACTION_BTN_CLASS}
                   >
                     Clear application logs
                   </button>
                 </Show>
 
-                <a
-                  href={downloadUrl()}
-                  class="px-3 py-1.5 border border-theme-border-em text-theme-text-secondary rounded text-sm hover:text-theme-text-primary hover:border-theme-accent transition-colors"
-                >
+                <a href={downloadUrl()} class={ACTION_BTN_CLASS}>
                   Download
                 </a>
               </div>

--- a/frontend/src/pages/TargetDetailPage.tsx
+++ b/frontend/src/pages/TargetDetailPage.tsx
@@ -68,7 +68,7 @@ const MergeFromDetailFlow: Component<MergeFromDetailFlowProps> = (props) => {
     searchTimeout = setTimeout(async () => {
       setSearching(true);
       try {
-        const results = await api.searchTargets(q.trim());
+        const results = await api.searchTargets(q.trim(), true);
         setSearchResults(results.filter((t) => t.id !== props.winnerId));
       } catch {
         setSearchResults([]);
@@ -137,6 +137,11 @@ const MergeFromDetailFlow: Component<MergeFromDetailFlowProps> = (props) => {
                         <Show when={t.object_type}>
                           <span class="text-xs text-theme-text-secondary ml-2">{t.object_type}</span>
                         </Show>
+                        <Show when={t.unresolved}>
+                          <span class="text-xs text-yellow-400 ml-2">
+                            Unresolved{t.image_count != null ? ` · ${t.image_count} ${t.image_count === 1 ? "image" : "images"}` : ""}
+                          </span>
+                        </Show>
                       </button>
                     )}
                   </For>
@@ -161,7 +166,8 @@ const MergeFromDetailFlow: Component<MergeFromDetailFlowProps> = (props) => {
       {(t) => (
         <MergePreviewModal
           winnerId={props.winnerId}
-          loserId={t().id}
+          loserId={t().unresolved ? undefined : t().id}
+          loserName={t().unresolved ? t().primary_name : undefined}
           onClose={props.onClose}
           onMerged={props.onMerged}
         />

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -387,6 +387,8 @@ export interface TargetSearchResultFuzzy {
   aliases: string[];
   match_source: string | null;
   similarity_score: number;
+  unresolved?: boolean;
+  image_count?: number | null;
 }
 
 export interface ObjectTypeCount {


### PR DESCRIPTION
**What's new**
*   New Application Log Viewer in the Activity Log tab.
*   View live-streaming backend logs with expandable tracebacks.
*   Filter logs by persistent, color-coded severity levels.
*   Download filtered or full application logs.
*   Configure application log retention settings.
*   New activity events for login, settings, task failures, and API errors.
*   Merge unlinked "Unresolved" image groups from the target page.

**What's fixed**
*   Fixed log viewer live-tail, download link, and pagination count.
*   Reverting a merge no longer deletes user-defined targets.

**What's changed**
*   Application logs now include all task logs, excluding the log draining task.
*   Live tail is enabled by default in the application log viewer.
*   Log level filter disables levels below the capture level.
*   Activity panel height in Library tab matches the left column.
*   Activity Log tab buttons unified to the Save button style.
*   Help popovers added to the Activity Log tab.