### PR TITLE
Align Equipment Inventory tables

### DIFF
--- a/frontend/src/components/EquipmentInventory.tsx
+++ b/frontend/src/components/EquipmentInventory.tsx
@@ -4,7 +4,17 @@ import { formatIntegration } from "../utils/format";
 
 const EquipmentTable: Component<{ title: string; items: EquipmentItem[] }> = (props) => (
   <div>
-    <table class="w-full text-xs">
+    <table class="w-full text-xs table-fixed">
+      <colgroup>
+        <col class="w-[24%]" />
+        <col class="w-[10.857%]" />
+        <col class="w-[10.857%]" />
+        <col class="w-[10.857%]" />
+        <col class="w-[10.857%]" />
+        <col class="w-[10.857%]" />
+        <col class="w-[10.857%]" />
+        <col class="w-[10.857%]" />
+      </colgroup>
       <thead>
         <tr class="border-b border-theme-border">
           <th class="text-left text-theme-text-secondary font-normal py-1 pr-4">{props.title}</th>


### PR DESCRIPTION
**What's changed**
- Equipment Inventory tables for Cameras and Telescopes now have aligned columns.