### PR TITLE
Job Monitor Updates and PHD2 Stability

### DIFF
--- a/backend/app/api/jobs.py
+++ b/backend/app/api/jobs.py
@@ -1,0 +1,63 @@
+"""Live background-job listing for the nav job monitor.
+
+Serves the registry that app.worker.job_registry's Celery signals maintain:
+every queued or running task not already covered by the richer scan/rebuild
+status sources. Read-only; the registry cleans itself up via task_postrun
+and entry TTLs.
+"""
+from fastapi import APIRouter, Depends
+
+from app.api.deps import require_admin
+from app.config import async_redis
+from app.models.user import User
+from app.schemas.tasks import JobEntry, JobsResponse
+from app.worker.job_registry import JOB_ENTRY_PREFIX, JOBS_ACTIVE_SET
+
+router = APIRouter(prefix="/jobs", tags=["jobs"])
+
+
+def _as_float(value: str | None) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+@router.get("", response_model=JobsResponse)
+async def list_jobs(user: User = Depends(require_admin)) -> JobsResponse:
+    async with async_redis() as r:
+        task_ids = sorted(await r.smembers(JOBS_ACTIVE_SET))
+        if not task_ids:
+            return JobsResponse(jobs=[])
+        pipe = r.pipeline()
+        for task_id in task_ids:
+            pipe.hgetall(JOB_ENTRY_PREFIX + task_id)
+        entries = await pipe.execute()
+
+        jobs: list[JobEntry] = []
+        orphans: list[str] = []
+        for task_id, entry in zip(task_ids, entries):
+            # An id whose hash TTL-expired (worker SIGKILL, Redis restart) is
+            # stale set residue; drop it here so it cannot accumulate.
+            if not entry or "name" not in entry:
+                orphans.append(task_id)
+                continue
+            jobs.append(JobEntry(
+                task_id=task_id,
+                name=entry["name"],
+                state=entry.get("state", "queued"),
+                queued_at=_as_float(entry.get("queued_at")),
+                started_at=_as_float(entry.get("started_at")),
+                eta=entry.get("eta"),
+            ))
+        if orphans:
+            await r.srem(JOBS_ACTIVE_SET, *orphans)
+
+    # Running first, then longest-queued first: the panel renders in order.
+    jobs.sort(key=lambda j: (
+        0 if j.state == "running" else 1,
+        j.started_at or j.queued_at or 0.0,
+    ))
+    return JobsResponse(jobs=jobs)

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -19,6 +19,7 @@ from .mosaics import router as mosaics_router
 from .custom_columns import router as custom_columns_router
 from .filename_resolution import router as filename_resolution_router
 from .tasks import router as tasks_router
+from .jobs import router as jobs_router
 from .backup import router as backup_router
 from .bootstrap import router as bootstrap_router
 from .preview import router as preview_router
@@ -49,6 +50,7 @@ api_router.include_router(mosaics_router)
 api_router.include_router(custom_columns_router)
 api_router.include_router(filename_resolution_router)
 api_router.include_router(tasks_router)
+api_router.include_router(jobs_router)
 api_router.include_router(backup_router)
 api_router.include_router(bootstrap_router)
 api_router.include_router(preview_router)

--- a/backend/app/schemas/scan.py
+++ b/backend/app/schemas/scan.py
@@ -70,6 +70,11 @@ class ScanStateResponse(BaseModel):
     phd2_found: int = 0
     phd2_ingested: int = 0
     phd2_failed: int = 0
+    # Files the pass has looked at so far, whatever the verdict (ingested,
+    # unchanged, empty, failed). The scan screen's numerator: most files in a
+    # rescan are unchanged, so counting only ingested+failed read "0 of N"
+    # for the whole pass.
+    phd2_checked: int = 0
     # "" | pending | running. The guide-log pass outlives the image scan, so
     # ``state == "complete"`` alone does not mean the scan is finished. A
     # caller that needs everything done waits for this to be "" as well; the

--- a/backend/app/schemas/tasks.py
+++ b/backend/app/schemas/tasks.py
@@ -9,3 +9,18 @@ class TaskStatusResponse(BaseModel):
     task_id: str
     state: str
     result: Any | None = None
+
+
+class JobEntry(BaseModel):
+    task_id: str
+    name: str
+    state: str  # "queued" | "running"
+    queued_at: float | None = None
+    started_at: float | None = None
+    # ISO timestamp from Celery's eta/countdown, when the task was dispatched
+    # with a delay; lets the UI say "starts in Ns" instead of just "waiting".
+    eta: str | None = None
+
+
+class JobsResponse(BaseModel):
+    jobs: list[JobEntry]

--- a/backend/app/services/phd2_correlation.py
+++ b/backend/app/services/phd2_correlation.py
@@ -40,7 +40,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import date as date_type, timedelta, timezone
 
-from sqlalchemy import or_, select, update
+from sqlalchemy import or_, select, text, update
 from sqlalchemy.orm import Session
 
 from app.models import Image
@@ -729,6 +729,13 @@ def correlate_dates(
     phd2-sourced value on them anyway.
     """
     result = CorrelationResult()
+
+    # Two passes running at once (each profile-map save queues one, and the
+    # post-scan cascade queues its own) update overlapping images rows in
+    # different orders and deadlock Postgres. The advisory lock makes the
+    # second pass wait instead; being transaction-scoped, a crashed pass
+    # releases it with its rollback.
+    db.execute(text("SELECT pg_advisory_xact_lock(hashtext('phd2_correlate'))"))
 
     if dates is None:
         target_dates = _dates_needing_fill(db)

--- a/backend/app/services/scan_state.py
+++ b/backend/app/services/scan_state.py
@@ -75,6 +75,12 @@ class ScanStateSnapshot:
     phd2_found: int = 0
     phd2_ingested: int = 0
     phd2_failed: int = 0
+    # Files the pass has looked at so far, whatever the verdict (ingested,
+    # unchanged, empty, failed). This is the scan screen's numerator: on a
+    # routine rescan nearly every log short-circuits as unchanged, so a
+    # numerator built from ingested+failed sat at 0 against a denominator of
+    # hundreds and then jumped straight to done.
+    phd2_checked: int = 0
     # "" | pending | running. The guide-log pass is dispatched by run_scan and
     # then runs on its own, so `state` can read "complete" while it is still
     # working. Without this field a caller polling for completeness reads the
@@ -118,6 +124,7 @@ class ScanStateSnapshot:
             "phd2_found": self.phd2_found,
             "phd2_ingested": self.phd2_ingested,
             "phd2_failed": self.phd2_failed,
+            "phd2_checked": self.phd2_checked,
             "phd2_state": self.phd2_state,
             "phd2_state_at": self.phd2_state_at,
             "task": self.task,
@@ -160,6 +167,7 @@ def parse_snapshot(data: dict | None) -> ScanStateSnapshot:
         phd2_found=int(data.get("phd2_found", 0)),
         phd2_ingested=int(data.get("phd2_ingested", 0)),
         phd2_failed=int(data.get("phd2_failed", 0)),
+        phd2_checked=int(data.get("phd2_checked", 0)),
         phd2_state=data.get("phd2_state", "") or "",
         phd2_state_at=(
             float(data["phd2_state_at"]) if data.get("phd2_state_at") else None
@@ -588,6 +596,7 @@ def reset_phd2_counts_sync(r: sync_redis.Redis, found: int) -> None:
         "phd2_found": found,
         "phd2_ingested": 0,
         "phd2_failed": 0,
+        "phd2_checked": 0,
         "phd2_state": PHD2_STATE_PENDING,
         "phd2_state_at": time.time(),
     })
@@ -622,7 +631,7 @@ def set_phd2_found_sync(r: sync_redis.Redis, found: int) -> None:
 
 
 def increment_phd2_progress_sync(
-    r: sync_redis.Redis, ingested: int = 0, failed: int = 0
+    r: sync_redis.Redis, ingested: int = 0, failed: int = 0, checked: int = 0
 ) -> None:
     """Advance the per-file guide-log counters, following increment_csv_enriched_sync.
 
@@ -635,7 +644,9 @@ def increment_phd2_progress_sync(
 
     A call with nothing to report writes nothing. Most files in a rescan are
     unchanged, and a Redis round trip per unchanged file in a library of
-    hundreds of logs is pure overhead.
+    hundreds of logs is pure overhead - which is why `checked` (files looked
+    at, whatever the verdict) is flushed by the caller in batches rather than
+    reported one file at a time.
 
     Real progress also renews phd2_state_at. The timestamp is what lets a
     reader age a stuck claim out, and a consumer that applies its staleness
@@ -646,17 +657,20 @@ def increment_phd2_progress_sync(
     evidence it is merely slow. Only a call that has progress to report
     renews it: a no-op must not keep a genuinely hung pass looking alive.
     """
-    if not ingested and not failed:
+    if not ingested and not failed and not checked:
         return
     if ingested:
         r.hincrby(SCAN_KEY, "phd2_ingested", ingested)
     if failed:
         r.hincrby(SCAN_KEY, "phd2_failed", failed)
+    if checked:
+        r.hincrby(SCAN_KEY, "phd2_checked", checked)
     r.hset(SCAN_KEY, "phd2_state_at", time.time())
 
 
 def set_phd2_counts_sync(
-    r: sync_redis.Redis, found: int, ingested: int, failed: int
+    r: sync_redis.Redis, found: int, ingested: int, failed: int,
+    checked: int | None = None,
 ) -> None:
     """Publish the PHD2 pass's totals in one write and clear the in-flight flag.
 
@@ -672,6 +686,9 @@ def set_phd2_counts_sync(
         "phd2_found": found,
         "phd2_ingested": ingested,
         "phd2_failed": failed,
+        # A finished pass has by definition checked everything it found; this
+        # also settles the partial batch the per-file flush had not sent yet.
+        "phd2_checked": found if checked is None else checked,
         "phd2_state": PHD2_STATE_IDLE,
         "phd2_state_at": "",
     })

--- a/backend/app/worker/celery_app.py
+++ b/backend/app/worker/celery_app.py
@@ -102,6 +102,9 @@ from app.worker import drain_logs as _drain_logs  # noqa: E402,F401
 from app.metrics import register_celery_signals
 register_celery_signals()
 
+from app.worker.job_registry import register_job_signals
+register_job_signals()
+
 
 # ---------------------------------------------------------------------------
 # Backend log capture: install RedisLogHandler in worker and beat processes.

--- a/backend/app/worker/job_registry.py
+++ b/backend/app/worker/job_registry.py
@@ -1,0 +1,144 @@
+"""Live Celery job registry: every queued or running task, visible to the UI.
+
+Celery signal handlers write one small Redis hash per in-flight task, and
+GET /api/jobs reads them back for the nav job monitor. Hooking the signals
+rather than the dispatch sites is deliberate: a task added next year is
+covered with zero per-task code, and no call site can forget to register
+(the same structural-over-conventional argument as auth at the route table).
+
+State model, one hash per task id under ``jobs:entry:<id>`` plus an id set
+under ``jobs:active``:
+
+- before_task_publish -> state "queued". This signal fires in whichever
+  process enqueues (API, worker cascade, beat), so a task sitting behind a
+  countdown or a busy worker is visible from the moment of dispatch - the
+  gap the monitor previously could not see.
+- task_prerun -> state "running". Also re-adds the id to the active set so a
+  task whose publish record was lost still shows while running.
+- task_postrun -> entry deleted. Fires on success and failure alike; the
+  activity feed, not this registry, is the durable outcome record.
+
+Entries carry a TTL because a SIGKILLed worker (hard time limit, OOM) never
+fires task_postrun, and a phantom "running" row that outlives its task by a
+week is worse than one that quietly expires.
+
+SUPPRESSED_TASKS names the work already surfaced by a richer source (scan
+status envelope, rebuild status), which the monitor renders with progress
+bars and cancel buttons this registry cannot know about. Suppression happens
+write-side, not in the API read, because run_scan fans out one ingest_file
+task per new file: recording tens of thousands of throwaway entries to
+filter them out later would be pure Redis churn.
+"""
+import logging
+import time
+
+logger = logging.getLogger(__name__)
+
+JOB_ENTRY_PREFIX = "jobs:entry:"
+JOBS_ACTIVE_SET = "jobs:active"
+JOB_ENTRY_TTL_S = 3600
+
+# Tasks the scan-status envelope already covers, including its per-file
+# ingest fan-out, and the rebuild-status family (REBUILD_KEY modes smart /
+# full / retry / ref_thumbnails / regen plus regen's per-image fan-out).
+SUPPRESSED_TASKS = frozenset({
+    "app.worker.tasks.run_scan",
+    "app.worker.tasks.ingest_file",
+    "app.worker.tasks.reingest_changed_file",
+    "app.worker.tasks.scan_phd2_logs",
+    "app.worker.tasks.rebuild_targets",
+    "app.worker.tasks.retry_unresolved",
+    "app.worker.tasks.smart_rebuild_targets",
+    "app.worker.tasks.generate_reference_thumbnails",
+    "app.worker.tasks.regenerate_thumbnail",
+    "regenerate_missing_thumbnails",
+    "purge_and_regenerate_thumbnails",
+})
+
+
+def register_job_signals():
+    """Connect the registry's Celery signals. Call once per process.
+
+    Registered from celery_app.py, which the API process imports on its first
+    enqueue and the worker/beat processes import at startup, so the publish
+    signal is live everywhere a task can be born. dispatch_uid makes repeat
+    calls idempotent. Every handler swallows Redis errors: visibility must
+    never fail the work it is watching (same tolerance as _queue_worker_task).
+    """
+    from celery.signals import before_task_publish, task_prerun, task_postrun
+    import redis as _redis_mod
+
+    _client = None
+
+    def _get_redis():
+        nonlocal _client
+        if _client is None:
+            from app.config import settings
+            _client = _redis_mod.from_url(settings.redis_url)
+        return _client
+
+    @before_task_publish.connect(dispatch_uid="galactilog_jobs_publish", weak=False)
+    def _on_publish(sender=None, headers=None, **_kwargs):
+        name = sender or (headers or {}).get("task")
+        task_id = (headers or {}).get("id")
+        if not name or not task_id or name in SUPPRESSED_TASKS:
+            return
+        try:
+            record_queued(_get_redis(), task_id, name, eta=(headers or {}).get("eta"))
+        except Exception:
+            logger.debug("job registry: publish write failed", exc_info=True)
+
+    @task_prerun.connect(dispatch_uid="galactilog_jobs_prerun", weak=False)
+    def _on_prerun(task_id=None, task=None, **_kwargs):
+        name = getattr(task, "name", None)
+        if not task_id or not name or name in SUPPRESSED_TASKS:
+            return
+        try:
+            record_running(_get_redis(), task_id, name)
+        except Exception:
+            logger.debug("job registry: prerun write failed", exc_info=True)
+
+    @task_postrun.connect(dispatch_uid="galactilog_jobs_postrun", weak=False)
+    def _on_postrun(task_id=None, task=None, **_kwargs):
+        name = getattr(task, "name", None)
+        if not task_id or (name and name in SUPPRESSED_TASKS):
+            return
+        try:
+            clear_entry(_get_redis(), task_id)
+        except Exception:
+            logger.debug("job registry: postrun cleanup failed", exc_info=True)
+
+
+# The write operations are module-level functions taking an explicit client
+# so tests can drive them against the test Redis without Celery in the loop.
+
+def record_queued(r, task_id: str, name: str, eta: str | None = None) -> None:
+    mapping = {"name": name, "state": "queued", "queued_at": time.time()}
+    if eta:
+        mapping["eta"] = eta
+    pipe = r.pipeline()
+    key = JOB_ENTRY_PREFIX + task_id
+    pipe.hset(key, mapping=mapping)
+    pipe.expire(key, JOB_ENTRY_TTL_S)
+    pipe.sadd(JOBS_ACTIVE_SET, task_id)
+    pipe.execute()
+
+
+def record_running(r, task_id: str, name: str) -> None:
+    key = JOB_ENTRY_PREFIX + task_id
+    pipe = r.pipeline()
+    # name is written here too, not just at publish: a run whose publish
+    # record expired (long countdown) or was never seen still gets a full row.
+    pipe.hset(key, mapping={
+        "name": name, "state": "running", "started_at": time.time(),
+    })
+    pipe.expire(key, JOB_ENTRY_TTL_S)
+    pipe.sadd(JOBS_ACTIVE_SET, task_id)
+    pipe.execute()
+
+
+def clear_entry(r, task_id: str) -> None:
+    pipe = r.pipeline()
+    pipe.delete(JOB_ENTRY_PREFIX + task_id)
+    pipe.srem(JOBS_ACTIVE_SET, task_id)
+    pipe.execute()

--- a/backend/app/worker/tasks_phd2.py
+++ b/backend/app/worker/tasks_phd2.py
@@ -947,6 +947,15 @@ def _run_phd2_pass(
     if scanned:
         set_phd2_found_sync(_redis, found)
 
+    # The scan screen's numerator counts files LOOKED AT, not files ingested:
+    # on a routine rescan nearly everything short-circuits as unchanged, and a
+    # numerator of ingested+failed reads "0 of 179" for the whole pass and
+    # then jumps to done. Flushed in batches because a Redis round trip per
+    # unchanged file is the overhead increment_phd2_progress_sync's contract
+    # promises to avoid; the end-of-pass counts write settles the remainder.
+    checked_batch = 0
+    CHECKED_FLUSH_EVERY = 25
+
     with Session(_sync_engine) as db:
         for path in candidates:
             # Collected per file and kept only when the file went in whole. A
@@ -954,6 +963,10 @@ def _run_phd2_pass(
             # pointing from a log the catalog does not hold is not evidence
             # about anything the user can see.
             file_pointing: list[PointingSample] = []
+            checked_batch += 1
+            flush = 0
+            if checked_batch >= CHECKED_FLUSH_EVERY:
+                flush, checked_batch = checked_batch, 0
             try:
                 result = ingest_phd2_log(
                     db, path, general, tz_name=tz_name, force=force,
@@ -964,20 +977,25 @@ def _run_phd2_pass(
                 db.rollback()
                 failed += 1
                 if scanned:
-                    increment_phd2_progress_sync(_redis, failed=1)
+                    increment_phd2_progress_sync(_redis, failed=1, checked=flush)
                 continue
             if result == "ok":
                 ingested += 1
                 ingested_paths.append(path)
                 pointing.extend(file_pointing)
                 if scanned:
-                    increment_phd2_progress_sync(_redis, ingested=1)
+                    increment_phd2_progress_sync(_redis, ingested=1, checked=flush)
             elif result == "empty":
                 empty += 1
+                if scanned and flush:
+                    increment_phd2_progress_sync(_redis, checked=flush)
+            elif result == "unchanged":
+                if scanned and flush:
+                    increment_phd2_progress_sync(_redis, checked=flush)
             elif result == "failed":
                 failed += 1
                 if scanned:
-                    increment_phd2_progress_sync(_redis, failed=1)
+                    increment_phd2_progress_sync(_redis, failed=1, checked=flush)
 
         # The map may have changed since the last scan; re-applying it here
         # keeps existing rows converged without a second task.

--- a/backend/app/worker/tasks_phd2.py
+++ b/backend/app/worker/tasks_phd2.py
@@ -951,8 +951,8 @@ def _run_phd2_pass(
     # on a routine rescan nearly everything short-circuits as unchanged, and a
     # numerator of ingested+failed reads "0 of 179" for the whole pass and
     # then jumps to done. Flushed in batches because a Redis round trip per
-    # unchanged file is the overhead increment_phd2_progress_sync's contract
-    # promises to avoid; the end-of-pass counts write settles the remainder.
+    # unchanged file is the overhead the progress counters' contract promises
+    # to avoid; the end-of-pass counts write settles the remainder.
     checked_batch = 0
     CHECKED_FLUSH_EVERY = 25
 

--- a/backend/tests/test_api_jobs.py
+++ b/backend/tests/test_api_jobs.py
@@ -1,0 +1,137 @@
+"""GET /api/jobs and the Redis write helpers behind it (job_registry)."""
+import uuid
+
+import pytest
+import redis as redis_mod
+from httpx import AsyncClient, ASGITransport
+
+from app.main import app
+from app.api.deps import require_admin
+from app.config import settings
+from app.worker.job_registry import (
+    JOB_ENTRY_PREFIX, JOBS_ACTIVE_SET, SUPPRESSED_TASKS,
+    clear_entry, record_queued, record_running,
+)
+
+
+@pytest.fixture
+def r():
+    client = redis_mod.from_url(settings.redis_url, decode_responses=True)
+    _wipe(client)
+    yield client
+    _wipe(client)
+    client.close()
+
+
+def _wipe(client):
+    ids = client.smembers(JOBS_ACTIVE_SET)
+    if ids:
+        client.delete(*(JOB_ENTRY_PREFIX + i for i in ids))
+    client.delete(JOBS_ACTIVE_SET)
+
+
+def _tid() -> str:
+    return str(uuid.uuid4())
+
+
+def test_record_queued_writes_entry_with_ttl(r):
+    tid = _tid()
+    record_queued(r, tid, "app.worker.tasks.correlate_phd2_images", eta="2026-08-05T21:00:00+00:00")
+    entry = r.hgetall(JOB_ENTRY_PREFIX + tid)
+    assert entry["state"] == "queued"
+    assert entry["name"] == "app.worker.tasks.correlate_phd2_images"
+    assert entry["eta"] == "2026-08-05T21:00:00+00:00"
+    assert float(entry["queued_at"]) > 0
+    assert r.ttl(JOB_ENTRY_PREFIX + tid) > 0
+    assert r.sismember(JOBS_ACTIVE_SET, tid)
+
+
+def test_record_running_upgrades_state_and_survives_missing_publish(r):
+    tid = _tid()
+    record_queued(r, tid, "recompute_session_dates")
+    record_running(r, tid, "recompute_session_dates")
+    entry = r.hgetall(JOB_ENTRY_PREFIX + tid)
+    assert entry["state"] == "running"
+    assert float(entry["started_at"]) > 0
+    assert float(entry["queued_at"]) > 0  # publish-time field kept
+
+    # No publish record at all (long countdown expired, or lost): prerun
+    # alone must still produce a complete row.
+    orphan = _tid()
+    record_running(r, orphan, "app.worker.tasks.backfill_dark_hours")
+    entry = r.hgetall(JOB_ENTRY_PREFIX + orphan)
+    assert entry["name"] == "app.worker.tasks.backfill_dark_hours"
+    assert entry["state"] == "running"
+    assert r.sismember(JOBS_ACTIVE_SET, orphan)
+
+
+def test_clear_entry_removes_hash_and_set_member(r):
+    tid = _tid()
+    record_queued(r, tid, "detect_mosaic_panels_task")
+    clear_entry(r, tid)
+    assert not r.exists(JOB_ENTRY_PREFIX + tid)
+    assert not r.sismember(JOBS_ACTIVE_SET, tid)
+
+
+def test_scan_and_rebuild_families_are_suppressed():
+    # These are surfaced by the richer scan/rebuild status sources; the
+    # registry must not double-report them, and ingest_file especially must
+    # not write one Redis entry per scanned file.
+    for name in (
+        "app.worker.tasks.run_scan",
+        "app.worker.tasks.ingest_file",
+        "app.worker.tasks.scan_phd2_logs",
+        "app.worker.tasks.rebuild_targets",
+        "app.worker.tasks.smart_rebuild_targets",
+    ):
+        assert name in SUPPRESSED_TASKS
+    assert "app.worker.tasks.correlate_phd2_images" not in SUPPRESSED_TASKS
+
+
+@pytest.mark.asyncio
+async def test_list_jobs_returns_running_before_queued(r):
+    running = _tid()
+    queued = _tid()
+    record_queued(r, queued, "app.worker.tasks.correlate_phd2_images")
+    record_running(r, running, "recompute_session_dates")
+
+    app.dependency_overrides[require_admin] = lambda: None
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.get("/api/jobs")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert resp.status_code == 200
+    jobs = resp.json()["jobs"]
+    assert [j["task_id"] for j in jobs] == [running, queued]
+    assert jobs[0]["state"] == "running"
+    assert jobs[1]["state"] == "queued"
+    assert jobs[1]["queued_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_list_jobs_drops_orphaned_set_members(r):
+    # A set member whose hash TTL-expired must be removed, not returned.
+    stale = _tid()
+    live = _tid()
+    r.sadd(JOBS_ACTIVE_SET, stale)
+    record_queued(r, live, "detect_filename_targets")
+
+    app.dependency_overrides[require_admin] = lambda: None
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.get("/api/jobs")
+    finally:
+        app.dependency_overrides.clear()
+
+    jobs = resp.json()["jobs"]
+    assert [j["task_id"] for j in jobs] == [live]
+    assert not r.sismember(JOBS_ACTIVE_SET, stale)
+
+
+@pytest.mark.asyncio
+async def test_list_jobs_requires_auth():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        resp = await c.get("/api/jobs")
+    assert resp.status_code in (401, 403)

--- a/backend/tests/test_tasks_phd2.py
+++ b/backend/tests/test_tasks_phd2.py
@@ -812,6 +812,9 @@ def test_publishing_the_counters_clears_the_flag_and_its_timestamp_together():
         "phd2_found": 25,
         "phd2_ingested": 19,
         "phd2_failed": 0,
+        # A finished pass has checked everything it found; the final write is
+        # what settles the batched checked counter at the exact total.
+        "phd2_checked": 25,
         "phd2_state": "",
         "phd2_state_at": "",
     })]
@@ -863,6 +866,32 @@ def test_per_file_progress_increments_rather_than_overwrites():
         (SCAN_KEY, "phd2_ingested", 1),
         (SCAN_KEY, "phd2_failed", 1),
     ]
+
+
+def test_checked_batches_increment_and_renew_the_timestamp():
+    """The scan screen's numerator counts files LOOKED AT, not files ingested:
+    a routine rescan short-circuits nearly everything as unchanged, and an
+    ingested+failed numerator sat at 0 of N for the whole pass. `checked` is
+    flushed in caller-side batches, is real progress (a stat walk advancing),
+    and so renews phd2_state_at like the other counters."""
+    from app.services.scan_state import SCAN_KEY, increment_phd2_progress_sync
+
+    redis = _RecordingRedis()
+    increment_phd2_progress_sync(redis, checked=25)
+    increment_phd2_progress_sync(redis, ingested=1, checked=25)
+    assert redis.increments == [
+        (SCAN_KEY, "phd2_checked", 25),
+        (SCAN_KEY, "phd2_ingested", 1),
+        (SCAN_KEY, "phd2_checked", 25),
+    ]
+    assert len(redis.writes) == 2  # one phd2_state_at renewal per flush
+
+    # Nothing to report still writes nothing: a no-op call must not keep a
+    # genuinely hung pass looking alive.
+    redis2 = _RecordingRedis()
+    increment_phd2_progress_sync(redis2, checked=0)
+    assert redis2.increments == []
+    assert redis2.writes == []
 
 
 def test_progress_renews_the_state_timestamp():

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -3517,6 +3517,78 @@
         "title": "IntegrationResponse",
         "type": "object"
       },
+      "JobEntry": {
+        "properties": {
+          "eta": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Eta"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "queued_at": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Queued At"
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Started At"
+          },
+          "state": {
+            "title": "State",
+            "type": "string"
+          },
+          "task_id": {
+            "title": "Task Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "task_id",
+          "name",
+          "state"
+        ],
+        "title": "JobEntry",
+        "type": "object"
+      },
+      "JobsResponse": {
+        "properties": {
+          "jobs": {
+            "items": {
+              "$ref": "#/components/schemas/JobEntry"
+            },
+            "title": "Jobs",
+            "type": "array"
+          }
+        },
+        "required": [
+          "jobs"
+        ],
+        "title": "JobsResponse",
+        "type": "object"
+      },
       "LoginRequest": {
         "properties": {
           "password": {
@@ -12330,6 +12402,55 @@
         "summary": "Send To Stellarium",
         "tags": [
           "integrations"
+        ]
+      }
+    },
+    "/api/jobs": {
+      "get": {
+        "operationId": "list_jobs_api_jobs_get",
+        "parameters": [
+          {
+            "in": "cookie",
+            "name": "access_token",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Access Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Jobs",
+        "tags": [
+          "jobs"
         ]
       }
     },

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -6867,6 +6867,11 @@
             "title": "Percent",
             "type": "number"
           },
+          "phd2_checked": {
+            "default": 0,
+            "title": "Phd2 Checked",
+            "type": "integer"
+          },
           "phd2_failed": {
             "default": 0,
             "title": "Phd2 Failed",

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -4742,6 +4742,11 @@ export interface components {
              */
             percent: number;
             /**
+             * Phd2 Checked
+             * @default 0
+             */
+            phd2_checked: number;
+            /**
              * Phd2 Failed
              * @default 0
              */

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -597,6 +597,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/jobs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Jobs */
+        get: operations["list_jobs_api_jobs_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/logs": {
         parameters: {
             query?: never;
@@ -3571,6 +3588,26 @@ export interface components {
             error?: string | null;
             /** Ok */
             ok: boolean;
+        };
+        /** JobEntry */
+        JobEntry: {
+            /** Eta */
+            eta?: string | null;
+            /** Name */
+            name: string;
+            /** Queued At */
+            queued_at?: number | null;
+            /** Started At */
+            started_at?: number | null;
+            /** State */
+            state: string;
+            /** Task Id */
+            task_id: string;
+        };
+        /** JobsResponse */
+        JobsResponse: {
+            /** Jobs */
+            jobs: components["schemas"]["JobEntry"][];
         };
         /** LoginRequest */
         LoginRequest: {
@@ -6945,6 +6982,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["IntegrationResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_jobs_api_jobs_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: {
+                access_token?: string | null;
+            };
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JobsResponse"];
                 };
             };
             /** @description Validation Error */

--- a/frontend/src/api/types.mirrors.test.ts
+++ b/frontend/src/api/types.mirrors.test.ts
@@ -4,18 +4,19 @@ import type { FrameRecord, ScanStatus } from "./types";
 
 type GeneratedScanState = components["schemas"]["ScanStateResponse"];
 
-// Compile-time guard: the four PHD2 counters this mirror declares must be the
-// four the generated ScanStateResponse actually reports. If the backend
+// Compile-time guard: the PHD2 counters this mirror declares must be the
+// ones the generated ScanStateResponse actually reports. If the backend
 // renames one, this object stops compiling and tsc names the field, instead
 // of the UI silently reading undefined forever.
 const generatedPhd2Fields: Pick<
   GeneratedScanState,
-  "phd2_state" | "phd2_found" | "phd2_ingested" | "phd2_failed"
+  "phd2_state" | "phd2_found" | "phd2_ingested" | "phd2_failed" | "phd2_checked"
 > = {
   phd2_state: "running",
   phd2_found: 3,
   phd2_ingested: 2,
   phd2_failed: 1,
+  phd2_checked: 3,
 };
 
 describe("ScanStatus mirror", () => {
@@ -37,6 +38,7 @@ describe("ScanStatus mirror", () => {
       phd2_found: 3,
       phd2_ingested: 2,
       phd2_failed: 1,
+      phd2_checked: 3,
       phd2_state_at: 1_753_800_000,
     };
 
@@ -44,6 +46,7 @@ describe("ScanStatus mirror", () => {
     expect(status.phd2_found).toBe(generatedPhd2Fields.phd2_found);
     expect(status.phd2_ingested).toBe(2);
     expect(status.phd2_failed).toBe(1);
+    expect(status.phd2_checked).toBe(generatedPhd2Fields.phd2_checked);
     expect(status.phd2_state_at).toBe(1_753_800_000);
   });
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -458,6 +458,11 @@ export interface ScanStatus {
   phd2_found?: number;
   phd2_ingested?: number;
   phd2_failed?: number;
+  // Files looked at so far, whatever the verdict (ingested, unchanged,
+  // empty, failed). The progress numerator; ingested+failed is only the
+  // fallback for a backend that predates it, and undercounts on a rescan
+  // where nearly every log short-circuits as unchanged.
+  phd2_checked?: number;
   // Epoch seconds, same unit as started_at: the LAST guide-log state
   // transition. Written when the pass is marked pending at dispatch,
   // rewritten when it reaches running, cleared in the same write that clears

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -880,7 +880,7 @@ export type ActivityCategory =
 // widget); not a server response shape.
 export interface ActiveJob {
   id: string;
-  category: "scan" | "rebuild" | "thumbnail" | "enrichment" | "mosaic" | "wbpp_copy";
+  category: "scan" | "rebuild" | "thumbnail" | "enrichment" | "mosaic" | "wbpp_copy" | "task";
   label: string;
   subLabel?: string;
   progress?: number;
@@ -888,6 +888,12 @@ export interface ActiveJob {
   detail?: string;
   cancelable: boolean;
   onCancel?: () => Promise<void>;
+  // "waiting" = queued server-side but not yet started (from /api/jobs).
+  // Absent means running; only the generic task rows ever carry "waiting".
+  state?: "running" | "waiting";
+  // When a waiting task was dispatched with a countdown/eta, its scheduled
+  // start in epoch ms, for a "starts in Ns" label.
+  etaMs?: number;
 }
 
 // Query-param bag for GET /activity -- the OpenAPI spec flattens these into

--- a/frontend/src/components/JobMonitor.tsx
+++ b/frontend/src/components/JobMonitor.tsx
@@ -5,10 +5,13 @@ import { useScan, scanStatus, refreshScanStatus } from "../store/scan";
 import { rebuildStatus, refreshRebuildStatus } from "../store/rebuild";
 import {
   monitorJobs,
+  runningJobs,
+  waitingJobs,
   hasMonitorJobs,
   stripProgress,
   wireGlobalJobSources,
 } from "../store/jobMonitor";
+import { refreshServerJobs } from "../store/serverJobs";
 import {
   unseenErrors,
   unseenErrorCount,
@@ -18,6 +21,7 @@ import {
 import type { ActiveJob } from "../api/types";
 
 const IDLE_CHECK_MS = 30_000;
+const JOBS_POLL_MS = 5_000;
 const PANEL_ERROR_LIMIT = 5;
 
 function timeAgo(iso: string): string {
@@ -71,6 +75,25 @@ const JobRow: Component<{ job: ActiveJob }> = (props) => (
   </div>
 );
 
+export function waitingLabel(job: ActiveJob, now: number): string {
+  if (job.etaMs !== undefined && job.etaMs > now) {
+    return `starts in ${Math.round((job.etaMs - now) / 1000)}s`;
+  }
+  const secs = Math.max(0, Math.floor((now - job.startedAt) / 1000));
+  if (secs < 60) return `queued ${secs}s ago`;
+  const mins = Math.floor(secs / 60);
+  return mins < 60 ? `queued ${mins}m ago` : `queued ${Math.floor(mins / 60)}h ago`;
+}
+
+const WaitingRow: Component<{ job: ActiveJob }> = (props) => (
+  <div class="px-4 py-2 flex items-center justify-between gap-2 border-t border-theme-border first:border-t-0">
+    <span class="text-xs text-theme-text-primary truncate">{props.job.label}</span>
+    <span class="text-tiny text-theme-text-tertiary tabular-nums whitespace-nowrap">
+      {waitingLabel(props.job, Date.now())}
+    </span>
+  </div>
+);
+
 /**
  * Ambient job monitor, mounted inside NavBar's right cluster on every page:
  * a 2px aggregate progress strip on the header's bottom edge, an Activity
@@ -104,6 +127,16 @@ const JobMonitor: Component = () => {
     if (rebuildStatus().state !== "running") void refreshRebuildStatus();
   }, IDLE_CHECK_MS);
   onCleanup(() => clearInterval(idleTimer));
+
+  // Server job registry (GET /api/jobs): queued + running Celery tasks the
+  // scan/rebuild sources don't cover. Steady poll rather than idle-gated,
+  // because these jobs start server-side with no client event to react to.
+  void refreshServerJobs();
+  const jobsTimer = setInterval(() => {
+    if (document.visibilityState !== "visible") return;
+    void refreshServerJobs();
+  }, JOBS_POLL_MS);
+  onCleanup(() => clearInterval(jobsTimer));
 
   const [open, setOpen] = createSignal(false);
   let panelRef: HTMLDivElement | undefined;
@@ -166,8 +199,9 @@ const JobMonitor: Component = () => {
         </button>
       </Show>
 
-      {/* Ambient 2px progress strip along the NavBar bottom edge */}
-      <Show when={hasMonitorJobs()}>
+      {/* Ambient 2px progress strip along the NavBar bottom edge. Running
+          work only: a queue of waiting tasks must not animate the strip. */}
+      <Show when={runningJobs().length > 0}>
         <div
           class="absolute left-0 right-0 -bottom-px h-0.5 overflow-hidden bg-theme-accent/15"
           aria-hidden="true"
@@ -199,10 +233,18 @@ const JobMonitor: Component = () => {
             Active jobs
           </div>
           <Show
-            when={monitorJobs().length > 0}
+            when={runningJobs().length > 0}
             fallback={<div class="px-4 py-2 text-xs text-theme-text-tertiary">No jobs running.</div>}
           >
-            <For each={monitorJobs()}>{(j) => <JobRow job={j} />}</For>
+            <For each={runningJobs()}>{(j) => <JobRow job={j} />}</For>
+          </Show>
+
+          <Show when={waitingJobs().length > 0}>
+            <div class="border-t border-theme-border-em mt-2" />
+            <div class="px-4 pt-3 pb-1 text-[11px] font-semibold uppercase tracking-wider text-theme-text-tertiary">
+              Waiting
+            </div>
+            <For each={waitingJobs()}>{(j) => <WaitingRow job={j} />}</For>
           </Show>
 
           <div class="border-t border-theme-border-em mt-2" />

--- a/frontend/src/store/activeJobs.ts
+++ b/frontend/src/store/activeJobs.ts
@@ -15,14 +15,18 @@ export function scanStatusToJob(
   if (!scanActive && !phd2Active) return null;
 
   // phd2_found is published once the candidate list is known, and
-  // phd2_ingested / phd2_failed increment per file as the pass runs, with the
-  // end-of-pass write authoritative. A counted label is therefore the expected
-  // steady state. The countless branch still earns its keep: it covers a
-  // status snapshot from a backend that predates the counters, and the window
-  // between dispatch and the first published count, where printing "0 of 0"
-  // would be worse than saying nothing about totals.
+  // phd2_checked advances (in batches) as the pass looks at each file, with
+  // the end-of-pass write authoritative. A counted label is therefore the
+  // expected steady state. ingested+failed is the fallback for a backend
+  // that predates phd2_checked; it undercounts on a routine rescan, where
+  // nearly every log short-circuits as unchanged and the counter used to
+  // sit at 0 of N until the pass finished. The countless branch still earns
+  // its keep: it covers a status snapshot from a backend that predates the
+  // counters, and the window between dispatch and the first published count,
+  // where printing "0 of 0" would be worse than saying nothing about totals.
   const phd2Total = s.phd2_found ?? 0;
-  const phd2Done = (s.phd2_ingested ?? 0) + (s.phd2_failed ?? 0);
+  const phd2Done =
+    s.phd2_checked ?? (s.phd2_ingested ?? 0) + (s.phd2_failed ?? 0);
 
   if (!scanActive) {
     // Elapsed time for this row must count up from when the pass began, so

--- a/frontend/src/store/activeJobs.ts
+++ b/frontend/src/store/activeJobs.ts
@@ -1,6 +1,7 @@
 import { createSignal } from "solid-js";
 import type { ActiveJob, ScanStatus, RebuildStatus } from "../api/types";
 import { phd2FirstSeenAt, phd2Phase, type Phd2Phase } from "./scan";
+import { serverJobs } from "./serverJobs";
 
 const [celeryJobs, setCeleryJobs] = createSignal<Map<string, ActiveJob>>(new Map());
 
@@ -174,7 +175,15 @@ export const activeJobs: Accessor<ActiveJob[]> = () => {
     if (rebuildJob) jobs.push(rebuildJob);
   }
 
-  celeryJobs().forEach((job) => jobs.push(job));
+  const tracked = celeryJobs();
+  tracked.forEach((job) => jobs.push(job));
+
+  // Registry rows share the `celery:<task_id>` key with track()'s rows, so a
+  // task the current tab is already watching (with its richer callbacks)
+  // appears once, from the tracker.
+  serverJobs().forEach((job) => {
+    if (!tracked.has(job.id)) jobs.push(job);
+  });
 
   return jobs;
 };

--- a/frontend/src/store/jobMonitor.ts
+++ b/frontend/src/store/jobMonitor.ts
@@ -24,6 +24,14 @@ export const monitorJobs = (): ActiveJob[] => {
   return jobs;
 };
 
+// Panel sections. A job with no state field predates the queued concept and
+// is by construction running.
+export const runningJobs = (): ActiveJob[] =>
+  monitorJobs().filter((j) => j.state !== "waiting");
+
+export const waitingJobs = (): ActiveJob[] =>
+  monitorJobs().filter((j) => j.state === "waiting");
+
 export const hasMonitorJobs = (): boolean => monitorJobs().length > 0;
 
 // Aggregate strip progress: mean of the determinate jobs' fractions, or null
@@ -36,4 +44,7 @@ export function aggregateProgress(jobs: ActiveJob[]): number | null {
   return Math.max(0, Math.min(1, sum / determinate.length));
 }
 
-export const stripProgress = (): number | null => aggregateProgress(monitorJobs());
+// The strip reflects work in motion: waiting jobs are excluded, otherwise a
+// queue of countdown tasks would run the indeterminate shimmer with nothing
+// actually executing.
+export const stripProgress = (): number | null => aggregateProgress(runningJobs());

--- a/frontend/src/store/serverJobs.test.ts
+++ b/frontend/src/store/serverJobs.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../api/generated/client", () => ({
+  apiClient: { GET: vi.fn() },
+}));
+
+import { taskLabel, serverJobToActiveJob, type ServerJob } from "./serverJobs";
+import { waitingLabel } from "../components/JobMonitor";
+
+describe("taskLabel", () => {
+  it("maps known task names to human labels", () => {
+    expect(taskLabel("app.worker.tasks.correlate_phd2_images")).toBe(
+      "Matching guiding to frames"
+    );
+    expect(taskLabel("recompute_session_dates")).toBe("Recomputing session dates");
+  });
+
+  it("prettifies unknown names instead of showing raw dotted paths", () => {
+    expect(taskLabel("app.worker.tasks.rebuild_star_index")).toBe("Rebuild star index");
+    expect(taskLabel("some_new_thing_task")).toBe("Some new thing");
+  });
+});
+
+describe("serverJobToActiveJob", () => {
+  const base: ServerJob = {
+    task_id: "abc-123",
+    name: "app.worker.tasks.correlate_phd2_images",
+    state: "queued",
+    queued_at: 1_000_000,
+  };
+
+  it("marks queued rows waiting, keyed like track() rows for dedupe", () => {
+    const job = serverJobToActiveJob(base);
+    expect(job.id).toBe("celery:abc-123");
+    expect(job.state).toBe("waiting");
+    expect(job.startedAt).toBe(1_000_000_000);
+    expect(job.cancelable).toBe(false);
+  });
+
+  it("anchors running rows to started_at and parses eta", () => {
+    const job = serverJobToActiveJob({
+      ...base,
+      state: "running",
+      started_at: 1_000_050,
+      eta: "2026-08-05T21:00:00+00:00",
+    });
+    expect(job.state).toBe("running");
+    expect(job.startedAt).toBe(1_000_050_000);
+    expect(job.etaMs).toBe(Date.parse("2026-08-05T21:00:00+00:00"));
+  });
+});
+
+describe("waitingLabel", () => {
+  const job = serverJobToActiveJob({
+    task_id: "x",
+    name: "recompute_session_dates",
+    state: "queued",
+    queued_at: 1_000,
+  });
+
+  it("counts up from queue time", () => {
+    expect(waitingLabel(job, 1_000_000 + 32_000)).toBe("queued 32s ago");
+    expect(waitingLabel(job, 1_000_000 + 3 * 60_000)).toBe("queued 3m ago");
+  });
+
+  it("counts down to a future eta", () => {
+    const withEta = { ...job, etaMs: 2_000_000 };
+    expect(waitingLabel(withEta, 1_988_000)).toBe("starts in 12s");
+  });
+
+  it("falls back to queue age once the eta has passed", () => {
+    const withEta = { ...job, etaMs: 1_500_000 };
+    expect(waitingLabel(withEta, 1_600_000)).toBe("queued 10m ago");
+  });
+});

--- a/frontend/src/store/serverJobs.ts
+++ b/frontend/src/store/serverJobs.ts
@@ -1,0 +1,80 @@
+// Server-side Celery job registry (GET /api/jobs): every queued or running
+// task the scan/rebuild status sources do not already cover. Polled by
+// JobMonitor; activeJobs() merges these rows in, so the panel shows work the
+// server started on its own (settings-save cascades, post-scan correlation,
+// beat) - the class of task that was invisible until it failed.
+import { createSignal } from "solid-js";
+import { apiClient } from "../api/generated/client";
+import { unwrap } from "../api/unwrap";
+import type { ActiveJob } from "../api/types";
+
+export interface ServerJob {
+  task_id: string;
+  name: string;
+  state: string;
+  queued_at?: number | null;
+  started_at?: number | null;
+  eta?: string | null;
+}
+
+const [serverJobsRaw, setServerJobsRaw] = createSignal<ServerJob[]>([]);
+
+// Human labels for known task names. Unknown names fall back to a prettified
+// form of the final dotted segment, so a task added next year shows up
+// legibly with no edit here.
+const TASK_LABELS: Record<string, string> = {
+  "app.worker.tasks.correlate_phd2_images": "Matching guiding to frames",
+  "app.worker.tasks.backfill_dark_hours": "Computing dark hours",
+  recompute_session_dates: "Recomputing session dates",
+  detect_mosaic_panels_task: "Detecting mosaic panels",
+  detect_duplicate_targets: "Checking for duplicate targets",
+  detect_filename_targets: "Resolving targets from filenames",
+  "app.worker.tasks.backfill_csv_metrics": "Backfilling CSV metrics",
+  "app.worker.tasks.run_data_migrations": "Running data migrations",
+  "app.worker.tasks.load_reference_catalogs_if_empty": "Loading reference catalogs",
+  "app.worker.tasks.enrich_new_target_task": "Enriching new target",
+  "app.worker.tasks.backfill_catalog_identity": "Repairing catalog links",
+  "app.worker.tasks.auto_scan_tick": "Auto-scan check",
+  "app.worker.drain_logs.drain_app_logs": "Collecting app logs",
+  "app.worker.prune_activity.prune_activity_events": "Pruning activity feed",
+  "app.worker.prune_activity.prune_refresh_tokens": "Pruning login sessions",
+};
+
+export function taskLabel(name: string): string {
+  const known = TASK_LABELS[name];
+  if (known) return known;
+  const leaf = name.split(".").pop() ?? name;
+  const words = leaf.replace(/_task$/, "").split("_").filter(Boolean);
+  if (words.length === 0) return name;
+  const sentence = words.join(" ");
+  return sentence.charAt(0).toUpperCase() + sentence.slice(1);
+}
+
+export function serverJobToActiveJob(j: ServerJob): ActiveJob {
+  const running = j.state === "running";
+  const anchor = running ? j.started_at ?? j.queued_at : j.queued_at;
+  return {
+    // Same key shape taskPoller's track() uses, which is what makes the
+    // dedupe in activeJobs() possible: a client-tracked task and its registry
+    // row are the same id.
+    id: `celery:${j.task_id}`,
+    category: "task",
+    label: taskLabel(j.name),
+    state: running ? "running" : "waiting",
+    startedAt: anchor != null ? anchor * 1000 : Date.now(),
+    etaMs: j.eta ? Date.parse(j.eta) || undefined : undefined,
+    cancelable: false,
+  };
+}
+
+export const serverJobs = (): ActiveJob[] => serverJobsRaw().map(serverJobToActiveJob);
+
+export async function refreshServerJobs(): Promise<void> {
+  try {
+    const res = await apiClient.GET("/api/jobs", {}).then(unwrap);
+    setServerJobsRaw(res.jobs as ServerJob[]);
+  } catch {
+    // Poll failure keeps the last known list; the next tick retries. A
+    // transient network error must not blank the panel mid-job.
+  }
+}


### PR DESCRIPTION
**What's new**
*   Job monitor now displays all background tasks, including queued ones.

**What's fixed**
*   Fixed deadlocks during PHD2 correlation processing.

**What's changed**
*   Guide log counter now shows files checked, not ingested.