### PR TITLE
Enhanced Performance Baselines and UI Improvements

### DIFF
--- a/backend/app/api/stats.py
+++ b/backend/app/api/stats.py
@@ -15,6 +15,7 @@ from app.api.deps import get_current_user
 from app.models.user import User
 from app.models import Image, Target
 from app.services.normalization import load_alias_maps, normalize_filter, normalize_equipment
+from app.services import frame_quality
 from sqlalchemy import cast
 from sqlalchemy.types import Date
 
@@ -283,6 +284,14 @@ async def get_stats(session: AsyncSession = Depends(get_session), user: User = D
             func.min(hfr_nz).label("best_hfr"),
             func.percentile_cont(0.5).within_group(ecc_nz).label("med_ecc"),
             func.percentile_cont(0.5).within_group(fwhm_nz).label("med_fwhm"),
+            # Raw non-zero metric values per raw group, so MAD can be computed in
+            # Python over the normalized (telescope, camera) combo. Postgres has
+            # no direct MAD aggregate, and the median needed for the absolute
+            # deviation is only known after the normalized regrouping merges
+            # filter sub-rows. NULLs are dropped in post-processing.
+            func.array_agg(hfr_nz).label("hfr_vals"),
+            func.array_agg(ecc_nz).label("ecc_vals"),
+            func.array_agg(fwhm_nz).label("fwhm_vals"),
         ).where(
             Image.image_type == "LIGHT",
             Image.telescope.isnot(None),
@@ -496,6 +505,11 @@ async def get_stats(session: AsyncSession = Depends(get_session), user: User = D
                 "filter_rows": {},
                 "raw_telescopes": set(),
                 "raw_cameras": set(),
+                # Raw per-frame metric values across all filter sub-rows, used
+                # to compute a robust MAD over the normalized combo.
+                "raw_hfr": [],
+                "raw_ecc": [],
+                "raw_fwhm": [],
             }
 
         combo_data[key]["raw_telescopes"].add(r.telescope)
@@ -504,6 +518,14 @@ async def get_stats(session: AsyncSession = Depends(get_session), user: User = D
         cd = combo_data[key]
         cd["frame_count"] += r.frame_count
         cd["total_seconds"] += float(r.total_seconds)
+
+        # array_agg returns NULLs for zero/absent metrics; drop them.
+        if getattr(r, "hfr_vals", None):
+            cd["raw_hfr"].extend(v for v in r.hfr_vals if v is not None)
+        if getattr(r, "ecc_vals", None):
+            cd["raw_ecc"].extend(v for v in r.ecc_vals if v is not None)
+        if getattr(r, "fwhm_vals", None):
+            cd["raw_fwhm"].extend(v for v in r.fwhm_vals if v is not None)
 
         if r.med_hfr is not None:
             cd["hfr_vals"].append((r.med_hfr, r.frame_count))
@@ -561,6 +583,10 @@ async def get_stats(session: AsyncSession = Depends(get_session), user: User = D
     def safe_round(v: float | None) -> float | None:
         return round(float(v), 2) if v is not None else None
 
+    def combo_mad(values: list[float]) -> float | None:
+        m = frame_quality.mad(values)
+        return round(float(m), 3) if m is not None else None
+
     def build_filter_metrics(filter_rows_dict: dict) -> list[EquipmentFilterMetrics]:
         result = []
         for fname, fr in sorted(filter_rows_dict.items(), key=lambda x: x[1]["frame_count"], reverse=True):
@@ -586,6 +612,9 @@ async def get_stats(session: AsyncSession = Depends(get_session), user: User = D
             best_hfr=safe_round(cd["best_hfr"]),
             median_eccentricity=weighted_median_approx(cd["ecc_vals"]),
             median_fwhm=weighted_median_approx(cd["fwhm_vals"]),
+            mad_hfr=combo_mad(cd["raw_hfr"]),
+            mad_eccentricity=combo_mad(cd["raw_ecc"]),
+            mad_fwhm=combo_mad(cd["raw_fwhm"]),
             grouped=len(cd["raw_telescopes"]) > 1 or len(cd["raw_cameras"]) > 1,
             filters=sorted(cd["filters"]),
             filter_breakdown=build_filter_metrics(cd["filter_rows"]),

--- a/backend/app/schemas/stats.py
+++ b/backend/app/schemas/stats.py
@@ -87,6 +87,9 @@ class EquipmentComboMetrics(BaseModel):
     best_hfr: float | None
     median_eccentricity: float | None
     median_fwhm: float | None
+    mad_hfr: float | None = None
+    mad_eccentricity: float | None = None
+    mad_fwhm: float | None = None
     grouped: bool
     filters: list[str]
     filter_breakdown: list[EquipmentFilterMetrics]

--- a/backend/app/schemas/target.py
+++ b/backend/app/schemas/target.py
@@ -233,6 +233,21 @@ class TargetDetailResponse(BaseModel):
     user_defined: bool = False
 
 
+class MetricBaseline(BaseModel):
+    median: float | None = None
+    mad: float | None = None
+    n: int = 0
+
+
+class GroupBaseline(BaseModel):
+    median_hfr: MetricBaseline
+    fwhm: MetricBaseline
+    eccentricity: MetricBaseline
+    detected_stars: MetricBaseline
+    adu_median: MetricBaseline
+    guiding_rms_arcsec: MetricBaseline
+
+
 class SessionDetailResponse(BaseModel):
     target_name: str
     session_date: str
@@ -273,6 +288,8 @@ class SessionDetailResponse(BaseModel):
     notes: str | None = None
     rigs: list[RigDetail] = []
     custom_values: list[dict] | None = None
+    session_baselines: dict[str, GroupBaseline] = {}
+    rig_baselines: dict[str, GroupBaseline] = {}
 
 
 class EquipmentOption(BaseModel):

--- a/backend/app/schemas/target.py
+++ b/backend/app/schemas/target.py
@@ -35,6 +35,8 @@ class SessionSummary(BaseModel):
     integration_seconds: float
     frame_count: int
     filters_used: list[str]
+    median_hfr: float | None = None
+    median_eccentricity: float | None = None
 
 
 class FilterMedian(BaseModel):

--- a/backend/app/services/frame_quality.py
+++ b/backend/app/services/frame_quality.py
@@ -1,0 +1,94 @@
+"""MAD-based frame-quality baseline math.
+
+Pure functions with no DB access. They compute, for a collection of already
+loaded light frames grouped by optical train + filter, a robust baseline
+(median + median-absolute-deviation) per graded metric. The frontend turns a
+per-frame metric and the matching baseline into a signed z-score and color band.
+
+No new DB columns and no DATA_VERSION bump: baselines are derived on the fly
+from existing per-frame data.
+"""
+
+import statistics
+
+MIN_GROUP = 8
+EPS = 1e-9
+
+# Metrics for which a baseline (median + MAD) is computed per group.
+METRICS = [
+    "median_hfr",
+    "fwhm",
+    "eccentricity",
+    "detected_stars",
+    "adu_median",
+    "guiding_rms_arcsec",
+]
+
+
+def median(values):
+    """Median of values, ignoring None. Returns None for an empty input.
+
+    For an even count the average of the two middle values is returned, matching
+    statistics.median.
+    """
+    nums = [v for v in values if v is not None]
+    if not nums:
+        return None
+    return statistics.median(nums)
+
+
+def mad(values):
+    """Median absolute deviation from the median, ignoring None.
+
+    Returns None for an empty input and 0.0 for a uniform group.
+    """
+    nums = [v for v in values if v is not None]
+    if not nums:
+        return None
+    m = statistics.median(nums)
+    return statistics.median([abs(x - m) for x in nums])
+
+
+def _get(frame, key):
+    """Read a field from a frame that may be a dict or an attribute-bearing object."""
+    if isinstance(frame, dict):
+        return frame.get(key)
+    return getattr(frame, key, None)
+
+
+def group_key(frame) -> str:
+    """Build the train+filter group key matching the frontend `groupKey(frame)`.
+
+    Format: ``"{telescope}|{camera}|{filter_used}"`` with null components
+    rendered as an empty string.
+    """
+    tel = _get(frame, "telescope") or ""
+    cam = _get(frame, "camera") or ""
+    filt = _get(frame, "filter_used") or ""
+    return f"{tel}|{cam}|{filt}"
+
+
+def group_baselines(frames):
+    """Compute per-group, per-metric ``{median, mad, n}`` baselines.
+
+    `frames` may be dicts or attribute-bearing objects. Groups by `group_key`;
+    for each metric, n is the count of non-null values for that metric within
+    the group.
+    """
+    groups: dict[str, list] = {}
+    for frame in frames:
+        groups.setdefault(group_key(frame), []).append(frame)
+
+    out: dict[str, dict] = {}
+    for key, group_frames in groups.items():
+        metric_stats: dict[str, dict] = {}
+        for metric in METRICS:
+            vals = [_get(f, metric) for f in group_frames]
+            non_null = [v for v in vals if v is not None]
+            metric_stats[metric] = {
+                "median": median(non_null),
+                "mad": mad(non_null),
+                "n": len(non_null),
+            }
+        out[key] = metric_stats
+    return out

--- a/backend/app/services/frame_quality.py
+++ b/backend/app/services/frame_quality.py
@@ -92,3 +92,35 @@ def group_baselines(frames):
             }
         out[key] = metric_stats
     return out
+
+
+def apply_fallback(target_baselines, catalog_baselines):
+    """Substitute catalog-wide stats where a target group's metric is too sparse.
+
+    Per group, per metric: if the target stat's ``n < MIN_GROUP`` and a matching
+    catalog stat exists, use the catalog stat; otherwise keep the target stat.
+    Groups present only in the catalog are added as-is. The inputs are not
+    mutated.
+    """
+    out: dict[str, dict] = {}
+
+    for key, target_metrics in target_baselines.items():
+        catalog_metrics = catalog_baselines.get(key, {})
+        merged: dict[str, dict] = {}
+        for metric, target_stat in target_metrics.items():
+            catalog_stat = catalog_metrics.get(metric)
+            if (
+                target_stat.get("n", 0) < MIN_GROUP
+                and catalog_stat is not None
+            ):
+                merged[metric] = dict(catalog_stat)
+            else:
+                merged[metric] = dict(target_stat)
+        out[key] = merged
+
+    # Groups only present catalog-wide carry over unchanged.
+    for key, catalog_metrics in catalog_baselines.items():
+        if key not in out:
+            out[key] = {m: dict(s) for m, s in catalog_metrics.items()}
+
+    return out

--- a/backend/app/services/frame_quality.py
+++ b/backend/app/services/frame_quality.py
@@ -92,35 +92,3 @@ def group_baselines(frames):
             }
         out[key] = metric_stats
     return out
-
-
-def apply_fallback(target_baselines, catalog_baselines):
-    """Substitute catalog-wide stats where a target group's metric is too sparse.
-
-    Per group, per metric: if the target stat's ``n < MIN_GROUP`` and a matching
-    catalog stat exists, use the catalog stat; otherwise keep the target stat.
-    Groups present only in the catalog are added as-is. The inputs are not
-    mutated.
-    """
-    out: dict[str, dict] = {}
-
-    for key, target_metrics in target_baselines.items():
-        catalog_metrics = catalog_baselines.get(key, {})
-        merged: dict[str, dict] = {}
-        for metric, target_stat in target_metrics.items():
-            catalog_stat = catalog_metrics.get(metric)
-            if (
-                target_stat.get("n", 0) < MIN_GROUP
-                and catalog_stat is not None
-            ):
-                merged[metric] = dict(catalog_stat)
-            else:
-                merged[metric] = dict(target_stat)
-        out[key] = merged
-
-    # Groups only present catalog-wide carry over unchanged.
-    for key, catalog_metrics in catalog_baselines.items():
-        if key not in out:
-            out[key] = {m: dict(s) for m, s in catalog_metrics.items()}
-
-    return out

--- a/backend/app/services/target_aggregation.py
+++ b/backend/app/services/target_aggregation.py
@@ -1325,6 +1325,8 @@ async def list_targets_aggregated(
                    i.filter_used,
                    i.camera,
                    i.telescope,
+                   i.median_hfr,
+                   i.eccentricity,
                    CASE WHEN i.session_date IS NULL THEN 'unknown'
                         ELSE CAST(i.session_date AS VARCHAR) END AS session_key
             FROM images i LEFT JOIN targets t ON i.resolved_target_id = t.id
@@ -1340,7 +1342,11 @@ async def list_targets_aggregated(
             SELECT target_key, session_key,
                    sum(exp) AS session_exp,
                    count(*) AS frame_count,
-                   array_agg(DISTINCT filter_used) FILTER (WHERE filter_used IS NOT NULL) AS session_filters
+                   array_agg(DISTINCT filter_used) FILTER (WHERE filter_used IS NOT NULL) AS session_filters,
+                   percentile_cont(0.5) WITHIN GROUP (ORDER BY median_hfr)
+                       FILTER (WHERE median_hfr IS NOT NULL) AS session_median_hfr,
+                   percentile_cont(0.5) WITHIN GROUP (ORDER BY eccentricity)
+                       FILTER (WHERE eccentricity IS NOT NULL) AS session_median_ecc
             FROM frames
             GROUP BY target_key, session_key
         ),
@@ -1368,7 +1374,9 @@ async def list_targets_aggregated(
                        'session_key', session_key,
                        'session_exp', session_exp,
                        'frame_count', frame_count,
-                       'filters', coalesce(session_filters, ARRAY[]::varchar[]))) AS sessions
+                       'filters', coalesce(session_filters, ARRAY[]::varchar[]),
+                       'median_hfr', session_median_hfr,
+                       'median_eccentricity', session_median_ecc)) AS sessions
             FROM per_session
             GROUP BY target_key
         )
@@ -1429,10 +1437,21 @@ async def list_targets_aggregated(
                     "integration_seconds": 0,
                     "frame_count": 0,
                     "filters_set": set(),
+                    "median_hfr": None,
+                    "median_eccentricity": None,
                 }
             s = sessions_detail[tk][date_key]
             s["integration_seconds"] += float(sess["session_exp"])
             s["frame_count"] += int(sess["frame_count"])
+            # Per-session median sharpness/roundness, computed SQL-side over the
+            # session's frames (nulls ignored). Each (target_key, session_key)
+            # appears once per detail row, so a direct set is correct.
+            mh = sess.get("median_hfr")
+            if mh is not None:
+                s["median_hfr"] = float(mh)
+            me = sess.get("median_eccentricity")
+            if me is not None:
+                s["median_eccentricity"] = float(me)
             for raw_filter in (sess.get("filters") or []):
                 f = normalize_filter(raw_filter, filter_map)
                 if f:
@@ -1563,6 +1582,8 @@ async def list_targets_aggregated(
                 integration_seconds=s["integration_seconds"],
                 frame_count=s["frame_count"],
                 filters_used=sorted(s["filters_set"]),
+                median_hfr=s["median_hfr"],
+                median_eccentricity=s["median_eccentricity"],
             )
             for s in sessions_list
         ]

--- a/backend/app/services/target_aggregation.py
+++ b/backend/app/services/target_aggregation.py
@@ -31,6 +31,7 @@ from app.schemas.target import (
     TargetSearchResultFuzzy, ObjectTypeCount, RigDetail,
 )
 from app.schemas.export import ExportResponse, ExportFilterRow, ExportEquipment, ExportCalibration
+from app.services import frame_quality
 
 logger = logging.getLogger(__name__)
 
@@ -1902,6 +1903,70 @@ async def get_session_detail(target_id: str, date: str, session: AsyncSession) -
                 for slug, sd, rl, val in cv_rows
             ]
 
+    # --- Frame-quality baselines (MAD-based, computed on the fly) ---
+    # Group keys use normalized telescope/camera/filter so they match the
+    # frontend `groupKey(frame)` built from the same normalized values.
+    def _baseline_frame(tel, cam, filt, hfr, fwhm_v, ecc, stars, adu_med, guide):
+        return {
+            "telescope": normalize_equipment(tel, tel_map),
+            "camera": normalize_equipment(cam, cam_map),
+            "filter_used": normalize_filter(filt, filter_map),
+            "median_hfr": hfr,
+            "fwhm": fwhm_v,
+            "eccentricity": ecc,
+            "detected_stars": stars,
+            "adu_median": adu_med,
+            "guiding_rms_arcsec": guide,
+        }
+
+    session_frame_dicts = [
+        _baseline_frame(
+            img.telescope, img.camera, img.filter_used,
+            img.median_hfr, img.fwhm, img.eccentricity,
+            img.detected_stars, img.adu_median, img.guiding_rms_arcsec,
+        )
+        for img in images
+    ]
+    session_baselines = frame_quality.group_baselines(session_frame_dicts)
+
+    # Cross-session frames for this target (same predicate as the session query,
+    # minus the session_date filter). Select only the columns the baseline needs.
+    metric_cols = (
+        Image.telescope, Image.camera, Image.filter_used,
+        Image.median_hfr, Image.fwhm, Image.eccentricity,
+        Image.detected_stars, Image.adu_median, Image.guiding_rms_arcsec,
+    )
+    if target_id == "obj:__uncategorized__":
+        target_frames_q = select(*metric_cols).where(
+            Image.resolved_target_id.is_(None),
+            or_(
+                ~Image.raw_headers.has_key("OBJECT"),
+                Image.raw_headers["OBJECT"].astext == "",
+                Image.raw_headers["OBJECT"].is_(None),
+            ),
+        )
+    elif target_id.startswith("obj:"):
+        target_frames_q = select(*metric_cols).where(
+            Image.raw_headers["OBJECT"].astext == target_id[4:],
+            Image.image_type == "LIGHT",
+        )
+    else:
+        target_frames_q = select(*metric_cols).where(
+            Image.resolved_target_id == tid,
+            Image.image_type == "LIGHT",
+        )
+    target_frame_rows = (await session.execute(target_frames_q)).all()
+    target_frame_dicts = [_baseline_frame(*row) for row in target_frame_rows]
+    target_baselines = frame_quality.group_baselines(target_frame_dicts)
+
+    # Catalog-wide frames (all LIGHT frames) for the sparse-group fallback.
+    catalog_frames_q = select(*metric_cols).where(Image.image_type == "LIGHT")
+    catalog_frame_rows = (await session.execute(catalog_frames_q)).all()
+    catalog_frame_dicts = [_baseline_frame(*row) for row in catalog_frame_rows]
+    catalog_baselines = frame_quality.group_baselines(catalog_frame_dicts)
+
+    rig_baselines = frame_quality.apply_fallback(target_baselines, catalog_baselines)
+
     return SessionDetailResponse(
         target_name=target_name,
         session_date=date,
@@ -1945,4 +2010,6 @@ async def get_session_detail(target_id: str, date: str, session: AsyncSession) -
         notes=session_note,
         rigs=rig_details,
         custom_values=custom_values_list,
+        session_baselines=session_baselines,
+        rig_baselines=rig_baselines,
     )

--- a/backend/app/services/target_aggregation.py
+++ b/backend/app/services/target_aggregation.py
@@ -1950,43 +1950,20 @@ async def get_session_detail(target_id: str, date: str, session: AsyncSession) -
     ]
     session_baselines = frame_quality.group_baselines(session_frame_dicts)
 
-    # Cross-session frames for this target (same predicate as the session query,
-    # minus the session_date filter). Select only the columns the baseline needs.
+    # Catalog-wide frames: every LIGHT frame across all targets and sessions,
+    # grouped by telescope|camera|filter. This is the "This rig overall"
+    # baseline. It is target-independent, which makes the per-frame
+    # "This session / This rig overall" toggle meaningful even for
+    # single-session targets. Select only the columns the baseline needs.
     metric_cols = (
         Image.telescope, Image.camera, Image.filter_used,
         Image.median_hfr, Image.fwhm, Image.eccentricity,
         Image.detected_stars, Image.adu_median, Image.guiding_rms_arcsec,
     )
-    if target_id == "obj:__uncategorized__":
-        target_frames_q = select(*metric_cols).where(
-            Image.resolved_target_id.is_(None),
-            or_(
-                ~Image.raw_headers.has_key("OBJECT"),
-                Image.raw_headers["OBJECT"].astext == "",
-                Image.raw_headers["OBJECT"].is_(None),
-            ),
-        )
-    elif target_id.startswith("obj:"):
-        target_frames_q = select(*metric_cols).where(
-            Image.raw_headers["OBJECT"].astext == target_id[4:],
-            Image.image_type == "LIGHT",
-        )
-    else:
-        target_frames_q = select(*metric_cols).where(
-            Image.resolved_target_id == tid,
-            Image.image_type == "LIGHT",
-        )
-    target_frame_rows = (await session.execute(target_frames_q)).all()
-    target_frame_dicts = [_baseline_frame(*row) for row in target_frame_rows]
-    target_baselines = frame_quality.group_baselines(target_frame_dicts)
-
-    # Catalog-wide frames (all LIGHT frames) for the sparse-group fallback.
     catalog_frames_q = select(*metric_cols).where(Image.image_type == "LIGHT")
     catalog_frame_rows = (await session.execute(catalog_frames_q)).all()
     catalog_frame_dicts = [_baseline_frame(*row) for row in catalog_frame_rows]
-    catalog_baselines = frame_quality.group_baselines(catalog_frame_dicts)
-
-    rig_baselines = frame_quality.apply_fallback(target_baselines, catalog_baselines)
+    rig_baselines = frame_quality.group_baselines(catalog_frame_dicts)
 
     return SessionDetailResponse(
         target_name=target_name,

--- a/backend/tests/test_api_session_detail_enriched.py
+++ b/backend/tests/test_api_session_detail_enriched.py
@@ -110,10 +110,17 @@ async def test_session_detail_has_new_fields():
     mock_cv_result = MagicMock()
     mock_cv_result.all.return_value = []
 
+    # target cross-session frames + catalog-wide frames for baselines; .all()
+    mock_target_frames_result = MagicMock()
+    mock_target_frames_result.all.return_value = []
+    mock_catalog_frames_result = MagicMock()
+    mock_catalog_frames_result.all.return_value = []
+
     mock_session.execute = AsyncMock(
         side_effect=[
             mock_img_result, mock_avg_result, mock_alias_result,
             mock_all_hfr_result, mock_note_result, mock_cv_result,
+            mock_target_frames_result, mock_catalog_frames_result,
         ]
     )
 
@@ -199,10 +206,17 @@ async def test_session_detail_hfr_outlier_insight():
     mock_cv_result = MagicMock()
     mock_cv_result.all.return_value = []
 
+    # target cross-session frames + catalog-wide frames for baselines; .all()
+    mock_target_frames_result = MagicMock()
+    mock_target_frames_result.all.return_value = []
+    mock_catalog_frames_result = MagicMock()
+    mock_catalog_frames_result.all.return_value = []
+
     mock_session.execute = AsyncMock(
         side_effect=[
             mock_img_result, mock_avg_result, mock_alias_result,
             mock_all_hfr_result, mock_note_result, mock_cv_result,
+            mock_target_frames_result, mock_catalog_frames_result,
         ]
     )
 

--- a/backend/tests/test_api_session_detail_enriched.py
+++ b/backend/tests/test_api_session_detail_enriched.py
@@ -110,9 +110,7 @@ async def test_session_detail_has_new_fields():
     mock_cv_result = MagicMock()
     mock_cv_result.all.return_value = []
 
-    # target cross-session frames + catalog-wide frames for baselines; .all()
-    mock_target_frames_result = MagicMock()
-    mock_target_frames_result.all.return_value = []
+    # catalog-wide frames for the rig baseline; .all()
     mock_catalog_frames_result = MagicMock()
     mock_catalog_frames_result.all.return_value = []
 
@@ -120,7 +118,7 @@ async def test_session_detail_has_new_fields():
         side_effect=[
             mock_img_result, mock_avg_result, mock_alias_result,
             mock_all_hfr_result, mock_note_result, mock_cv_result,
-            mock_target_frames_result, mock_catalog_frames_result,
+            mock_catalog_frames_result,
         ]
     )
 
@@ -206,9 +204,7 @@ async def test_session_detail_hfr_outlier_insight():
     mock_cv_result = MagicMock()
     mock_cv_result.all.return_value = []
 
-    # target cross-session frames + catalog-wide frames for baselines; .all()
-    mock_target_frames_result = MagicMock()
-    mock_target_frames_result.all.return_value = []
+    # catalog-wide frames for the rig baseline; .all()
     mock_catalog_frames_result = MagicMock()
     mock_catalog_frames_result.all.return_value = []
 
@@ -216,7 +212,7 @@ async def test_session_detail_hfr_outlier_insight():
         side_effect=[
             mock_img_result, mock_avg_result, mock_alias_result,
             mock_all_hfr_result, mock_note_result, mock_cv_result,
-            mock_target_frames_result, mock_catalog_frames_result,
+            mock_catalog_frames_result,
         ]
     )
 

--- a/backend/tests/test_frame_quality.py
+++ b/backend/tests/test_frame_quality.py
@@ -44,28 +44,3 @@ def test_group_baselines_null_component_key():
                "detected_stars": None, "adu_median": None, "guiding_rms_arcsec": None}]
     out = group_baselines(frames)
     assert "|C|" in out
-
-
-def test_apply_fallback_substitutes_small_groups():
-    from app.services.frame_quality import apply_fallback
-    target = {"T|C|Ha": {"median_hfr": {"median": 2.0, "mad": 0.1, "n": 3}}}
-    catalog = {"T|C|Ha": {"median_hfr": {"median": 2.5, "mad": 0.3, "n": 50}}}
-    out = apply_fallback(target, catalog)
-    assert out["T|C|Ha"]["median_hfr"]["median"] == 2.5   # n=3 < 8 -> fallback
-    assert out["T|C|Ha"]["median_hfr"]["n"] == 50
-
-
-def test_apply_fallback_keeps_large_groups():
-    from app.services.frame_quality import apply_fallback
-    target = {"T|C|Ha": {"median_hfr": {"median": 2.0, "mad": 0.1, "n": 20}}}
-    catalog = {"T|C|Ha": {"median_hfr": {"median": 2.5, "mad": 0.3, "n": 50}}}
-    out = apply_fallback(target, catalog)
-    assert out["T|C|Ha"]["median_hfr"]["median"] == 2.0
-
-
-def test_apply_fallback_adds_catalog_only_groups():
-    from app.services.frame_quality import apply_fallback
-    target = {}
-    catalog = {"T|C|OIII": {"median_hfr": {"median": 2.5, "mad": 0.3, "n": 50}}}
-    out = apply_fallback(target, catalog)
-    assert out["T|C|OIII"]["median_hfr"]["median"] == 2.5

--- a/backend/tests/test_frame_quality.py
+++ b/backend/tests/test_frame_quality.py
@@ -44,3 +44,28 @@ def test_group_baselines_null_component_key():
                "detected_stars": None, "adu_median": None, "guiding_rms_arcsec": None}]
     out = group_baselines(frames)
     assert "|C|" in out
+
+
+def test_apply_fallback_substitutes_small_groups():
+    from app.services.frame_quality import apply_fallback
+    target = {"T|C|Ha": {"median_hfr": {"median": 2.0, "mad": 0.1, "n": 3}}}
+    catalog = {"T|C|Ha": {"median_hfr": {"median": 2.5, "mad": 0.3, "n": 50}}}
+    out = apply_fallback(target, catalog)
+    assert out["T|C|Ha"]["median_hfr"]["median"] == 2.5   # n=3 < 8 -> fallback
+    assert out["T|C|Ha"]["median_hfr"]["n"] == 50
+
+
+def test_apply_fallback_keeps_large_groups():
+    from app.services.frame_quality import apply_fallback
+    target = {"T|C|Ha": {"median_hfr": {"median": 2.0, "mad": 0.1, "n": 20}}}
+    catalog = {"T|C|Ha": {"median_hfr": {"median": 2.5, "mad": 0.3, "n": 50}}}
+    out = apply_fallback(target, catalog)
+    assert out["T|C|Ha"]["median_hfr"]["median"] == 2.0
+
+
+def test_apply_fallback_adds_catalog_only_groups():
+    from app.services.frame_quality import apply_fallback
+    target = {}
+    catalog = {"T|C|OIII": {"median_hfr": {"median": 2.5, "mad": 0.3, "n": 50}}}
+    out = apply_fallback(target, catalog)
+    assert out["T|C|OIII"]["median_hfr"]["median"] == 2.5

--- a/backend/tests/test_frame_quality.py
+++ b/backend/tests/test_frame_quality.py
@@ -1,0 +1,46 @@
+import math
+
+from app.services.frame_quality import median, mad, group_baselines, MIN_GROUP
+
+
+def test_median_ignores_none():
+    assert median([1.0, None, 3.0, 2.0]) == 2.0
+
+
+def test_median_empty_is_none():
+    assert median([None, None]) is None
+
+
+def test_mad_basic():
+    # values 1,2,3,4,5 -> median 3 -> |dev| 2,1,0,1,2 -> median 1
+    assert mad([1, 2, 3, 4, 5]) == 1.0
+
+
+def test_mad_uniform_is_zero():
+    assert mad([4, 4, 4]) == 0.0
+
+
+def test_group_baselines_groups_by_train_filter():
+    frames = [
+        {"telescope": "T", "camera": "C", "filter_used": "Ha", "median_hfr": 2.0,
+         "fwhm": None, "eccentricity": 0.3, "detected_stars": 100,
+         "adu_median": 500, "guiding_rms_arcsec": 0.5},
+        {"telescope": "T", "camera": "C", "filter_used": "Ha", "median_hfr": 2.4,
+         "fwhm": None, "eccentricity": 0.5, "detected_stars": 80,
+         "adu_median": 600, "guiding_rms_arcsec": 0.7},
+    ]
+    out = group_baselines(frames)
+    key = "T|C|Ha"
+    assert key in out
+    assert out[key]["median_hfr"]["median"] == 2.2
+    assert out[key]["median_hfr"]["n"] == 2
+    # |2.0-2.2|, |2.4-2.2| -> 0.2,0.2 -> 0.2 (isclose: 0.4-0.2 subtraction is FP-inexact)
+    assert math.isclose(out[key]["median_hfr"]["mad"], 0.2, abs_tol=1e-9)
+
+
+def test_group_baselines_null_component_key():
+    frames = [{"telescope": None, "camera": "C", "filter_used": None,
+               "median_hfr": 1.0, "fwhm": None, "eccentricity": None,
+               "detected_stars": None, "adu_median": None, "guiding_rms_arcsec": None}]
+    out = group_baselines(frames)
+    assert "|C|" in out

--- a/backend/tests/test_session_baselines.py
+++ b/backend/tests/test_session_baselines.py
@@ -1,0 +1,161 @@
+import uuid
+import pytest
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+from httpx import AsyncClient, ASGITransport
+
+from app.main import app
+from app.database import get_session
+from app.api.deps import get_current_user
+from app.models import Target, Image
+from app.models.user import User, UserRole
+
+
+def _admin_user():
+    u = MagicMock(spec=User)
+    u.id = uuid.uuid4()
+    u.role = UserRole.admin
+    u.is_active = True
+    return u
+
+
+def make_image(date_str, filter_used="Ha", hfr=2.1, ecc=0.38):
+    img = MagicMock(spec=Image)
+    img.capture_date = datetime.fromisoformat(date_str).replace(tzinfo=timezone.utc)
+    img.filter_used = filter_used
+    img.exposure_time = 300.0
+    img.median_hfr = hfr
+    img.eccentricity = ecc
+    img.sensor_temp = -10.0
+    img.camera_gain = 100
+    img.camera = "ZWO ASI2600MM"
+    img.telescope = "Esprit 150"
+    img.file_name = f"Light_{filter_used}_{date_str}.fits"
+    img.file_path = f"/data/Light_{filter_used}_{date_str}.fits"
+    img.pier_side = "W"
+    img.thumbnail_path = None
+    img.raw_headers = {"OBJECT": "M 42", "EXPTIME": "300"}
+    img.fwhm = None
+    img.hfr_stdev = None
+    img.guiding_rms_arcsec = None
+    img.guiding_rms_ra_arcsec = None
+    img.guiding_rms_dec_arcsec = None
+    img.detected_stars = None
+    img.adu_stdev = None
+    img.adu_mean = None
+    img.adu_median = None
+    img.adu_min = None
+    img.adu_max = None
+    img.focuser_position = None
+    img.focuser_temp = None
+    img.rotator_position = None
+    img.airmass = None
+    img.ambient_temp = None
+    img.dew_point = None
+    img.humidity = None
+    img.pressure = None
+    img.wind_speed = None
+    img.wind_direction = None
+    img.wind_gust = None
+    img.cloud_cover = None
+    img.sky_quality = None
+    return img
+
+
+@pytest.mark.asyncio
+async def test_session_detail_returns_baselines():
+    tid = uuid.uuid4()
+    target = MagicMock(spec=Target)
+    target.id = tid
+    target.primary_name = "M 42"
+
+    images = [
+        make_image("2026-03-20T21:00:00", "Ha", hfr=2.0, ecc=0.30),
+        make_image("2026-03-20T21:05:00", "Ha", hfr=2.4, ecc=0.40),
+    ]
+
+    mock_session = AsyncMock()
+    mock_session.get = AsyncMock(return_value=target)
+
+    # img_q -> scalars().all()
+    mock_img_result = MagicMock()
+    mock_img_result.scalars.return_value.all.return_value = images
+
+    # avg_hfr_q -> scalar()
+    mock_avg_result = MagicMock()
+    mock_avg_result.scalar.return_value = 2.1
+
+    # load_alias_maps -> scalar_one_or_none() None
+    mock_alias_result = MagicMock()
+    mock_alias_result.scalar_one_or_none.return_value = None
+
+    # all_hfr_q -> .all() rows of (session_date, median_hfr)
+    mock_all_hfr_result = MagicMock()
+    mock_all_hfr_result.all.return_value = [
+        ("2026-03-20", 2.0), ("2026-03-20", 2.4),
+    ]
+
+    # note_q -> scalar_one_or_none()
+    mock_note_result = MagicMock()
+    mock_note_result.scalar_one_or_none.return_value = None
+
+    # cv_q -> .all()
+    mock_cv_result = MagicMock()
+    mock_cv_result.all.return_value = []
+
+    # target cross-session frames -> .all() of column rows
+    # columns: telescope, camera, filter_used, median_hfr, fwhm, eccentricity,
+    #          detected_stars, adu_median, guiding_rms_arcsec
+    target_frame_rows = [
+        ("Esprit 150", "ZWO ASI2600MM", "Ha", 2.0, None, 0.30, None, None, None),
+        ("Esprit 150", "ZWO ASI2600MM", "Ha", 2.4, None, 0.40, None, None, None),
+    ]
+    mock_target_frames_result = MagicMock()
+    mock_target_frames_result.all.return_value = target_frame_rows
+
+    # catalog-wide frames -> .all() of column rows
+    catalog_frame_rows = [
+        ("Esprit 150", "ZWO ASI2600MM", "Ha", 2.1, None, 0.35, None, None, None),
+    ]
+    mock_catalog_frames_result = MagicMock()
+    mock_catalog_frames_result.all.return_value = catalog_frame_rows
+
+    mock_session.execute = AsyncMock(
+        side_effect=[
+            mock_img_result, mock_avg_result, mock_alias_result,
+            mock_all_hfr_result, mock_note_result, mock_cv_result,
+            mock_target_frames_result, mock_catalog_frames_result,
+        ]
+    )
+
+    async def override():
+        yield mock_session
+
+    from app.services.normalization import invalidate_alias_cache
+    invalidate_alias_cache()
+    app.dependency_overrides[get_session] = override
+    app.dependency_overrides[get_current_user] = lambda: _admin_user()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(f"/api/targets/{tid}/sessions/2026-03-20")
+
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert "session_baselines" in data
+    assert "rig_baselines" in data
+
+    key = "Esprit 150|ZWO ASI2600MM|Ha"
+    assert key in data["session_baselines"]
+    sb = data["session_baselines"][key]
+    assert sb["median_hfr"]["median"] == 2.2
+    assert sb["median_hfr"]["n"] == 2
+    assert "mad" in sb["median_hfr"]
+
+    assert key in data["rig_baselines"]
+    rb = data["rig_baselines"][key]
+    assert "median_hfr" in rb
+    assert "median" in rb["median_hfr"]
+
+    app.dependency_overrides.clear()

--- a/backend/tests/test_session_baselines.py
+++ b/backend/tests/test_session_baselines.py
@@ -103,19 +103,20 @@ async def test_session_detail_returns_baselines():
     mock_cv_result = MagicMock()
     mock_cv_result.all.return_value = []
 
-    # target cross-session frames -> .all() of column rows
+    # catalog-wide frames -> .all() of column rows
     # columns: telescope, camera, filter_used, median_hfr, fwhm, eccentricity,
     #          detected_stars, adu_median, guiding_rms_arcsec
-    target_frame_rows = [
+    # Includes this target's two frames PLUS frames from OTHER targets/sessions
+    # that share the same telescope+camera+filter, so the catalog-wide rig
+    # baseline count exceeds this session's count.
+    catalog_frame_rows = [
+        # This session's own frames
         ("Esprit 150", "ZWO ASI2600MM", "Ha", 2.0, None, 0.30, None, None, None),
         ("Esprit 150", "ZWO ASI2600MM", "Ha", 2.4, None, 0.40, None, None, None),
-    ]
-    mock_target_frames_result = MagicMock()
-    mock_target_frames_result.all.return_value = target_frame_rows
-
-    # catalog-wide frames -> .all() of column rows
-    catalog_frame_rows = [
+        # Other targets / other sessions, same rig+filter
         ("Esprit 150", "ZWO ASI2600MM", "Ha", 2.1, None, 0.35, None, None, None),
+        ("Esprit 150", "ZWO ASI2600MM", "Ha", 2.2, None, 0.36, None, None, None),
+        ("Esprit 150", "ZWO ASI2600MM", "Ha", 2.3, None, 0.37, None, None, None),
     ]
     mock_catalog_frames_result = MagicMock()
     mock_catalog_frames_result.all.return_value = catalog_frame_rows
@@ -124,7 +125,7 @@ async def test_session_detail_returns_baselines():
         side_effect=[
             mock_img_result, mock_avg_result, mock_alias_result,
             mock_all_hfr_result, mock_note_result, mock_cv_result,
-            mock_target_frames_result, mock_catalog_frames_result,
+            mock_catalog_frames_result,
         ]
     )
 
@@ -153,9 +154,14 @@ async def test_session_detail_returns_baselines():
     assert sb["median_hfr"]["n"] == 2
     assert "mad" in sb["median_hfr"]
 
+    # rig_baselines is now catalog-wide: it includes frames from other
+    # targets / sessions sharing the same telescope+camera+filter, so its
+    # count exceeds the session-only count for the shared group.
     assert key in data["rig_baselines"]
     rb = data["rig_baselines"][key]
     assert "median_hfr" in rb
     assert "median" in rb["median_hfr"]
+    assert rb["median_hfr"]["n"] == 5
+    assert rb["median_hfr"]["n"] > sb["median_hfr"]["n"]
 
     app.dependency_overrides.clear()

--- a/backend/tests/test_stats_timeline.py
+++ b/backend/tests/test_stats_timeline.py
@@ -132,6 +132,111 @@ def _make_async_redis_cm():
     return _cm
 
 
+def _make_perf_row(tel, cam, filt, hfr_vals, ecc_vals, fwhm_vals):
+    """Mimic a row from _query_equipment_perf with array_agg columns."""
+    import statistics
+    row = MagicMock()
+    row.telescope = tel
+    row.camera = cam
+    row.filter_used = filt
+    row.frame_count = len(hfr_vals)
+    row.total_seconds = 300.0 * len(hfr_vals)
+    row.med_hfr = statistics.median(hfr_vals) if hfr_vals else None
+    row.best_hfr = min(hfr_vals) if hfr_vals else None
+    row.med_ecc = statistics.median(ecc_vals) if ecc_vals else None
+    row.med_fwhm = statistics.median(fwhm_vals) if fwhm_vals else None
+    row.hfr_vals = hfr_vals
+    row.ecc_vals = ecc_vals
+    row.fwhm_vals = fwhm_vals
+    return row
+
+
+def _make_perf_result(rows):
+    r = MagicMock()
+    r.all.return_value = rows
+    r.one.return_value = (0,)
+    r.first.return_value = None
+    r.scalar_one.return_value = 0
+    r.scalar_one_or_none.return_value = None
+    return r
+
+
+def _make_async_session_cm_with_perf(perf_rows):
+    _results = [
+        _make_overview_result(),
+        _make_default_result(),
+        _make_default_result(),
+        _make_perf_result(perf_rows),  # 3 _query_equipment_perf
+        _make_default_result(),
+        _make_default_result(),
+        _make_default_result(),
+        _make_default_result(),
+        _make_default_result(),
+        _make_default_result(),
+        _make_quality_result(),
+        _make_bucket_result(),
+        _make_default_result(),
+        _make_default_result(),
+    ]
+    _call_count = [0]
+
+    @asynccontextmanager
+    async def _cm():
+        idx = _call_count[0]
+        _call_count[0] += 1
+        result = _results[idx] if idx < len(_results) else _make_default_result()
+        session = AsyncMock()
+        session.execute = AsyncMock(return_value=result)
+        yield session
+    return _cm
+
+
+@pytest.mark.asyncio
+async def test_equipment_combo_has_mad_fields():
+    """equipment_performance combos expose mad_hfr/mad_eccentricity/mad_fwhm."""
+    session = _make_mock_session_for_stats()
+    user = _make_admin_user()
+
+    perf_rows = [
+        _make_perf_row(
+            "Esprit 150", "ASI2600MM", "Ha",
+            hfr_vals=[2.0, 2.4, 2.2, 2.1],
+            ecc_vals=[0.30, 0.40, 0.35, 0.32],
+            fwhm_vals=[3.0, 3.4, 3.2, 3.1],
+        ),
+    ]
+
+    async def override_session():
+        yield session
+
+    async def override_user():
+        return user
+
+    app.dependency_overrides[get_session] = override_session
+    app.dependency_overrides[get_current_user] = override_user
+
+    try:
+        with patch("app.api.stats.async_session", side_effect=_make_async_session_cm_with_perf(perf_rows)), \
+             patch("app.api.stats.async_redis", side_effect=_make_async_redis_cm()), \
+             patch("app.api.stats._extract_site_coords", new=AsyncMock(return_value=None)):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.get("/api/stats")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["equipment_performance"]) >= 1
+        combo = data["equipment_performance"][0]
+        assert "mad_hfr" in combo
+        assert "mad_eccentricity" in combo
+        assert "mad_fwhm" in combo
+        # median of |x-2.15| for [2.0,2.4,2.2,2.1] -> |.15,.25,.05,.05| -> median 0.10
+        assert combo["mad_hfr"] is not None
+        assert abs(combo["mad_hfr"] - 0.10) < 1e-6
+    finally:
+        app.dependency_overrides.clear()
+
+
 @pytest.mark.asyncio
 async def test_stats_has_timeline_fields():
     """Verify /stats returns all three timeline granularities and site_coords."""

--- a/backend/tests/test_targets_aggregation.py
+++ b/backend/tests/test_targets_aggregation.py
@@ -112,24 +112,24 @@ async def seeded_db():
                    capture_date=datetime(2024, 1, 10, 20, 0, tzinfo=timezone.utc),
                    exposure_time=300.0, filter_used="Ha",
                    camera="ASI2600", telescope="ESPRIT100",
-                   median_hfr=2.0, raw_headers={"OBJECT": "M31"}))
+                   median_hfr=2.0, eccentricity=0.40, raw_headers={"OBJECT": "M31"}))
         s.add(_img(resolved_target_id=TID_M31, session_date=d1,
                    capture_date=datetime(2024, 1, 10, 20, 5, tzinfo=timezone.utc),
                    exposure_time=300.0, filter_used="H_alpha",
                    camera="2600MM", telescope="ESPRIT100",
-                   median_hfr=2.2, raw_headers={"OBJECT": "M31"}))
+                   median_hfr=2.2, eccentricity=0.42, raw_headers={"OBJECT": "M31"}))
         s.add(_img(resolved_target_id=TID_M31, session_date=d1,
                    capture_date=datetime(2024, 1, 10, 21, 0, tzinfo=timezone.utc),
                    exposure_time=120.0, filter_used="O3",
                    camera="ASI2600", telescope="ESPRIT100",
-                   median_hfr=2.1, raw_headers={"OBJECT": "M31"}))
+                   median_hfr=2.1, eccentricity=0.44, raw_headers={"OBJECT": "M31"}))
 
         # --- M31 session 2: another Ha-aliased frame
         s.add(_img(resolved_target_id=TID_M31, session_date=d2,
                    capture_date=datetime(2024, 1, 12, 20, 0, tzinfo=timezone.utc),
                    exposure_time=600.0, filter_used="Ha",
                    camera="ASI2600", telescope="ESPRIT100",
-                   median_hfr=5.0, raw_headers={"OBJECT": "M31 mosaic"}))
+                   median_hfr=5.0, eccentricity=0.70, raw_headers={"OBJECT": "M31 mosaic"}))
 
         # --- Unresolved frame WITH an OBJECT header -> obj:NGC 7000
         s.add(_img(resolved_target_id=None, session_date=d1,
@@ -201,9 +201,11 @@ EXPECTED_TARGETS = {
         "equipment": ["ASI2600MM Pro", "Esprit 100"],
         "sessions": [
             {"session_date": "2024-01-12", "integration_seconds": 600.0,
-             "frame_count": 1, "filters_used": ["H-alpha"]},
+             "frame_count": 1, "filters_used": ["H-alpha"],
+             "median_hfr": 5.0, "median_eccentricity": 0.7},
             {"session_date": "2024-01-10", "integration_seconds": 720.0,
-             "frame_count": 3, "filters_used": ["H-alpha", "OIII"]},
+             "frame_count": 3, "filters_used": ["H-alpha", "OIII"],
+             "median_hfr": 2.1, "median_eccentricity": 0.42},
         ],
         "matched_sessions": None,
         "total_sessions": None,
@@ -222,7 +224,8 @@ EXPECTED_TARGETS = {
         "equipment": ["ASI2600MM Pro", "Esprit 100"],
         "sessions": [
             {"session_date": "2024-01-10", "integration_seconds": 180.0,
-             "frame_count": 1, "filters_used": ["OIII"]},
+             "frame_count": 1, "filters_used": ["OIII"],
+             "median_hfr": None, "median_eccentricity": None},
         ],
         "matched_sessions": None,
         "total_sessions": None,
@@ -241,7 +244,8 @@ EXPECTED_TARGETS = {
         "equipment": ["ASI2600MM Pro", "Esprit 100"],
         "sessions": [
             {"session_date": "2024-01-12", "integration_seconds": 90.0,
-             "frame_count": 1, "filters_used": ["H-alpha"]},
+             "frame_count": 1, "filters_used": ["H-alpha"],
+             "median_hfr": None, "median_eccentricity": None},
         ],
         "matched_sessions": None,
         "total_sessions": None,
@@ -272,6 +276,38 @@ async def test_full_response_parity(seeded_db):
     assert len(data["targets"]) == 3
     for t in data["targets"]:
         assert t == EXPECTED_TARGETS[t["target_id"]], t["target_id"]
+
+
+@pytest.mark.asyncio
+async def test_session_summary_includes_quality_medians(seeded_db):
+    """Each session in a target's `sessions` list now carries per-session
+    median_hfr and median_eccentricity (sharpness + roundness), computed over
+    that session's frame metrics ignoring nulls. Sessions with no frame metrics
+    report None for both."""
+    data = await _get("?sort_by=integration&sort_dir=desc")
+    m31 = _by_id(data, str(TID_M31))
+
+    sessions = {s["session_date"]: s for s in m31["sessions"]}
+
+    # New keys must be present on every session.
+    for s in m31["sessions"]:
+        assert "median_hfr" in s
+        assert "median_eccentricity" in s
+        assert s["median_hfr"] is None or isinstance(s["median_hfr"], float)
+        assert s["median_eccentricity"] is None or isinstance(s["median_eccentricity"], float)
+
+    # 2024-01-10: hfr median([2.0, 2.2, 2.1]) = 2.1; ecc median([0.40, 0.42, 0.44]) = 0.42
+    assert sessions["2024-01-10"]["median_hfr"] == pytest.approx(2.1)
+    assert sessions["2024-01-10"]["median_eccentricity"] == pytest.approx(0.42)
+
+    # 2024-01-12: single frame hfr 5.0, ecc 0.70.
+    assert sessions["2024-01-12"]["median_hfr"] == pytest.approx(5.0)
+    assert sessions["2024-01-12"]["median_eccentricity"] == pytest.approx(0.70)
+
+    # Targets whose frames carry no metrics report None (no crash).
+    ngc = _by_id(data, "obj:NGC 7000")
+    assert ngc["sessions"][0]["median_hfr"] is None
+    assert ngc["sessions"][0]["median_eccentricity"] is None
 
 
 @pytest.mark.asyncio
@@ -441,6 +477,8 @@ async def test_empty_object_header_collapses_to_uncategorized(seeded_edge_db):
     assert len(uncat["sessions"]) == 1
     assert uncat["sessions"][0]["session_date"] == "2024-02-01"
     assert uncat["sessions"][0]["frame_count"] == 1
+    assert uncat["sessions"][0]["median_hfr"] is None
+    assert uncat["sessions"][0]["median_eccentricity"] is None
     # The empty-string OBJECT must not surface as an alias.
     assert uncat["aliases"] == []
 

--- a/frontend/src/components/EquipmentPerformance.tsx
+++ b/frontend/src/components/EquipmentPerformance.tsx
@@ -1,8 +1,14 @@
-import { Component, For, Show, createSignal } from "solid-js";
+import { Component, For, Show, createMemo, createSignal } from "solid-js";
 import type { EquipmentComboMetrics, EquipmentFilterMetrics } from "../types";
 import FilterBadges from "./FilterBadges";
 
 import { formatIntegration } from "../utils/format";
+import {
+  madZ,
+  bandForZ,
+  bandToCellClass,
+  type MetricBaseline,
+} from "../utils/frameQuality";
 
 function formatMetric(val: number | null, suffix = ""): string {
   if (val === null || val === undefined) return "\u2014";
@@ -11,6 +17,53 @@ function formatMetric(val: number | null, suffix = ""): string {
 
 function metricClass(val: number | null): string {
   return val !== null ? "text-theme-text-primary" : "text-theme-text-secondary";
+}
+
+// Catalog-wide reference for the combo-median tables: a MetricBaseline built from
+// the combo medians across every combo in the list (median of the combo medians;
+// mad = median(|x - median|); n = count of combos with a non-null value).
+interface ComboBaselines {
+  median_hfr: MetricBaseline;
+  median_eccentricity: MetricBaseline;
+  median_fwhm: MetricBaseline;
+}
+
+function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+function baselineOf(values: (number | null)[]): MetricBaseline {
+  const present = values.filter((v): v is number => v !== null && v !== undefined);
+  const med = median(present);
+  const madVal = med === null ? null : median(present.map((v) => Math.abs(v - med)));
+  return { median: med, mad: madVal, n: present.length };
+}
+
+function buildComboBaselines(combos: EquipmentComboMetrics[]): ComboBaselines {
+  return {
+    median_hfr: baselineOf(combos.map((c) => c.median_hfr)),
+    median_eccentricity: baselineOf(combos.map((c) => c.median_eccentricity)),
+    median_fwhm: baselineOf(combos.map((c) => c.median_fwhm)),
+  };
+}
+
+// All three metrics are higher-is-worse. Returns the color class plus a tooltip
+// describing the deviation in sigma; falls back to the neutral default class.
+function deviationCell(
+  val: number | null,
+  base: MetricBaseline,
+  label: string,
+): { class: string; title: string | undefined } {
+  if (val === null || val === undefined) {
+    return { class: "text-theme-text-secondary", title: undefined };
+  }
+  const z = madZ(val, base);
+  const cls = bandToCellClass(bandForZ(z));
+  const title = z === null ? undefined : `${label} ${z.toFixed(1)}\u03c3 vs catalog median`;
+  return { class: cls, title };
 }
 
 const FilterBreakdownRow: Component<{ row: EquipmentFilterMetrics }> = (props) => {
@@ -42,8 +95,11 @@ const FilterBreakdownRow: Component<{ row: EquipmentFilterMetrics }> = (props) =
   );
 };
 
-const ComboRow: Component<{ combo: EquipmentComboMetrics }> = (props) => {
+const ComboRow: Component<{ combo: EquipmentComboMetrics; baselines: ComboBaselines }> = (props) => {
   const [expanded, setExpanded] = createSignal(false);
+  const hfrCell = () => deviationCell(props.combo.median_hfr, props.baselines.median_hfr, "HFR");
+  const eccCell = () => deviationCell(props.combo.median_eccentricity, props.baselines.median_eccentricity, "Ecc");
+  const fwhmCell = () => deviationCell(props.combo.median_fwhm, props.baselines.median_fwhm, "FWHM");
   const dist = () => {
     const d: Record<string, number> = {};
     for (const f of props.combo.filter_breakdown) {
@@ -88,16 +144,16 @@ const ComboRow: Component<{ combo: EquipmentComboMetrics }> = (props) => {
         <td class="text-right text-theme-text-secondary py-1.5 px-2 tabular-nums">
           {formatIntegration(props.combo.total_integration_seconds)}
         </td>
-        <td class={`text-right py-1.5 px-2 tabular-nums ${metricClass(props.combo.median_hfr)}`}>
+        <td class={`text-right py-1.5 px-2 tabular-nums ${hfrCell().class}`} title={hfrCell().title}>
           {formatMetric(props.combo.median_hfr)}
         </td>
         <td class={`text-right py-1.5 px-2 tabular-nums ${metricClass(props.combo.best_hfr)}`}>
           {formatMetric(props.combo.best_hfr)}
         </td>
-        <td class={`text-right py-1.5 px-2 tabular-nums ${metricClass(props.combo.median_eccentricity)}`}>
+        <td class={`text-right py-1.5 px-2 tabular-nums ${eccCell().class}`} title={eccCell().title}>
           {formatMetric(props.combo.median_eccentricity)}
         </td>
-        <td class={`text-right py-1.5 px-2 tabular-nums ${metricClass(props.combo.median_fwhm)}`}>
+        <td class={`text-right py-1.5 px-2 tabular-nums ${fwhmCell().class}`} title={fwhmCell().title}>
           {formatMetric(props.combo.median_fwhm, "\u2033")}
         </td>
         <td class="py-1.5 px-2">
@@ -139,6 +195,7 @@ const ComboRow: Component<{ combo: EquipmentComboMetrics }> = (props) => {
 };
 
 const EquipmentPerformance: Component<{ combos: EquipmentComboMetrics[] }> = (props) => {
+  const baselines = createMemo(() => buildComboBaselines(props.combos));
   return (
     <div class="bg-theme-surface border border-theme-border rounded-[var(--radius-md)] shadow-[var(--shadow-sm)] p-4">
       <h3 class="text-theme-text-primary font-medium text-sm mb-3">Equipment Performance</h3>
@@ -162,7 +219,7 @@ const EquipmentPerformance: Component<{ combos: EquipmentComboMetrics[] }> = (pr
           </thead>
           <tbody>
             <For each={props.combos}>
-              {(combo) => <ComboRow combo={combo} />}
+              {(combo) => <ComboRow combo={combo} baselines={baselines()} />}
             </For>
           </tbody>
         </table>

--- a/frontend/src/components/SessionAccordionCard.reactivity.test.tsx
+++ b/frontend/src/components/SessionAccordionCard.reactivity.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { render, fireEvent } from "@solidjs/testing-library";
+import { createSignal, For } from "solid-js";
+import {
+  madZ,
+  bandForZ,
+  bandToCellClass,
+  type GroupBaseline,
+} from "../utils/frameQuality";
+
+// Regression guard for the Per-Frame Data table reactivity bug.
+//
+// In SessionAccordionCard's renderFrameTable, each row is produced by a <For>
+// callback. <For> does NOT re-run its body when a signal changes, so any
+// mode-dependent color derivation must be a THUNK that is CALLED inside the JSX
+// attribute (e.g. class={bandToCellClass(bandForZ(zHfr()))}). If instead the
+// derivation is a plain const read once at row-creation time, the cell color
+// freezes and never updates when the "Compare to" baseline toggle flips.
+//
+// This test reproduces that exact binding shape with the real frameQuality
+// utilities and asserts the cell class re-tracks the baseline signal. It fails
+// against the const pattern and passes against the thunk pattern.
+
+interface MiniFrame {
+  median_hfr: number;
+}
+
+// Two baselines chosen so the same HFR value lands in different color bands:
+//  - session: z = (2.8 - 2.1) / 0.37 ~ 1.89  -> "watch" -> text-theme-warning
+//  - rig:     z = (2.8 - 2.8) / 0.50 = 0      -> "neutral" -> text-theme-text-primary
+const sessionBaseline: GroupBaseline = {
+  median_hfr: { median: 2.1, mad: 0.37, n: 10 },
+};
+const rigBaseline: GroupBaseline = {
+  median_hfr: { median: 2.8, mad: 0.5, n: 20 },
+};
+
+const frame: MiniFrame = { median_hfr: 2.8 };
+
+function FrameTablePattern() {
+  const [baselineMode, setBaselineMode] = createSignal<"session" | "rig">("session");
+  const baselineFor = () =>
+    baselineMode() === "session" ? sessionBaseline : rigBaseline;
+
+  return (
+    <div>
+      <button data-testid="toggle-rig" onClick={() => setBaselineMode("rig")}>
+        This rig overall
+      </button>
+      <table>
+        <tbody>
+          <For each={[frame]}>
+            {(f) => {
+              // Mirror the fixed pattern: mode-dependent derivation is a thunk
+              // and is invoked inside the class attribute so it re-tracks.
+              const zHfr = () => madZ(f.median_hfr, baselineFor()?.median_hfr);
+              return (
+                <tr>
+                  <td
+                    data-testid="hfr-cell"
+                    class={bandToCellClass(bandForZ(zHfr()))}
+                  >
+                    {f.median_hfr.toFixed(2)}
+                  </td>
+                </tr>
+              );
+            }}
+          </For>
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+describe("Per-Frame table baseline-toggle reactivity", () => {
+  it("recolors the cell when the comparison baseline changes", () => {
+    const { getByTestId } = render(() => <FrameTablePattern />);
+    const cell = getByTestId("hfr-cell");
+
+    // Session baseline -> "watch" band.
+    expect(cell.className).toBe("text-theme-warning");
+
+    fireEvent.click(getByTestId("toggle-rig"));
+
+    // Rig baseline -> "neutral" band. The class must have re-evaluated.
+    expect(cell.className).toBe("text-theme-text-primary");
+    expect(cell.className).not.toBe("text-theme-warning");
+  });
+});

--- a/frontend/src/components/SessionAccordionCard.tsx
+++ b/frontend/src/components/SessionAccordionCard.tsx
@@ -14,6 +14,15 @@ import { ClickableFilePath } from "./ClickableFilePath";
 
 import { formatIntegration } from "../utils/format";
 import { showToast } from "./Toast";
+import {
+  madZ,
+  bandForZ,
+  combinedScore,
+  bandToCellClass,
+  scoreToRowClass,
+  type GroupBaseline,
+  type QualityBand,
+} from "../utils/frameQuality";
 
 const INSIGHT_STYLES: Record<string, string> = {
   good: "text-theme-success",
@@ -59,6 +68,7 @@ const SessionAccordionCard: Component<{
   const [showSummary, setShowSummary] = createSignal(true);
   const [showInsights, setShowInsights] = createSignal(true);
   const [showFrames, setShowFrames] = createSignal(false);
+  const [baselineMode, setBaselineMode] = createSignal<"session" | "rig">("session");
   const [sortColumn, setSortColumn] = createSignal<keyof FrameRecord>("timestamp");
   const [sortAsc, setSortAsc] = createSignal(true);
   const [csvCopiedRig, setCsvCopiedRig] = createSignal<string | null>(null);
@@ -247,23 +257,113 @@ const SessionAccordionCard: Component<{
     }
   };
 
-  const isHfrOutlier = (frame: FrameRecord, medianHfr?: number | null): boolean => {
-    const med = medianHfr ?? props.detail?.median_hfr;
-    if (!med || !frame.median_hfr) return false;
-    return frame.median_hfr > med * 1.5;
+  // Build the train+filter group key matching the backend: "telescope|camera|filter".
+  // The frame record itself does not carry telescope/camera, so they are supplied
+  // from the rig (multi-rig) or the session equipment (single-rig).
+  const frameGroupKey = (frame: FrameRecord, telescope?: string | null, camera?: string | null): string =>
+    `${telescope ?? ""}|${camera ?? ""}|${frame.filter_used ?? ""}`;
+
+  // Resolve the active baseline group for a frame. The selected mode picks the
+  // sharpness/roundness baselines (session vs rig), but cause-metrics
+  // (adu_median, detected_stars, guiding_rms_arcsec) are ALWAYS session-scoped
+  // because they drift nightly with sky conditions.
+  const baselineFor = (
+    frame: FrameRecord,
+    telescope?: string | null,
+    camera?: string | null,
+  ): GroupBaseline | undefined => {
+    const key = frameGroupKey(frame, telescope, camera);
+    const maps = props.detail;
+    if (!maps) return undefined;
+    return baselineMode() === "session" ? maps.session_baselines[key] : maps.rig_baselines[key];
   };
 
-  const isEccOutlier = (frame: FrameRecord, medianEcc?: number | null): boolean => {
-    const med = medianEcc ?? props.detail?.median_eccentricity;
-    if (!med || !frame.eccentricity) return false;
-    return frame.eccentricity > med * 1.5;
+  const sessionBaselineFor = (
+    frame: FrameRecord,
+    telescope?: string | null,
+    camera?: string | null,
+  ): GroupBaseline | undefined => {
+    const key = frameGroupKey(frame, telescope, camera);
+    return props.detail?.session_baselines[key];
   };
 
-  const isOutlier = (frame: FrameRecord, medianHfr?: number | null, medianEcc?: number | null): boolean => {
-    return isHfrOutlier(frame, medianHfr) || isEccOutlier(frame, medianEcc);
+  // Tooltip text describing a colored cell: value, direction, baseline median,
+  // active mode, and the z to one decimal. Returns "" when the cell is neutral
+  // (no usable baseline), so no misleading tooltip is shown.
+  const cellTooltip = (
+    label: string,
+    value: number | null | undefined,
+    z: number | null,
+    median: number | null | undefined,
+    mode: string,
+    formatter: (v: number) => string,
+  ): string => {
+    if (z == null || value == null || median == null) return "";
+    const direction = z > 0 ? "worse" : "better";
+    return `${label} ${formatter(value)} — ${Math.abs(z).toFixed(1)}σ ${direction} than ${mode} median ${formatter(median)}`;
   };
 
-  const renderFrameTable = (frames: FrameRecord[], medianHfr?: number | null, medianEcc?: number | null) => {
+  // Per-frame combined 0-100 score from signal (stars, higher-is-better),
+  // sharpness (hfr) and roundness (eccentricity) against the active baseline.
+  const frameScore = (
+    frame: FrameRecord,
+    telescope?: string | null,
+    camera?: string | null,
+  ): number | null => {
+    const b = baselineFor(frame, telescope, camera);
+    const sb = sessionBaselineFor(frame, telescope, camera);
+    const zSignal = madZ(frame.detected_stars, sb?.detected_stars, true);
+    const zSharp = madZ(frame.median_hfr, b?.median_hfr);
+    const zRound = madZ(frame.eccentricity, b?.eccentricity);
+    return combinedScore(zSignal, zSharp, zRound);
+  };
+
+  // Resolve the optical train (telescope/camera) for a frame. Multi-rig sessions
+  // carry it on the rig; single-rig falls back to the session equipment.
+  const equipmentForFrame = (frame: FrameRecord): { telescope: string | null; camera: string | null } => {
+    const d = props.detail;
+    if (!d) return { telescope: null, camera: null };
+    if (frame.rig) {
+      const rig = d.rigs.find((r) => r.rig_label === frame.rig);
+      if (rig) return { telescope: rig.telescope, camera: rig.camera };
+    }
+    return { telescope: d.equipment.telescope, camera: d.equipment.camera };
+  };
+
+  // Band the per-frame combined score (mirrors scoreToRowClass thresholds) for
+  // the session distribution strip.
+  const scoreBand = (score: number | null): QualityBand | null => {
+    if (score == null) return null;
+    if (score >= 60) return "better";
+    if (score >= 45) return "neutral";
+    if (score >= 30) return "watch";
+    return "reject";
+  };
+
+  // Session-wide quality distribution + mean score across all frames, recomputed
+  // when the baseline mode flips.
+  const qualitySummary = createMemo(() => {
+    const frames = props.detail?.frames ?? [];
+    let good = 0, watch = 0, reject = 0, scored = 0, sum = 0;
+    for (const frame of frames) {
+      const eq = equipmentForFrame(frame);
+      const score = frameScore(frame, eq.telescope, eq.camera);
+      if (score == null) continue;
+      scored += 1;
+      sum += score;
+      const band = scoreBand(score);
+      if (band === "better" || band === "neutral") good += 1;
+      else if (band === "watch") watch += 1;
+      else if (band === "reject") reject += 1;
+    }
+    return { good, watch, reject, scored, mean: scored > 0 ? sum / scored : null };
+  });
+
+  const renderFrameTable = (
+    frames: FrameRecord[],
+    telescope?: string | null,
+    camera?: string | null,
+  ) => {
     const sorted = createMemo(() => sortedFrames(frames));
     const previewFiles = createMemo(() =>
       sorted().map((f) => ({
@@ -364,24 +464,46 @@ const SessionAccordionCard: Component<{
       </thead>
       <tbody>
         <For each={sorted()}>
-          {(frame, i) => (
-            <tr class={`border-b border-theme-border/30 hover:bg-theme-hover transition-colors duration-100 ${isOutlier(frame, medianHfr, medianEcc) ? "bg-theme-error/20" : ""}`}>
+          {(frame, i) => {
+            const b = baselineFor(frame, telescope, camera);
+            const sb = sessionBaselineFor(frame, telescope, camera);
+            const mode = baselineMode() === "session" ? "session" : "rig";
+            const zHfr = madZ(frame.median_hfr, b?.median_hfr);
+            const zFwhm = madZ(frame.fwhm, b?.fwhm);
+            const zEcc = madZ(frame.eccentricity, b?.eccentricity);
+            const zStars = madZ(frame.detected_stars, sb?.detected_stars, true);
+            const zAdu = madZ(frame.adu_median, sb?.adu_median);
+            const rowClass = scoreToRowClass(frameScore(frame, telescope, camera));
+            return (
+            <tr class={`border-b border-theme-border/30 hover:bg-theme-hover transition-colors duration-100 ${rowClass}`}>
               <td class="py-1 px-2 text-theme-text-primary">{formatTimeUtil(frame.timestamp, settingsCtx.timezone(), settingsCtx.use24hTime())}</td>
               <td class="py-1 px-2 text-theme-text-primary text-center">{frame.filter_used ?? "—"}</td>
               <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.exposure_time ?? "—"}s</td>
               <Show when={visible("quality", "hfr")}>
-                <td class={`py-1 px-2 text-right tabular-nums ${isHfrOutlier(frame, medianHfr) ? "text-theme-error" : "text-theme-text-primary"}`}>
+                <td
+                  class={`py-1 px-2 text-right tabular-nums ${bandToCellClass(bandForZ(zHfr))}`}
+                  title={cellTooltip("HFR", frame.median_hfr, zHfr, b?.median_hfr.median, mode, (v) => v.toFixed(2))}
+                >
                   {frame.median_hfr?.toFixed(2) ?? "\u2014"}
                 </td>
               </Show>
               <Show when={visible("quality", "eccentricity")}>
-                <td class={`py-1 px-2 text-right tabular-nums ${isEccOutlier(frame, medianEcc) ? "text-theme-error" : "text-theme-text-primary"}`}>{frame.eccentricity?.toFixed(2) ?? "\u2014"}</td>
+                <td
+                  class={`py-1 px-2 text-right tabular-nums ${bandToCellClass(bandForZ(zEcc))}`}
+                  title={cellTooltip("Ecc", frame.eccentricity, zEcc, b?.eccentricity.median, mode, (v) => v.toFixed(2))}
+                >{frame.eccentricity?.toFixed(2) ?? "\u2014"}</td>
               </Show>
               <Show when={visible("quality", "fwhm")}>
-                <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.fwhm?.toFixed(2) ?? "\u2014"}</td>
+                <td
+                  class={`py-1 px-2 text-right tabular-nums ${bandToCellClass(bandForZ(zFwhm))}`}
+                  title={cellTooltip("FWHM", frame.fwhm, zFwhm, b?.fwhm.median, mode, (v) => v.toFixed(2))}
+                >{frame.fwhm?.toFixed(2) ?? "\u2014"}</td>
               </Show>
               <Show when={visible("quality", "detected_stars")}>
-                <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.detected_stars ?? "\u2014"}</td>
+                <td
+                  class={`py-1 px-2 text-right tabular-nums ${bandToCellClass(bandForZ(zStars))}`}
+                  title={cellTooltip("Stars", frame.detected_stars, zStars, sb?.detected_stars.median, "session", (v) => v.toFixed(0))}
+                >{frame.detected_stars ?? "\u2014"}</td>
               </Show>
               <Show when={visible("guiding", "rms_total")}>
                 <td class="py-1 px-2 text-theme-text-primary text-right">
@@ -402,7 +524,10 @@ const SessionAccordionCard: Component<{
                 <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.adu_mean?.toFixed(2) ?? "\u2014"}</td>
               </Show>
               <Show when={visible("adu", "median")}>
-                <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.adu_median?.toFixed(2) ?? "\u2014"}</td>
+                <td
+                  class={`py-1 px-2 text-right tabular-nums ${bandToCellClass(bandForZ(zAdu))}`}
+                  title={cellTooltip("ADU Med", frame.adu_median, zAdu, sb?.adu_median.median, "session", (v) => v.toFixed(2))}
+                >{frame.adu_median?.toFixed(2) ?? "\u2014"}</td>
               </Show>
               <Show when={visible("adu", "stdev")}>
                 <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.adu_stdev?.toFixed(2) ?? "\u2014"}</td>
@@ -478,7 +603,8 @@ const SessionAccordionCard: Component<{
                 />
               </td>
             </tr>
-          )}
+            );
+          }}
         </For>
       </tbody>
     </table>
@@ -948,9 +1074,58 @@ const SessionAccordionCard: Component<{
                   <div class={`grid transition-[grid-template-rows] duration-200 ${showFrames() ? "grid-rows-[1fr]" : "grid-rows-[0fr]"}`}>
                     <div class="overflow-hidden">
                       <div class="px-3 pb-3">
+                      {/* Quality grading controls + summary */}
+                      <div class="flex flex-wrap items-center gap-x-4 gap-y-1.5 mb-2 text-tiny">
+                        <div class="flex items-center gap-1.5">
+                          <span class="text-theme-text-tertiary">Compare to:</span>
+                          <div class="inline-flex rounded border border-theme-border overflow-hidden">
+                            <button
+                              class="px-2 py-0.5 transition-colors cursor-pointer"
+                              classList={{
+                                "bg-theme-accent/20 text-theme-accent font-semibold": baselineMode() === "session",
+                                "text-theme-text-tertiary hover:text-theme-text-primary": baselineMode() !== "session",
+                              }}
+                              onClick={() => setBaselineMode("session")}
+                            >
+                              This session
+                            </button>
+                            <button
+                              class="px-2 py-0.5 transition-colors cursor-pointer border-l border-theme-border"
+                              classList={{
+                                "bg-theme-accent/20 text-theme-accent font-semibold": baselineMode() === "rig",
+                                "text-theme-text-tertiary hover:text-theme-text-primary": baselineMode() !== "rig",
+                              }}
+                              onClick={() => setBaselineMode("rig")}
+                            >
+                              This rig overall
+                            </button>
+                          </div>
+                        </div>
+                        <Show when={qualitySummary().scored > 0}>
+                          <div class="flex items-center gap-2 text-theme-text-secondary">
+                            <span class="text-theme-success">{qualitySummary().good} good</span>
+                            <span class="text-theme-text-tertiary">·</span>
+                            <span class="text-theme-warning">{qualitySummary().watch} watch</span>
+                            <span class="text-theme-text-tertiary">·</span>
+                            <span class="text-theme-error">{qualitySummary().reject} reject</span>
+                            <Show when={qualitySummary().mean !== null}>
+                              <span class="text-theme-text-tertiary">·</span>
+                              <span class="text-theme-text-secondary">mean score {qualitySummary().mean!.toFixed(0)}</span>
+                            </Show>
+                          </div>
+                        </Show>
+                      </div>
+                      {/* Legend + advisory */}
+                      <div class="flex flex-wrap items-center gap-x-3 gap-y-0.5 mb-2 text-tiny text-theme-text-tertiary">
+                        <span class="flex items-center gap-1"><span class="text-theme-success">●</span> better</span>
+                        <span class="flex items-center gap-1"><span class="text-theme-text-primary">●</span> neutral</span>
+                        <span class="flex items-center gap-1"><span class="text-theme-warning">●</span> watch</span>
+                        <span class="flex items-center gap-1"><span class="text-theme-error">●</span> reject</span>
+                        <span class="italic">Advisory only; no frames are deleted or hidden.</span>
+                      </div>
                       <Show when={isMultiRig()} fallback={
                         <div class="overflow-x-auto max-h-[600px] overflow-y-auto">
-                          {renderFrameTable(props.detail!.frames, props.detail!.median_hfr, props.detail!.median_eccentricity)}
+                          {renderFrameTable(props.detail!.frames, props.detail!.equipment.telescope, props.detail!.equipment.camera)}
                         </div>
                       }>
                         <For each={props.detail!.rigs}>
@@ -964,7 +1139,7 @@ const SessionAccordionCard: Component<{
                                   <span class="text-tiny text-theme-text-tertiary">{rig.frame_count} frames</span>
                                 </div>
                                 <div class="overflow-x-auto max-h-[600px] overflow-y-auto">
-                                  {renderFrameTable(rig.frames, rig.median_hfr, rig.median_eccentricity)}
+                                  {renderFrameTable(rig.frames, rig.telescope, rig.camera)}
                                 </div>
                               </div>
                             </Show>

--- a/frontend/src/components/SessionAccordionCard.tsx
+++ b/frontend/src/components/SessionAccordionCard.tsx
@@ -11,6 +11,7 @@ import { isFieldVisible, isColumnVisible } from "../utils/displaySettings";
 import InlineEditCell from "./InlineEditCell";
 import { formatTime as formatTimeUtil, timezoneLabel } from "../utils/dateTime";
 import { ClickableFilePath } from "./ClickableFilePath";
+import HelpPopover from "./HelpPopover";
 
 import { formatIntegration } from "../utils/format";
 import { showToast } from "./Toast";
@@ -1100,6 +1101,14 @@ const SessionAccordionCard: Component<{
                               This rig overall
                             </button>
                           </div>
+                          <HelpPopover title="Per-Frame Data grading" label="About per-frame grading">
+                            <p>Each frame is graded by how far its metrics deviate from a typical baseline, not against a fixed threshold.</p>
+                            <p><strong>Compare to</strong> picks the baseline. <em>This session</em> compares each frame to the other frames captured the same night. <em>This rig overall</em> compares to this target's long-run average for the same telescope, camera, and filter.</p>
+                            <p>Deviation is measured in robust sigma units (median absolute deviation from the median), the same approach PixInsight SubframeSelector uses. It stays reliable on small sessions.</p>
+                            <p>Color shows the verdict, in both directions: green means clearly better than typical, no color means normal, amber means moderately worse (watch), red means far worse (likely reject).</p>
+                            <p>Signal-related metrics (star count, background ADU, guiding) are always compared within the same night because they drift with sky conditions, regardless of the toggle.</p>
+                            <p>Grading is advisory only. No frames are deleted or hidden.</p>
+                          </HelpPopover>
                         </div>
                         <Show when={qualitySummary().scored > 0}>
                           <div class="flex items-center gap-2 text-theme-text-secondary">

--- a/frontend/src/components/SessionAccordionCard.tsx
+++ b/frontend/src/components/SessionAccordionCard.tsx
@@ -1103,7 +1103,7 @@ const SessionAccordionCard: Component<{
                           </div>
                           <HelpPopover title="Per-Frame Data grading" label="About per-frame grading">
                             <p>Each frame is graded by how far its metrics deviate from a typical baseline, not against a fixed threshold.</p>
-                            <p><strong>Compare to</strong> picks the baseline. <em>This session</em> compares each frame to the other frames captured the same night. <em>This rig overall</em> compares to this target's long-run average for the same telescope, camera, and filter.</p>
+                            <p><strong>Compare to</strong> picks the baseline. <em>This session</em> compares each frame to the other frames captured the same night. <em>This rig overall</em> compares each frame to all frames captured with the same telescope, camera, and filter across your whole catalog, regardless of target.</p>
                             <p>Deviation is measured in robust sigma units (median absolute deviation from the median), the same approach PixInsight SubframeSelector uses. It stays reliable on small sessions.</p>
                             <p>Color shows the verdict, in both directions: green means clearly better than typical, no color means normal, amber means moderately worse (watch), red means far worse (likely reject).</p>
                             <p>Signal-related metrics (star count, background ADU, guiding) are always compared within the same night because they drift with sky conditions, regardless of the toggle.</p>

--- a/frontend/src/components/SessionAccordionCard.tsx
+++ b/frontend/src/components/SessionAccordionCard.tsx
@@ -466,44 +466,48 @@ const SessionAccordionCard: Component<{
       <tbody>
         <For each={sorted()}>
           {(frame, i) => {
-            const b = baselineFor(frame, telescope, camera);
-            const sb = sessionBaselineFor(frame, telescope, camera);
-            const mode = baselineMode() === "session" ? "session" : "rig";
-            const zHfr = madZ(frame.median_hfr, b?.median_hfr);
-            const zFwhm = madZ(frame.fwhm, b?.fwhm);
-            const zEcc = madZ(frame.eccentricity, b?.eccentricity);
-            const zStars = madZ(frame.detected_stars, sb?.detected_stars, true);
-            const zAdu = madZ(frame.adu_median, sb?.adu_median);
-            const rowClass = scoreToRowClass(frameScore(frame, telescope, camera));
+            // Mode-dependent derivations must be thunks so the JSX attribute
+            // effects re-track baselineMode() when the comparison toggle flips.
+            // <For> does not re-run this body on signal changes, so a plain const
+            // would freeze the color/tooltip at row-creation time.
+            const b = () => baselineFor(frame, telescope, camera);
+            const sb = () => sessionBaselineFor(frame, telescope, camera);
+            const mode = () => (baselineMode() === "session" ? "session" : "rig");
+            const zHfr = () => madZ(frame.median_hfr, b()?.median_hfr);
+            const zFwhm = () => madZ(frame.fwhm, b()?.fwhm);
+            const zEcc = () => madZ(frame.eccentricity, b()?.eccentricity);
+            const zStars = () => madZ(frame.detected_stars, sb()?.detected_stars, true);
+            const zAdu = () => madZ(frame.adu_median, sb()?.adu_median);
+            const rowClass = () => scoreToRowClass(frameScore(frame, telescope, camera));
             return (
-            <tr class={`border-b border-theme-border/30 hover:bg-theme-hover transition-colors duration-100 ${rowClass}`}>
+            <tr class={`border-b border-theme-border/30 hover:bg-theme-hover transition-colors duration-100 ${rowClass()}`}>
               <td class="py-1 px-2 text-theme-text-primary">{formatTimeUtil(frame.timestamp, settingsCtx.timezone(), settingsCtx.use24hTime())}</td>
               <td class="py-1 px-2 text-theme-text-primary text-center">{frame.filter_used ?? "—"}</td>
               <td class="py-1 px-2 text-theme-text-primary text-right tabular-nums">{frame.exposure_time ?? "—"}s</td>
               <Show when={visible("quality", "hfr")}>
                 <td
-                  class={`py-1 px-2 text-right tabular-nums ${bandToCellClass(bandForZ(zHfr))}`}
-                  title={cellTooltip("HFR", frame.median_hfr, zHfr, b?.median_hfr.median, mode, (v) => v.toFixed(2))}
+                  class={`py-1 px-2 text-right tabular-nums ${bandToCellClass(bandForZ(zHfr()))}`}
+                  title={cellTooltip("HFR", frame.median_hfr, zHfr(), b()?.median_hfr.median, mode(), (v) => v.toFixed(2))}
                 >
                   {frame.median_hfr?.toFixed(2) ?? "\u2014"}
                 </td>
               </Show>
               <Show when={visible("quality", "eccentricity")}>
                 <td
-                  class={`py-1 px-2 text-right tabular-nums ${bandToCellClass(bandForZ(zEcc))}`}
-                  title={cellTooltip("Ecc", frame.eccentricity, zEcc, b?.eccentricity.median, mode, (v) => v.toFixed(2))}
+                  class={`py-1 px-2 text-right tabular-nums ${bandToCellClass(bandForZ(zEcc()))}`}
+                  title={cellTooltip("Ecc", frame.eccentricity, zEcc(), b()?.eccentricity.median, mode(), (v) => v.toFixed(2))}
                 >{frame.eccentricity?.toFixed(2) ?? "\u2014"}</td>
               </Show>
               <Show when={visible("quality", "fwhm")}>
                 <td
-                  class={`py-1 px-2 text-right tabular-nums ${bandToCellClass(bandForZ(zFwhm))}`}
-                  title={cellTooltip("FWHM", frame.fwhm, zFwhm, b?.fwhm.median, mode, (v) => v.toFixed(2))}
+                  class={`py-1 px-2 text-right tabular-nums ${bandToCellClass(bandForZ(zFwhm()))}`}
+                  title={cellTooltip("FWHM", frame.fwhm, zFwhm(), b()?.fwhm.median, mode(), (v) => v.toFixed(2))}
                 >{frame.fwhm?.toFixed(2) ?? "\u2014"}</td>
               </Show>
               <Show when={visible("quality", "detected_stars")}>
                 <td
-                  class={`py-1 px-2 text-right tabular-nums ${bandToCellClass(bandForZ(zStars))}`}
-                  title={cellTooltip("Stars", frame.detected_stars, zStars, sb?.detected_stars.median, "session", (v) => v.toFixed(0))}
+                  class={`py-1 px-2 text-right tabular-nums ${bandToCellClass(bandForZ(zStars()))}`}
+                  title={cellTooltip("Stars", frame.detected_stars, zStars(), sb()?.detected_stars.median, "session", (v) => v.toFixed(0))}
                 >{frame.detected_stars ?? "\u2014"}</td>
               </Show>
               <Show when={visible("guiding", "rms_total")}>
@@ -526,8 +530,8 @@ const SessionAccordionCard: Component<{
               </Show>
               <Show when={visible("adu", "median")}>
                 <td
-                  class={`py-1 px-2 text-right tabular-nums ${bandToCellClass(bandForZ(zAdu))}`}
-                  title={cellTooltip("ADU Med", frame.adu_median, zAdu, sb?.adu_median.median, "session", (v) => v.toFixed(2))}
+                  class={`py-1 px-2 text-right tabular-nums ${bandToCellClass(bandForZ(zAdu()))}`}
+                  title={cellTooltip("ADU Med", frame.adu_median, zAdu(), sb()?.adu_median.median, "session", (v) => v.toFixed(2))}
                 >{frame.adu_median?.toFixed(2) ?? "\u2014"}</td>
               </Show>
               <Show when={visible("adu", "stdev")}>

--- a/frontend/src/components/SessionAccordionCard.tsx
+++ b/frontend/src/components/SessionAccordionCard.tsx
@@ -375,7 +375,7 @@ const SessionAccordionCard: Component<{
     );
     return (
     <table class="w-full text-label">
-      <thead class="sticky top-0 bg-theme-base">
+      <thead class="sticky top-0 z-10 glass-popover">
         <tr class="text-theme-text-secondary border-b border-theme-border">
           <SortHeader label={`Time (${timezoneLabel(settingsCtx.timezone())})`} column="timestamp" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} />
           <SortHeader label="Filter" column="filter_used" current={sortColumn()} asc={sortAsc()} onSort={toggleSort} align="center" />

--- a/frontend/src/components/TargetRow.tsx
+++ b/frontend/src/components/TargetRow.tsx
@@ -1,7 +1,6 @@
 import { Component, Show, For, createMemo } from "solid-js";
 import { A, useNavigate } from "@solidjs/router";
 import type { TargetAggregation } from "../types";
-import type { TargetAnomaly } from "./TargetTable";
 import { useCatalog } from "../store/catalog";
 import { useSettingsContext } from "./SettingsProvider";
 import { isColumnVisible } from "../utils/displaySettings";
@@ -13,7 +12,6 @@ import { api } from "../api/client";
 
 const TargetRow: Component<{
   target: TargetAggregation;
-  anomaly?: TargetAnomaly | null;
 }> = (props) => {
   const { expandedTargets, toggleExpanded } = useCatalog();
   const navigate = useNavigate();
@@ -25,23 +23,6 @@ const TargetRow: Component<{
 
   const displayName = () =>
     props.target.aliases[0] || props.target.primary_name;
-
-  // Small unobtrusive anomaly dot. warning -> watch, error -> reject; neutral
-  // and better targets carry no `anomaly` and render nothing.
-  const AnomalyDot: Component = () => (
-    <Show when={props.anomaly}>
-      {(a) => (
-        <span
-          class={`inline-block w-2 h-2 rounded-full flex-shrink-0 ${
-            a().band === "reject" ? "bg-theme-error" : "bg-theme-warning"
-          }`}
-          title={a().title}
-          aria-label={a().title}
-          onClick={(e) => e.stopPropagation()}
-        />
-      )}
-    </Show>
-  );
 
   const lastSession = createMemo(() => {
     const sorted = [...props.target.sessions].sort(
@@ -63,7 +44,6 @@ const TargetRow: Component<{
             : "text-theme-text-primary"
         }`}>
           <span class="inline-flex items-center gap-1.5">
-            <AnomalyDot />
             {displayName()}
             {props.target.mosaic_id && (
               <A href={`/mosaics/${props.target.mosaic_id}`} class="text-theme-accent" title={`Mosaic: ${props.target.mosaic_name}`} onClick={(e) => e.stopPropagation()}>
@@ -144,7 +124,6 @@ const TargetRow: Component<{
                   ? "text-theme-text-tertiary italic"
                   : "text-theme-text-primary"
               }`}>
-                <AnomalyDot />
                 {displayName()}
                 {props.target.mosaic_id && (
                   <A href={`/mosaics/${props.target.mosaic_id}`} class="text-theme-accent" title={`Mosaic: ${props.target.mosaic_name}`} onClick={(e) => e.stopPropagation()}>

--- a/frontend/src/components/TargetRow.tsx
+++ b/frontend/src/components/TargetRow.tsx
@@ -1,6 +1,7 @@
 import { Component, Show, For, createMemo } from "solid-js";
 import { A, useNavigate } from "@solidjs/router";
 import type { TargetAggregation } from "../types";
+import type { TargetAnomaly } from "./TargetTable";
 import { useCatalog } from "../store/catalog";
 import { useSettingsContext } from "./SettingsProvider";
 import { isColumnVisible } from "../utils/displaySettings";
@@ -12,6 +13,7 @@ import { api } from "../api/client";
 
 const TargetRow: Component<{
   target: TargetAggregation;
+  anomaly?: TargetAnomaly | null;
 }> = (props) => {
   const { expandedTargets, toggleExpanded } = useCatalog();
   const navigate = useNavigate();
@@ -23,6 +25,23 @@ const TargetRow: Component<{
 
   const displayName = () =>
     props.target.aliases[0] || props.target.primary_name;
+
+  // Small unobtrusive anomaly dot. warning -> watch, error -> reject; neutral
+  // and better targets carry no `anomaly` and render nothing.
+  const AnomalyDot: Component = () => (
+    <Show when={props.anomaly}>
+      {(a) => (
+        <span
+          class={`inline-block w-2 h-2 rounded-full flex-shrink-0 ${
+            a().band === "reject" ? "bg-theme-error" : "bg-theme-warning"
+          }`}
+          title={a().title}
+          aria-label={a().title}
+          onClick={(e) => e.stopPropagation()}
+        />
+      )}
+    </Show>
+  );
 
   const lastSession = createMemo(() => {
     const sorted = [...props.target.sessions].sort(
@@ -44,6 +63,7 @@ const TargetRow: Component<{
             : "text-theme-text-primary"
         }`}>
           <span class="inline-flex items-center gap-1.5">
+            <AnomalyDot />
             {displayName()}
             {props.target.mosaic_id && (
               <A href={`/mosaics/${props.target.mosaic_id}`} class="text-theme-accent" title={`Mosaic: ${props.target.mosaic_name}`} onClick={(e) => e.stopPropagation()}>
@@ -124,6 +144,7 @@ const TargetRow: Component<{
                   ? "text-theme-text-tertiary italic"
                   : "text-theme-text-primary"
               }`}>
+                <AnomalyDot />
                 {displayName()}
                 {props.target.mosaic_id && (
                   <A href={`/mosaics/${props.target.mosaic_id}`} class="text-theme-accent" title={`Mosaic: ${props.target.mosaic_name}`} onClick={(e) => e.stopPropagation()}>

--- a/frontend/src/components/TargetTable.tsx
+++ b/frontend/src/components/TargetTable.tsx
@@ -1,80 +1,11 @@
 import { Component, For, Show, createMemo } from "solid-js";
-import type { TargetAggregation, SessionSummary } from "../types";
+import type { TargetAggregation } from "../types";
 import TargetRow from "./TargetRow";
 import ColumnPicker from "./ColumnPicker";
 import { useSettingsContext } from "./SettingsProvider";
 import { isColumnVisible } from "../utils/displaySettings";
 import { timezoneLabel } from "../utils/dateTime";
 import { useDashboardFilters, type SortKey } from "./DashboardFilterProvider";
-import {
-  type MetricBaseline,
-  type QualityBand,
-  madZ,
-  bandForZ,
-} from "../utils/frameQuality";
-
-// Anomaly badge metadata attached to a target row. `null` band -> render nothing.
-export interface TargetAnomaly {
-  band: QualityBand;
-  title: string;
-}
-
-function median(xs: number[]): number {
-  const s = [...xs].sort((a, b) => a - b);
-  const m = Math.floor(s.length / 2);
-  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
-}
-
-// Build a robust MAD baseline from the per-session medians supplied. The
-// median-of-medians and MAD give a filter-agnostic reference for the metric
-// across every session currently shown on the dashboard.
-function baselineFrom(values: (number | null)[]): MetricBaseline {
-  const xs = values.filter((v): v is number => v != null && Number.isFinite(v));
-  if (xs.length === 0) return { median: null, mad: null, n: 0 };
-  const med = median(xs);
-  const mad = median(xs.map((x) => Math.abs(x - med)));
-  return { median: med, mad, n: xs.length };
-}
-
-// Pick the session used to characterize a target's recent quality: the most
-// recent session that carries at least one quality median (sharpness or
-// roundness). Falls back to the newest session, or null when there are none.
-function recentQualitySession(t: TargetAggregation): SessionSummary | null {
-  const sorted = [...t.sessions].sort((a, b) => b.session_date.localeCompare(a.session_date));
-  for (const s of sorted) {
-    if (s.median_hfr != null || s.median_eccentricity != null) return s;
-  }
-  return sorted[0] ?? null;
-}
-
-const BAND_RANK: Record<QualityBand, number> = { better: 0, neutral: 1, watch: 2, reject: 3 };
-
-// Evaluate a target's recent session against the dashboard-wide baselines.
-// Both HFR and eccentricity are higher-is-worse; the badge takes the worse of
-// the two bands. Returns null for neutral/better (no badge rendered).
-function anomalyFor(
-  t: TargetAggregation,
-  hfrRef: MetricBaseline,
-  eccRef: MetricBaseline,
-): TargetAnomaly | null {
-  const s = recentQualitySession(t);
-  if (!s) return null;
-
-  const zHfr = madZ(s.median_hfr, hfrRef);
-  const zEcc = madZ(s.median_eccentricity, eccRef);
-  const bHfr = bandForZ(zHfr);
-  const bEcc = bandForZ(zEcc);
-
-  const worst: QualityBand = BAND_RANK[bHfr] >= BAND_RANK[bEcc] ? bHfr : bEcc;
-  if (worst !== "watch" && worst !== "reject") return null;
-
-  const parts: string[] = [];
-  if (zHfr != null && bHfr === worst) parts.push(`HFR ${zHfr.toFixed(1)}σ above typical`);
-  if (zEcc != null && bEcc === worst) parts.push(`eccentricity ${zEcc.toFixed(1)}σ above typical`);
-  const detail = parts.length ? parts.join(", ") : "elevated relative to other sessions";
-  const verb = worst === "reject" ? "stands out sharply" : "to watch";
-  return { band: worst, title: `Recent session ${verb}: ${detail}` };
-}
 
 function getLastSession(t: TargetAggregation): string {
   if (t.sessions.length === 0) return "";
@@ -106,28 +37,6 @@ const TargetTable: Component<{ targets: TargetAggregation[] }> = (props) => {
       return dir === "asc" ? cmp : -cmp;
     });
     return sorted;
-  });
-
-  // Dashboard-wide quality reference: median-of-session-medians + MAD for HFR
-  // and eccentricity across every target currently shown. Both are roughly
-  // filter-agnostic, unlike star count / ADU / SNR which SessionSummary mixes
-  // across filters. madZ self-guards when n < MIN_GROUP, so a sparse page
-  // yields no badges rather than noise.
-  const qualityRefs = createMemo(() => {
-    const hfr: (number | null)[] = [];
-    const ecc: (number | null)[] = [];
-    for (const t of props.targets) {
-      for (const s of t.sessions) {
-        hfr.push(s.median_hfr);
-        ecc.push(s.median_eccentricity);
-      }
-    }
-    return { hfr: baselineFrom(hfr), ecc: baselineFrom(ecc) };
-  });
-
-  const anomalyFn = createMemo(() => {
-    const refs = qualityRefs();
-    return (t: TargetAggregation) => anomalyFor(t, refs.hfr, refs.ecc);
   });
 
   const arrow = (key: SortKey) => {
@@ -216,7 +125,7 @@ const TargetTable: Component<{ targets: TargetAggregation[] }> = (props) => {
       <tbody>
         <For each={sortedTargets()}>
           {(target) => (
-            <TargetRow target={target} anomaly={anomalyFn()(target)} />
+            <TargetRow target={target} />
           )}
         </For>
       </tbody>

--- a/frontend/src/components/TargetTable.tsx
+++ b/frontend/src/components/TargetTable.tsx
@@ -1,11 +1,80 @@
 import { Component, For, Show, createMemo } from "solid-js";
-import type { TargetAggregation } from "../types";
+import type { TargetAggregation, SessionSummary } from "../types";
 import TargetRow from "./TargetRow";
 import ColumnPicker from "./ColumnPicker";
 import { useSettingsContext } from "./SettingsProvider";
 import { isColumnVisible } from "../utils/displaySettings";
 import { timezoneLabel } from "../utils/dateTime";
 import { useDashboardFilters, type SortKey } from "./DashboardFilterProvider";
+import {
+  type MetricBaseline,
+  type QualityBand,
+  madZ,
+  bandForZ,
+} from "../utils/frameQuality";
+
+// Anomaly badge metadata attached to a target row. `null` band -> render nothing.
+export interface TargetAnomaly {
+  band: QualityBand;
+  title: string;
+}
+
+function median(xs: number[]): number {
+  const s = [...xs].sort((a, b) => a - b);
+  const m = Math.floor(s.length / 2);
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+}
+
+// Build a robust MAD baseline from the per-session medians supplied. The
+// median-of-medians and MAD give a filter-agnostic reference for the metric
+// across every session currently shown on the dashboard.
+function baselineFrom(values: (number | null)[]): MetricBaseline {
+  const xs = values.filter((v): v is number => v != null && Number.isFinite(v));
+  if (xs.length === 0) return { median: null, mad: null, n: 0 };
+  const med = median(xs);
+  const mad = median(xs.map((x) => Math.abs(x - med)));
+  return { median: med, mad, n: xs.length };
+}
+
+// Pick the session used to characterize a target's recent quality: the most
+// recent session that carries at least one quality median (sharpness or
+// roundness). Falls back to the newest session, or null when there are none.
+function recentQualitySession(t: TargetAggregation): SessionSummary | null {
+  const sorted = [...t.sessions].sort((a, b) => b.session_date.localeCompare(a.session_date));
+  for (const s of sorted) {
+    if (s.median_hfr != null || s.median_eccentricity != null) return s;
+  }
+  return sorted[0] ?? null;
+}
+
+const BAND_RANK: Record<QualityBand, number> = { better: 0, neutral: 1, watch: 2, reject: 3 };
+
+// Evaluate a target's recent session against the dashboard-wide baselines.
+// Both HFR and eccentricity are higher-is-worse; the badge takes the worse of
+// the two bands. Returns null for neutral/better (no badge rendered).
+function anomalyFor(
+  t: TargetAggregation,
+  hfrRef: MetricBaseline,
+  eccRef: MetricBaseline,
+): TargetAnomaly | null {
+  const s = recentQualitySession(t);
+  if (!s) return null;
+
+  const zHfr = madZ(s.median_hfr, hfrRef);
+  const zEcc = madZ(s.median_eccentricity, eccRef);
+  const bHfr = bandForZ(zHfr);
+  const bEcc = bandForZ(zEcc);
+
+  const worst: QualityBand = BAND_RANK[bHfr] >= BAND_RANK[bEcc] ? bHfr : bEcc;
+  if (worst !== "watch" && worst !== "reject") return null;
+
+  const parts: string[] = [];
+  if (zHfr != null && bHfr === worst) parts.push(`HFR ${zHfr.toFixed(1)}σ above typical`);
+  if (zEcc != null && bEcc === worst) parts.push(`eccentricity ${zEcc.toFixed(1)}σ above typical`);
+  const detail = parts.length ? parts.join(", ") : "elevated relative to other sessions";
+  const verb = worst === "reject" ? "stands out sharply" : "to watch";
+  return { band: worst, title: `Recent session ${verb}: ${detail}` };
+}
 
 function getLastSession(t: TargetAggregation): string {
   if (t.sessions.length === 0) return "";
@@ -37,6 +106,28 @@ const TargetTable: Component<{ targets: TargetAggregation[] }> = (props) => {
       return dir === "asc" ? cmp : -cmp;
     });
     return sorted;
+  });
+
+  // Dashboard-wide quality reference: median-of-session-medians + MAD for HFR
+  // and eccentricity across every target currently shown. Both are roughly
+  // filter-agnostic, unlike star count / ADU / SNR which SessionSummary mixes
+  // across filters. madZ self-guards when n < MIN_GROUP, so a sparse page
+  // yields no badges rather than noise.
+  const qualityRefs = createMemo(() => {
+    const hfr: (number | null)[] = [];
+    const ecc: (number | null)[] = [];
+    for (const t of props.targets) {
+      for (const s of t.sessions) {
+        hfr.push(s.median_hfr);
+        ecc.push(s.median_eccentricity);
+      }
+    }
+    return { hfr: baselineFrom(hfr), ecc: baselineFrom(ecc) };
+  });
+
+  const anomalyFn = createMemo(() => {
+    const refs = qualityRefs();
+    return (t: TargetAggregation) => anomalyFor(t, refs.hfr, refs.ecc);
   });
 
   const arrow = (key: SortKey) => {
@@ -125,7 +216,7 @@ const TargetTable: Component<{ targets: TargetAggregation[] }> = (props) => {
       <tbody>
         <For each={sortedTargets()}>
           {(target) => (
-            <TargetRow target={target} />
+            <TargetRow target={target} anomaly={anomalyFn()(target)} />
           )}
         </For>
       </tbody>

--- a/frontend/src/components/analysis/DistributionsTab.tsx
+++ b/frontend/src/components/analysis/DistributionsTab.tsx
@@ -114,7 +114,11 @@ const DistributionsTab: Component<Props> = (props) => {
           </select>
         </div>
         <div style={{ height: "450px" }} class="relative">
-          <HistogramChart data={histData.latest} loading={histData.loading} />
+          <HistogramChart
+            data={histData.latest}
+            loading={histData.loading}
+            baselineMedian={histData.latest?.stats?.median ?? null}
+          />
         </div>
         <Show when={histData.latest?.stats}>
           <div class="mt-3">

--- a/frontend/src/components/analysis/HistogramChart.tsx
+++ b/frontend/src/components/analysis/HistogramChart.tsx
@@ -7,6 +7,27 @@ import { chartFontSize } from "../../utils/chartConfig";
 interface Props {
   data: DistributionResponse | undefined;
   loading: boolean;
+  baselineMedian?: number | null;
+}
+
+// Maps a metric value to a fractional position on the histogram's category axis.
+// Each bin occupies one category slot centered on its integer index; the value is
+// interpolated within its bin. Returns null when the value is outside all bins.
+function medianCategoryIndex(
+  bins: { bin_start: number; bin_end: number }[],
+  value: number,
+): number | null {
+  for (let i = 0; i < bins.length; i++) {
+    const b = bins[i];
+    if (value >= b.bin_start && value <= b.bin_end) {
+      const width = b.bin_end - b.bin_start;
+      const frac = width > 0 ? (value - b.bin_start) / width : 0.5;
+      return i - 0.5 + frac;
+    }
+  }
+  if (value < bins[0].bin_start) return -0.5;
+  if (value > bins[bins.length - 1].bin_end) return bins.length - 0.5;
+  return null;
 }
 
 const HistogramChart: Component<Props> = (props) => {
@@ -20,19 +41,45 @@ const HistogramChart: Component<Props> = (props) => {
     const { bins } = props.data;
     const labels = bins.map((b) => `${b.bin_start.toFixed(1)}`);
 
+    const datasets: any[] = [
+      {
+        label: "Count",
+        data: bins.map((b) => b.count),
+        backgroundColor: "rgba(100, 180, 255, 0.6)",
+        borderColor: "rgba(130, 200, 255, 0.9)",
+        borderWidth: 1,
+      },
+    ];
+
+    // Vertical baseline-median reference line. The x-axis is a category scale, so
+    // the median value is mapped to a fractional category index via the bin centers.
+    const median = props.baselineMedian;
+    if (median != null && bins.length > 0) {
+      const idx = medianCategoryIndex(bins, median);
+      if (idx != null) {
+        const maxCount = Math.max(...bins.map((b) => b.count));
+        datasets.push({
+          label: "Baseline median",
+          type: "line" as const,
+          data: [
+            { x: idx, y: 0 },
+            { x: idx, y: maxCount },
+          ],
+          borderColor: "rgba(200, 210, 220, 0.55)",
+          borderWidth: 1.5,
+          borderDash: [4, 3],
+          pointRadius: 0,
+          pointHoverRadius: 0,
+          fill: false,
+        });
+      }
+    }
+
     chartInstance = new Chart(canvasRef, {
       type: "bar",
       data: {
         labels,
-        datasets: [
-          {
-            label: "Count",
-            data: bins.map((b) => b.count),
-            backgroundColor: "rgba(100, 180, 255, 0.6)",
-            borderColor: "rgba(130, 200, 255, 0.9)",
-            borderWidth: 1,
-          },
-        ],
+        datasets,
       },
       options: {
         responsive: true,
@@ -53,11 +100,13 @@ const HistogramChart: Component<Props> = (props) => {
           tooltip: {
             titleFont: { size: chartFontSize.tooltipTitle() },
             bodyFont: { size: chartFontSize.tooltipBody() },
+            filter: (item) => item.dataset.label !== "Baseline median",
             callbacks: {
               title: (items) => {
                 const i = items[0]?.dataIndex;
                 if (i === undefined) return "";
                 const b = bins[i];
+                if (!b) return "";
                 return `${b.bin_start.toFixed(2)} \u2013 ${b.bin_end.toFixed(2)}`;
               },
             },
@@ -70,6 +119,7 @@ const HistogramChart: Component<Props> = (props) => {
 
   createEffect(() => {
     const _ = props.data;
+    const _m = props.baselineMedian;
     renderChart();
   });
 

--- a/frontend/src/components/analysis/TimeSeriesChart.tsx
+++ b/frontend/src/components/analysis/TimeSeriesChart.tsx
@@ -4,13 +4,22 @@ import "../../utils/chartRegistry";
 import "chartjs-adapter-date-fns";
 import type { TimeSeriesResponse } from "../../types";
 import { chartFontSize } from "../../utils/chartConfig";
+import { madZ, bandForZ, type MetricBaseline } from "../../utils/frameQuality";
 
 interface Props {
   data: TimeSeriesResponse | undefined;
   loading: boolean;
   smoothing: "raw" | "ma7" | "ma30";
   metricLabel?: string;
+  baseline?: MetricBaseline | null;
+  higherIsBetter?: boolean;
 }
+
+// Subtle point tints matching the theme warning/error tokens (watch/reject bands).
+const BAND_POINT_COLOR: Record<string, string | null> = {
+  watch: "rgba(245, 180, 80, 0.85)", // theme-warning (amber)
+  reject: "rgba(245, 110, 110, 0.9)", // theme-error (red)
+};
 
 const TimeSeriesChart: Component<Props> = (props) => {
   let canvasRef: HTMLCanvasElement | undefined;
@@ -21,19 +30,81 @@ const TimeSeriesChart: Component<Props> = (props) => {
     chartInstance?.destroy();
 
     const { points, ma_7, ma_30 } = props.data;
+    const baseline = props.baseline;
+    const higherIsBetter = props.higherIsBetter ?? false;
 
-    const datasets: any[] = [
-      {
-        label: "Nightly Median",
-        data: points.map((p) => ({ x: p.date, y: p.value })),
-        backgroundColor: "rgba(100, 180, 255, 0.6)",
-        borderColor: "rgba(130, 200, 255, 0.8)",
+    const defaultPointColor = "rgba(100, 180, 255, 0.6)";
+    const pointColors = baseline
+      ? points.map((p) => {
+          const band = bandForZ(madZ(p.value, baseline, higherIsBetter));
+          return BAND_POINT_COLOR[band] ?? defaultPointColor;
+        })
+      : defaultPointColor;
+
+    const datasets: any[] = [];
+
+    // Baseline reference bands drawn beneath the points: a filled median ± 1*MAD
+    // band and a fainter median + 3*MAD reject bound. Skipped when the baseline is
+    // too sparse or uniform (baseline === null).
+    if (baseline && baseline.median != null && baseline.mad != null && points.length > 0) {
+      const xs = points.map((p) => p.date);
+      const med = baseline.median;
+      const mad = baseline.mad;
+      const flat = (y: number) => xs.map((x) => ({ x, y }));
+      const lineBase = {
+        type: "line" as const,
+        pointRadius: 0,
+        pointHoverRadius: 0,
+        fill: false,
+        spanGaps: true,
+      };
+      // Reject bound: median + 3*MAD on the "worse" side (and mirror for better metrics).
+      datasets.push({
+        ...lineBase,
+        label: "+3 MAD",
+        data: flat(higherIsBetter ? med - 3 * mad : med + 3 * mad),
+        borderColor: "rgba(245, 110, 110, 0.35)",
         borderWidth: 1,
-        pointRadius: 4,
-        pointHoverRadius: 6,
-        showLine: false,
-      },
-    ];
+        borderDash: [4, 4],
+      });
+      // Upper edge of the ±1 MAD band.
+      datasets.push({
+        ...lineBase,
+        label: "+1 MAD",
+        data: flat(med + mad),
+        borderColor: "rgba(200, 210, 220, 0.25)",
+        borderWidth: 1,
+        backgroundColor: "rgba(120, 190, 255, 0.06)",
+        fill: "+1", // fill to the next dataset (lower edge of band)
+      });
+      // Lower edge of the ±1 MAD band.
+      datasets.push({
+        ...lineBase,
+        label: "-1 MAD",
+        data: flat(med - mad),
+        borderColor: "rgba(200, 210, 220, 0.25)",
+        borderWidth: 1,
+      });
+      // Baseline median line.
+      datasets.push({
+        ...lineBase,
+        label: "Baseline median",
+        data: flat(med),
+        borderColor: "rgba(200, 210, 220, 0.45)",
+        borderWidth: 1.5,
+      });
+    }
+
+    datasets.push({
+      label: "Nightly Median",
+      data: points.map((p) => ({ x: p.date, y: p.value })),
+      backgroundColor: pointColors,
+      borderColor: "rgba(130, 200, 255, 0.8)",
+      borderWidth: 1,
+      pointRadius: 4,
+      pointHoverRadius: 6,
+      showLine: false,
+    });
 
     if (props.smoothing === "ma7" && ma_7.length > 0) {
       datasets.push({
@@ -85,6 +156,8 @@ const TimeSeriesChart: Component<Props> = (props) => {
           tooltip: {
             titleFont: { size: chartFontSize.tooltipTitle() },
             bodyFont: { size: chartFontSize.tooltipBody() },
+            filter: (item) =>
+              !["Baseline median", "+1 MAD", "-1 MAD", "+3 MAD"].includes(item.dataset.label || ""),
             callbacks: {
               label: (ctx) => {
                 const pt = points.find((p) => p.value === ctx.parsed.y);
@@ -104,6 +177,8 @@ const TimeSeriesChart: Component<Props> = (props) => {
   createEffect(() => {
     const _d = props.data;
     const _s = props.smoothing;
+    const _b = props.baseline;
+    const _h = props.higherIsBetter;
     renderChart();
   });
 

--- a/frontend/src/components/analysis/TimeSeriesTab.tsx
+++ b/frontend/src/components/analysis/TimeSeriesTab.tsx
@@ -1,7 +1,26 @@
-import { Component, createSignal, createResource } from "solid-js";
+import { Component, createSignal, createResource, createMemo } from "solid-js";
 import { api } from "../../api/client";
 import type { SharedFilters } from "../../pages/AnalysisPage";
 import TimeSeriesChart from "./TimeSeriesChart";
+import { MIN_GROUP, type MetricBaseline } from "../../utils/frameQuality";
+
+// Higher-is-better metrics flip z-score polarity so "worse than baseline" stays positive.
+const HIGHER_IS_BETTER = new Set(["detected_stars", "sky_quality"]);
+
+// Robust median + MAD computed over the displayed values, matching the util's
+// definition (MAD = median(|x - median|)). Returns null when too sparse or uniform.
+function baselineFromValues(values: number[]): MetricBaseline | null {
+  const xs = values.filter((v) => v != null && !Number.isNaN(v)).sort((a, b) => a - b);
+  if (xs.length < MIN_GROUP) return null;
+  const med = (arr: number[]): number => {
+    const m = Math.floor(arr.length / 2);
+    return arr.length % 2 ? arr[m] : (arr[m - 1] + arr[m]) / 2;
+  };
+  const median = med(xs);
+  const mad = med(xs.map((v) => Math.abs(v - median)).sort((a, b) => a - b));
+  if (mad === 0) return null;
+  return { median, mad, n: xs.length };
+}
 
 const ALL_METRICS = [
   { value: "humidity", label: "Humidity" },
@@ -48,6 +67,13 @@ const TimeSeriesTab: Component<Props> = (props) => {
     })
   );
 
+  // Baseline computed client-side over the displayed nightly-median points.
+  const baseline = createMemo<MetricBaseline | null>(() => {
+    const pts = data.latest?.points;
+    if (!pts || pts.length === 0) return null;
+    return baselineFromValues(pts.map((p) => p.value));
+  });
+
   const selectClass = "text-sm bg-theme-elevated border border-theme-border rounded px-2.5 py-1.5 text-theme-text-primary";
   const toggleClass = (active: boolean) =>
     `text-sm px-3 py-1.5 rounded-[var(--radius-sm)] transition-colors ${
@@ -76,6 +102,8 @@ const TimeSeriesTab: Component<Props> = (props) => {
           loading={data.loading}
           smoothing={smoothing()}
           metricLabel={ALL_METRICS.find((m) => m.value === metric())?.label}
+          baseline={baseline()}
+          higherIsBetter={HIGHER_IS_BETTER.has(metric())}
         />
       </div>
     </div>

--- a/frontend/src/components/settings/ActivityLogTab.tsx
+++ b/frontend/src/components/settings/ActivityLogTab.tsx
@@ -533,7 +533,11 @@ const ActivityLogTab: Component = () => {
                   </button>
                 </Show>
 
-                <a href={downloadUrl()} class={ACTION_BTN_CLASS}>
+                <a
+                  href={downloadUrl()}
+                  download="galactilog-app.log"
+                  class={ACTION_BTN_CLASS}
+                >
                   Download
                 </a>
               </div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,3 +1,5 @@
+import type { Baselines } from "../utils/frameQuality";
+
 // === Target Aggregation ===
 
 export interface SessionSummary {
@@ -85,6 +87,8 @@ export interface SessionDetail {
   notes: string | null;
   rigs: RigDetail[];
   custom_values?: CustomColumnValue[] | null;
+  session_baselines: Baselines;
+  rig_baselines: Baselines;
 }
 
 // === Target Detail (Deep Dive Page) ===
@@ -528,6 +532,9 @@ export interface EquipmentComboMetrics {
   best_hfr: number | null;
   median_eccentricity: number | null;
   median_fwhm: number | null;
+  mad_hfr: number | null;
+  mad_eccentricity: number | null;
+  mad_fwhm: number | null;
   grouped: boolean;
   filters: string[];
   filter_breakdown: EquipmentFilterMetrics[];

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -7,6 +7,8 @@ export interface SessionSummary {
   integration_seconds: number;
   frame_count: number;
   filters_used: string[];
+  median_hfr: number | null;
+  median_eccentricity: number | null;
 }
 
 export interface TargetAggregation {

--- a/frontend/src/utils/frameQuality.test.ts
+++ b/frontend/src/utils/frameQuality.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from "vitest";
+import {
+  groupKey,
+  madZ,
+  bandForZ,
+  combinedScore,
+  scoreToRowClass,
+  bandToCellClass,
+  MIN_GROUP,
+  type MetricBaseline,
+} from "./frameQuality";
+
+describe("groupKey", () => {
+  it("builds 'telescope|camera|filter'", () => {
+    expect(
+      groupKey({ telescope: "WO", camera: "2600", filter_used: "Ha" }),
+    ).toBe("WO|2600|Ha");
+  });
+
+  it("renders null components as empty strings", () => {
+    expect(
+      groupKey({ telescope: null, camera: "2600", filter_used: null }),
+    ).toBe("|2600|");
+  });
+
+  it("renders undefined components as empty strings", () => {
+    expect(groupKey({})).toBe("||");
+  });
+});
+
+describe("madZ", () => {
+  const baseline = (median: number, mad: number, n: number): MetricBaseline => ({
+    median,
+    mad,
+    n,
+  });
+
+  it("returns null when the value is null", () => {
+    expect(madZ(null, baseline(2.1, 0.37, 20))).toBeNull();
+  });
+
+  it("returns null when the baseline is missing", () => {
+    expect(madZ(2.8, undefined)).toBeNull();
+  });
+
+  it("returns null when median is missing", () => {
+    expect(madZ(2.8, { median: null, mad: 0.37, n: 20 })).toBeNull();
+  });
+
+  it("returns null when mad is missing", () => {
+    expect(madZ(2.8, { median: 2.1, mad: null, n: 20 })).toBeNull();
+  });
+
+  it("returns null when n < MIN_GROUP", () => {
+    expect(madZ(2.8, baseline(2.1, 0.37, MIN_GROUP - 1))).toBeNull();
+  });
+
+  it("returns null when mad === 0", () => {
+    expect(madZ(2.8, baseline(2.1, 0, 20))).toBeNull();
+  });
+
+  it("computes (value - median)/mad for a higher-is-worse metric", () => {
+    // HFR: value 2.8, median 2.1, mad 0.37, n 20 -> z ≈ 1.89
+    expect(madZ(2.8, baseline(2.1, 0.37, 20))).toBeCloseTo(1.8919, 4);
+  });
+
+  it("flips the sign when higherIsBetter is true", () => {
+    // detected_stars: value 80, median 100, mad 10, n 20 -> raw z -2 -> flipped +2
+    expect(madZ(80, baseline(100, 10, 20), true)).toBe(2);
+  });
+});
+
+describe("bandForZ", () => {
+  it("returns neutral for null", () => {
+    expect(bandForZ(null)).toBe("neutral");
+  });
+
+  it("returns better for z = -1 (inclusive boundary)", () => {
+    expect(bandForZ(-1)).toBe("better");
+  });
+
+  it("returns neutral for z = 0", () => {
+    expect(bandForZ(0)).toBe("neutral");
+  });
+
+  it("returns watch for z = 1.5 (inclusive boundary)", () => {
+    expect(bandForZ(1.5)).toBe("watch");
+  });
+
+  it("returns reject for z = 3 (inclusive boundary)", () => {
+    expect(bandForZ(3)).toBe("reject");
+  });
+
+  it("keeps neutral just below the watch boundary", () => {
+    expect(bandForZ(1.4999)).toBe("neutral");
+  });
+
+  it("keeps watch just below the reject boundary", () => {
+    expect(bandForZ(2.9999)).toBe("watch");
+  });
+
+  it("returns better just at the better boundary and reject above 3", () => {
+    expect(bandForZ(-1.0001)).toBe("better");
+    expect(bandForZ(3.5)).toBe("reject");
+  });
+});
+
+describe("combinedScore", () => {
+  it("returns null when all axes are null", () => {
+    expect(combinedScore(null, null, null)).toBeNull();
+  });
+
+  it("maps a median frame (all z = 0) to 50", () => {
+    expect(combinedScore(0, 0, 0)).toBe(50);
+  });
+
+  it("applies weights 0.5 / 0.25 / 0.25", () => {
+    // zc = (1*0.5 + 1*0.25 + 1*0.25) / 1 = 1 -> 50 - 16.7
+    expect(combinedScore(1, 1, 1)).toBeCloseTo(33.3, 5);
+  });
+
+  it("renormalizes the remaining weights when an axis is null", () => {
+    // only signal present -> wsum 0.5, zc = (2*0.5)/0.5 = 2 -> 50 - 16.7*2
+    expect(combinedScore(2, null, null)).toBeCloseTo(50 - 16.7 * 2, 5);
+    // sharp + round present -> wsum 0.5, zc = (1*0.25 + 1*0.25)/0.5 = 1
+    expect(combinedScore(null, 1, 1)).toBeCloseTo(50 - 16.7, 5);
+  });
+
+  it("clamps |z| > 3", () => {
+    // very negative (good) clamps to -3 -> 50 + 50.1 = 100.1
+    expect(combinedScore(-10, -10, -10)).toBeCloseTo(50 + 16.7 * 3, 5);
+    // very positive (bad) clamps to +3 -> 50 - 50.1 = -0.1
+    expect(combinedScore(10, 10, 10)).toBeCloseTo(50 - 16.7 * 3, 5);
+  });
+});
+
+describe("bandToCellClass", () => {
+  it("returns the expected theme class per band", () => {
+    expect(bandToCellClass("better")).toBe("text-theme-success");
+    expect(bandToCellClass("watch")).toBe("text-theme-warning");
+    expect(bandToCellClass("reject")).toBe("text-theme-error");
+    expect(bandToCellClass("neutral")).toBe("text-theme-text-primary");
+  });
+});
+
+describe("scoreToRowClass", () => {
+  it("returns empty string for null", () => {
+    expect(scoreToRowClass(null)).toBe("");
+  });
+
+  it("returns the success tint at or above 60", () => {
+    expect(scoreToRowClass(60)).toBe("bg-theme-success/10");
+    expect(scoreToRowClass(85)).toBe("bg-theme-success/10");
+  });
+
+  it("returns empty string in the neutral 45..60 band", () => {
+    expect(scoreToRowClass(45)).toBe("");
+    expect(scoreToRowClass(50)).toBe("");
+    expect(scoreToRowClass(59.9)).toBe("");
+  });
+
+  it("returns the warning tint in the 30..45 band", () => {
+    expect(scoreToRowClass(30)).toBe("bg-theme-warning/15");
+    expect(scoreToRowClass(44.9)).toBe("bg-theme-warning/15");
+  });
+
+  it("returns the error tint below 30", () => {
+    expect(scoreToRowClass(29.9)).toBe("bg-theme-error/20");
+    expect(scoreToRowClass(0)).toBe("bg-theme-error/20");
+  });
+});

--- a/frontend/src/utils/frameQuality.ts
+++ b/frontend/src/utils/frameQuality.ts
@@ -1,0 +1,97 @@
+// Shared frame-quality deviation utility.
+//
+// Grades a single frame metric against a learned MAD-based baseline and turns it
+// into a signed robust z-score, a color band, and a combined 0-100 quality score.
+// The group-key format ("telescope|camera|filter") matches the backend exactly so
+// frontend and backend index the same baseline maps.
+
+export type QualityBand = "better" | "neutral" | "watch" | "reject";
+
+export interface MetricBaseline {
+  median: number | null;
+  mad: number | null;
+  n: number;
+}
+
+export type GroupBaseline = Record<string, MetricBaseline>;
+export type Baselines = Record<string, GroupBaseline>;
+
+export const MIN_GROUP = 8;
+const EPS = 1e-9;
+
+export function groupKey(f: {
+  telescope?: string | null;
+  camera?: string | null;
+  filter_used?: string | null;
+}): string {
+  return `${f.telescope ?? ""}|${f.camera ?? ""}|${f.filter_used ?? ""}`;
+}
+
+// MAD-based robust z-score. higherIsBetter flips the sign so that "worse than
+// baseline" is always positive regardless of metric polarity.
+// Returns null (treated as neutral) when the baseline is too sparse, uniform
+// (mad === 0), or the value/baseline is missing.
+export function madZ(
+  value: number | null | undefined,
+  b: MetricBaseline | undefined,
+  higherIsBetter = false,
+): number | null {
+  if (value == null || !b || b.median == null || b.mad == null || b.n < MIN_GROUP || b.mad === 0) return null;
+  const z = (value - b.median) / Math.max(b.mad, EPS);
+  return higherIsBetter ? -z : z;
+}
+
+export function bandForZ(z: number | null): QualityBand {
+  if (z == null) return "neutral";
+  if (z <= -1.0) return "better";
+  if (z < 1.5) return "neutral";
+  if (z < 3.0) return "watch";
+  return "reject";
+}
+
+// Combined 0-100 score from up to three axes (signal/sharpness/roundness).
+// Weights 0.5 / 0.25 / 0.25; when an axis is null it is dropped and the
+// remaining weights are renormalized to sum to 1. All-null -> null (neutral row).
+export function combinedScore(
+  zSignal: number | null,
+  zSharp: number | null,
+  zRound: number | null,
+): number | null {
+  const axes = [
+    [zSignal, 0.5],
+    [zSharp, 0.25],
+    [zRound, 0.25],
+  ].filter(([z]) => z != null) as [number, number][];
+  if (axes.length === 0) return null;
+  const wsum = axes.reduce((s, [, w]) => s + w, 0);
+  const zc = axes.reduce((s, [z, w]) => s + z * w, 0) / wsum;
+  const clamped = Math.max(-3, Math.min(3, zc));
+  return 50 - 16.7 * clamped;
+}
+
+export function bandToCellClass(band: QualityBand): string {
+  switch (band) {
+    case "better": return "text-theme-success";
+    case "watch":  return "text-theme-warning";
+    case "reject": return "text-theme-error";
+    default:       return "text-theme-text-primary";
+  }
+}
+
+export function scoreToRowClass(score: number | null): string {
+  if (score == null) return "";
+  if (score >= 60) return "bg-theme-success/10";
+  if (score >= 45) return "";
+  if (score >= 30) return "bg-theme-warning/15";
+  return "bg-theme-error/20";
+}
+
+// Worked examples (sanity checks for the math above):
+//
+// 1. Higher-is-worse metric (HFR): value 2.8, baseline median 2.1, mad 0.37.
+//    z = (2.8 - 2.1) / 0.37 = 0.7 / 0.37 ≈ 1.89  ->  bandForZ -> "watch".
+//
+// 2. Higher-is-better metric (detected_stars): value 80, baseline median 100,
+//    mad 10, higherIsBetter = true.
+//    raw z = (80 - 100) / 10 = -2; sign-flipped -> +2  ->  bandForZ -> "watch".
+//    (Fewer stars than baseline is worse, so the flipped z is positive.)


### PR DESCRIPTION
**What's new**
*   Dashboard flags anomalous recent sessions.
*   Session summaries now show median HFR and eccentricity.
*   Equipment performance medians are color-coded by deviation.
*   Analysis charts overlay rig baseline reference bands.
*   Session frame tables are color-coded by MAD deviation with a toggle.
*   Equipment stats now include per-combo MAD values.
*   New help popover explains frame deviation grading.

**What's fixed**
*   Per-frame table colors now update correctly with baseline toggle.

**What's changed**
*   Rig baselines are now catalog-wide per equipment combination.
*   Rig baselines use a catalog-wide fallback for sparse data.
*   Per-Frame Data table header is now opaque.
*   Dashboard session-quality badges have been removed.
*   Per-Frame Data help text has been updated.