### PR TITLE
Dashboard Sidebar UI Refinements

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -991,9 +991,9 @@
       "license": "MIT"
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "1.34.18",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.18.tgz",
-      "integrity": "sha512-UyKIm0wTPw5BcY7Z2PkbK1Ma260um96LSBWXHrdSMe+ZV0EPMyDfAcUcjjm3qEiGST9OK/1TriekdPCZkn4Q3A==",
+      "version": "1.34.19",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.19.tgz",
+      "integrity": "sha512-o/0VgsBXgwcY1lyeqcVtSGdTQAPnVggo0fbFVPlxl5XVDKUcVH0OLRqt3CbkwByT5FU305E0iE0O7MzThjDblw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1002,7 +1002,7 @@
         "colorette": "1.4.0",
         "https-proxy-agent": "7.0.6",
         "js-levenshtein": "1.1.6",
-        "js-yaml": "4.3.0",
+        "js-yaml": "4.3.1",
         "minimatch": "5.1.9",
         "pluralize": "8.0.0",
         "yaml-ast-parser": "0.0.43"
@@ -2694,9 +2694,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -3155,9 +3155,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/frontend/src/components/CollapsibleSection.tsx
+++ b/frontend/src/components/CollapsibleSection.tsx
@@ -31,7 +31,7 @@ function saveCollapsedState(state: Record<string, boolean>) {
   } catch { /* ignore */ }
 }
 
-const CollapsibleSection: Component<{ id: string; label: string; active?: boolean; children: JSX.Element }> = (props) => {
+const CollapsibleSection: Component<{ id: string; label: string; icon?: () => JSX.Element; active?: boolean; children: JSX.Element }> = (props) => {
   const [collapsed, setCollapsed] = createSignal(false);
   let sectionRef: HTMLElement | undefined;
 
@@ -76,7 +76,15 @@ const CollapsibleSection: Component<{ id: string; label: string; active?: boolea
         onClick={toggle}
         class="flex items-center justify-between w-full text-label font-medium uppercase tracking-wider text-theme-text-tertiary hover:text-theme-text-secondary transition-colors cursor-pointer select-none"
       >
-        <span class="flex items-center gap-1.5">
+        <span class="flex items-center gap-2">
+          <Show when={props.icon}>
+            <span
+              class="shrink-0 [&>svg]:w-4 [&>svg]:h-4"
+              classList={{ "text-theme-accent": props.active }}
+            >
+              {props.icon!()}
+            </span>
+          </Show>
           {props.label}
           <Show when={props.active}>
             <span class="w-1.5 h-1.5 rounded-full bg-theme-accent shrink-0" />

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { Component, Show } from "solid-js";
+import { Component, JSX, Show } from "solid-js";
 import { useDashboardFilters } from "./DashboardFilterProvider";
 import { useSettingsContext } from "./SettingsProvider";
 import { toggleSidebarCollapsed } from "./sidebarLayout";
@@ -23,6 +23,50 @@ export type SidebarSectionId =
   | "metrics"
   | "fits-query"
   | "custom-columns";
+
+// Single-path glyphs shared by the collapsed rail and the expanded section headers.
+export const SECTION_ICONS: Record<SidebarSectionId, () => JSX.Element> = {
+  "search": () => (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="11" cy="11" r="7" /><line x1="21" y1="21" x2="16.65" y2="16.65" />
+    </svg>
+  ),
+  "object-type": () => (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <polygon points="12 2 15 9 22 9 17 14 19 21 12 17 5 21 7 14 2 9 9 9 12 2" />
+    </svg>
+  ),
+  "date-range": () => (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <rect x="3" y="4" width="18" height="18" rx="2" /><line x1="16" y1="2" x2="16" y2="6" /><line x1="8" y1="2" x2="8" y2="6" /><line x1="3" y1="10" x2="21" y2="10" />
+    </svg>
+  ),
+  "filters": () => (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3" />
+    </svg>
+  ),
+  "equipment": () => (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="12" cy="12" r="9" /><circle cx="12" cy="12" r="3" /><line x1="12" y1="3" x2="12" y2="6" /><line x1="12" y1="18" x2="12" y2="21" />
+    </svg>
+  ),
+  "metrics": () => (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M3 12a9 9 0 0 1 18 0" /><line x1="12" y1="12" x2="16" y2="8" />
+    </svg>
+  ),
+  "fits-query": () => (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <polyline points="16 18 22 12 16 6" /><polyline points="8 6 2 12 8 18" />
+    </svg>
+  ),
+  "custom-columns": () => (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <rect x="3" y="3" width="7" height="18" rx="1" /><rect x="14" y="3" width="7" height="18" rx="1" />
+    </svg>
+  ),
+};
 
 export interface ActiveSectionFilters {
   searchQuery?: string;
@@ -90,15 +134,15 @@ const Sidebar: Component = () => {
           </section>
         )}
       </Show>
-      <CollapsibleSection id="search" label="Search" active={activeSections().has("search")}><SearchBar /></CollapsibleSection>
-      <CollapsibleSection id="object-type" label="Object Type" active={activeSections().has("object-type")}><ObjectTypeToggles /></CollapsibleSection>
-      <CollapsibleSection id="date-range" label="Date Range" active={activeSections().has("date-range")}><DateRangePicker /></CollapsibleSection>
-      <CollapsibleSection id="filters" label="Filters" active={activeSections().has("filters")}><FilterToggles /></CollapsibleSection>
-      <CollapsibleSection id="equipment" label="Equipment" active={activeSections().has("equipment")}><HardwareSelects /></CollapsibleSection>
-      <CollapsibleSection id="metrics" label="Metrics Quality" active={activeSections().has("metrics")}><MetricFilters /></CollapsibleSection>
-      <CollapsibleSection id="fits-query" label="FITS Header Query" active={activeSections().has("fits-query")}><FitsQueryBuilder /></CollapsibleSection>
+      <CollapsibleSection id="search" label="Search" icon={SECTION_ICONS["search"]} active={activeSections().has("search")}><SearchBar /></CollapsibleSection>
+      <CollapsibleSection id="object-type" label="Object Type" icon={SECTION_ICONS["object-type"]} active={activeSections().has("object-type")}><ObjectTypeToggles /></CollapsibleSection>
+      <CollapsibleSection id="date-range" label="Date Range" icon={SECTION_ICONS["date-range"]} active={activeSections().has("date-range")}><DateRangePicker /></CollapsibleSection>
+      <CollapsibleSection id="filters" label="Filters" icon={SECTION_ICONS["filters"]} active={activeSections().has("filters")}><FilterToggles /></CollapsibleSection>
+      <CollapsibleSection id="equipment" label="Equipment" icon={SECTION_ICONS["equipment"]} active={activeSections().has("equipment")}><HardwareSelects /></CollapsibleSection>
+      <CollapsibleSection id="metrics" label="Metrics Quality" icon={SECTION_ICONS["metrics"]} active={activeSections().has("metrics")}><MetricFilters /></CollapsibleSection>
+      <CollapsibleSection id="fits-query" label="FITS Header Query" icon={SECTION_ICONS["fits-query"]} active={activeSections().has("fits-query")}><FitsQueryBuilder /></CollapsibleSection>
       <Show when={(customColumns() ?? []).length > 0}>
-        <CollapsibleSection id="custom-columns" label="Custom Columns" active={activeSections().has("custom-columns")}><CustomColumnFilters /></CollapsibleSection>
+        <CollapsibleSection id="custom-columns" label="Custom Columns" icon={SECTION_ICONS["custom-columns"]} active={activeSections().has("custom-columns")}><CustomColumnFilters /></CollapsibleSection>
       </Show>
       <button
         onClick={resetFilters}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -43,7 +43,8 @@ export const SECTION_ICONS: Record<SidebarSectionId, () => JSX.Element> = {
   ),
   "filters": () => (
     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3" />
+      <circle cx="13.5" cy="6.5" r=".5" /><circle cx="17.5" cy="10.5" r=".5" /><circle cx="8.5" cy="7.5" r=".5" /><circle cx="6.5" cy="12.5" r=".5" />
+      <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z" />
     </svg>
   ),
   "equipment": () => (

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -104,19 +104,19 @@ const Sidebar: Component = () => {
 
   return (
     <aside class="w-full min-h-0 max-h-[calc(100vh-57px)] p-4 space-y-3 overflow-y-auto">
-      <div class="flex items-center justify-between -mt-1">
-        <span class="text-label font-medium uppercase tracking-wider text-theme-text-tertiary">Filters</span>
-        <button
-          onClick={toggleSidebarCollapsed}
-          class="p-1 text-theme-text-tertiary hover:text-theme-text-primary transition-colors cursor-pointer"
-          aria-label="Collapse sidebar"
-          title="Collapse sidebar"
-        >
+      <button
+        onClick={toggleSidebarCollapsed}
+        class="group flex items-center justify-between w-full -mt-1 cursor-pointer"
+        aria-label="Collapse sidebar"
+        title="Collapse sidebar"
+      >
+        <span class="text-label font-medium uppercase tracking-wider text-theme-text-tertiary group-hover:text-theme-text-primary transition-colors">Filters</span>
+        <span class="p-1 text-theme-text-tertiary group-hover:text-theme-text-primary transition-colors">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <polyline points="15 18 9 12 15 6" />
           </svg>
-        </button>
-      </div>
+        </span>
+      </button>
       <Show when={targetData()}>
         {(data) => (
           <section class="rounded-[var(--radius-sm)] bg-theme-elevated border border-theme-border-em p-3 flex flex-wrap gap-x-4 gap-y-1 text-sm">

--- a/frontend/src/components/SidebarRail.tsx
+++ b/frontend/src/components/SidebarRail.tsx
@@ -1,7 +1,7 @@
 import { Component, For, Show } from "solid-js";
 import { useDashboardFilters } from "./DashboardFilterProvider";
 import { useSettingsContext } from "./SettingsProvider";
-import { sidebarCollapsed, setSidebarCollapsed, toggleSidebarCollapsed, requestExpandSection, expandRequestId } from "./sidebarLayout";
+import { setSidebarCollapsed, requestExpandSection } from "./sidebarLayout";
 import { getActiveSectionIds, ActiveSectionFilters, SidebarSectionId } from "./Sidebar";
 
 interface RailItem {
@@ -64,14 +64,6 @@ const SidebarRail: Component = () => {
     ITEMS.filter((it) => it.id !== "custom-columns" || (customColumns() ?? []).length > 0);
 
   const onItemClick = (id: SidebarSectionId) => {
-    if (!sidebarCollapsed()) {
-      if (expandRequestId() === id) {
-        setSidebarCollapsed(true);
-      } else {
-        requestExpandSection(id);
-      }
-      return;
-    }
     setSidebarCollapsed(false);
     // Wait one frame so the width transition begins before the section scrolls.
     requestAnimationFrame(() => requestExpandSection(id));
@@ -80,13 +72,13 @@ const SidebarRail: Component = () => {
   return (
     <div class="h-full flex flex-col items-center py-3 gap-1">
       <button
-        onClick={toggleSidebarCollapsed}
+        onClick={() => setSidebarCollapsed(false)}
         class="p-2 text-theme-text-tertiary hover:text-theme-text-primary transition-colors cursor-pointer"
-        aria-label={sidebarCollapsed() ? "Expand sidebar" : "Collapse sidebar"}
-        title={sidebarCollapsed() ? "Expand sidebar" : "Collapse sidebar"}
+        aria-label="Expand sidebar"
+        title="Expand sidebar"
       >
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <polyline points={sidebarCollapsed() ? "9 18 15 12 9 6" : "15 18 9 12 15 6"} />
+          <polyline points="9 18 15 12 9 6" />
         </svg>
       </button>
       <div class="w-full border-t border-theme-border-em my-1" />
@@ -100,7 +92,6 @@ const SidebarRail: Component = () => {
             classList={{
               "text-theme-accent": activeIds().has(item.id),
               "text-theme-text-tertiary": !activeIds().has(item.id),
-              "bg-theme-elevated": !sidebarCollapsed() && expandRequestId() === item.id,
             }}
             style={{ "--i": String(i()) }}
           >

--- a/frontend/src/components/SidebarRail.tsx
+++ b/frontend/src/components/SidebarRail.tsx
@@ -36,7 +36,11 @@ const SidebarRail: Component = () => {
   };
 
   return (
-    <div class="h-full flex flex-col items-center py-3 gap-1">
+    <div
+      class="h-full flex flex-col items-center py-3 gap-1 cursor-pointer"
+      onClick={() => setSidebarCollapsed(false)}
+      title="Expand sidebar"
+    >
       <button
         onClick={() => setSidebarCollapsed(false)}
         class="p-2 text-theme-text-tertiary hover:text-theme-text-primary transition-colors cursor-pointer"
@@ -71,7 +75,7 @@ const SidebarRail: Component = () => {
       <Show when={activeIds().size > 0}>
         <div class="mt-auto w-full border-t border-theme-border-em my-1" />
         <button
-          onClick={resetFilters}
+          onClick={(e) => { e.stopPropagation(); resetFilters(); }}
           title="Reset Filters"
           aria-label="Reset Filters"
           class="p-2 rounded-[var(--radius-sm)] text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-elevated transition-colors cursor-pointer"

--- a/frontend/src/components/SidebarRail.tsx
+++ b/frontend/src/components/SidebarRail.tsx
@@ -2,56 +2,22 @@ import { Component, For, Show } from "solid-js";
 import { useDashboardFilters } from "./DashboardFilterProvider";
 import { useSettingsContext } from "./SettingsProvider";
 import { setSidebarCollapsed, requestExpandSection } from "./sidebarLayout";
-import { getActiveSectionIds, ActiveSectionFilters, SidebarSectionId } from "./Sidebar";
+import { getActiveSectionIds, ActiveSectionFilters, SidebarSectionId, SECTION_ICONS } from "./Sidebar";
 
 interface RailItem {
   id: SidebarSectionId;
   label: string;
-  icon: () => any;
 }
 
-// Icons are simple single-path glyphs chosen for legibility at 18px.
 const ITEMS: RailItem[] = [
-  { id: "search",         label: "Search",              icon: () => (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <circle cx="11" cy="11" r="7" /><line x1="21" y1="21" x2="16.65" y2="16.65" />
-    </svg>
-  )},
-  { id: "object-type",    label: "Object Type",         icon: () => (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <polygon points="12 2 15 9 22 9 17 14 19 21 12 17 5 21 7 14 2 9 9 9 12 2" />
-    </svg>
-  )},
-  { id: "date-range",     label: "Date Range",          icon: () => (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <rect x="3" y="4" width="18" height="18" rx="2" /><line x1="16" y1="2" x2="16" y2="6" /><line x1="8" y1="2" x2="8" y2="6" /><line x1="3" y1="10" x2="21" y2="10" />
-    </svg>
-  )},
-  { id: "filters",        label: "Filters",             icon: () => (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3" />
-    </svg>
-  )},
-  { id: "equipment",      label: "Equipment",           icon: () => (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <circle cx="12" cy="12" r="9" /><circle cx="12" cy="12" r="3" /><line x1="12" y1="3" x2="12" y2="6" /><line x1="12" y1="18" x2="12" y2="21" />
-    </svg>
-  )},
-  { id: "metrics",        label: "Metrics Quality",      icon: () => (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <path d="M3 12a9 9 0 0 1 18 0" /><line x1="12" y1="12" x2="16" y2="8" />
-    </svg>
-  )},
-  { id: "fits-query",     label: "FITS Header Query",   icon: () => (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <polyline points="16 18 22 12 16 6" /><polyline points="8 6 2 12 8 18" />
-    </svg>
-  )},
-  { id: "custom-columns", label: "Custom Columns",      icon: () => (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <rect x="3" y="3" width="7" height="18" rx="1" /><rect x="14" y="3" width="7" height="18" rx="1" />
-    </svg>
-  )},
+  { id: "search",         label: "Search" },
+  { id: "object-type",    label: "Object Type" },
+  { id: "date-range",     label: "Date Range" },
+  { id: "filters",        label: "Filters" },
+  { id: "equipment",      label: "Equipment" },
+  { id: "metrics",        label: "Metrics Quality" },
+  { id: "fits-query",     label: "FITS Header Query" },
+  { id: "custom-columns", label: "Custom Columns" },
 ];
 
 const SidebarRail: Component = () => {
@@ -95,7 +61,7 @@ const SidebarRail: Component = () => {
             }}
             style={{ "--i": String(i()) }}
           >
-            {item.icon()}
+            {SECTION_ICONS[item.id]()}
             {activeIds().has(item.id) && (
               <span class="absolute top-1 right-1 w-2 h-2 rounded-full bg-theme-accent" />
             )}

--- a/frontend/src/components/SidebarRail.tsx
+++ b/frontend/src/components/SidebarRail.tsx
@@ -1,7 +1,7 @@
-import { Component, For } from "solid-js";
+import { Component, For, Show } from "solid-js";
 import { useDashboardFilters } from "./DashboardFilterProvider";
 import { useSettingsContext } from "./SettingsProvider";
-import { setSidebarCollapsed, requestExpandSection } from "./sidebarLayout";
+import { sidebarCollapsed, setSidebarCollapsed, toggleSidebarCollapsed, requestExpandSection, expandRequestId } from "./sidebarLayout";
 import { getActiveSectionIds, ActiveSectionFilters, SidebarSectionId } from "./Sidebar";
 
 interface RailItem {
@@ -55,7 +55,7 @@ const ITEMS: RailItem[] = [
 ];
 
 const SidebarRail: Component = () => {
-  const { filters } = useDashboardFilters();
+  const { filters, resetFilters } = useDashboardFilters();
   const { customColumns } = useSettingsContext();
 
   const activeIds = () => getActiveSectionIds(filters() as unknown as ActiveSectionFilters);
@@ -64,6 +64,14 @@ const SidebarRail: Component = () => {
     ITEMS.filter((it) => it.id !== "custom-columns" || (customColumns() ?? []).length > 0);
 
   const onItemClick = (id: SidebarSectionId) => {
+    if (!sidebarCollapsed()) {
+      if (expandRequestId() === id) {
+        setSidebarCollapsed(true);
+      } else {
+        requestExpandSection(id);
+      }
+      return;
+    }
     setSidebarCollapsed(false);
     // Wait one frame so the width transition begins before the section scrolls.
     requestAnimationFrame(() => requestExpandSection(id));
@@ -72,13 +80,13 @@ const SidebarRail: Component = () => {
   return (
     <div class="h-full flex flex-col items-center py-3 gap-1">
       <button
-        onClick={() => setSidebarCollapsed(false)}
+        onClick={toggleSidebarCollapsed}
         class="p-2 text-theme-text-tertiary hover:text-theme-text-primary transition-colors cursor-pointer"
-        aria-label="Expand sidebar"
-        title="Expand sidebar"
+        aria-label={sidebarCollapsed() ? "Expand sidebar" : "Collapse sidebar"}
+        title={sidebarCollapsed() ? "Expand sidebar" : "Collapse sidebar"}
       >
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <polyline points="9 18 15 12 9 6" />
+          <polyline points={sidebarCollapsed() ? "9 18 15 12 9 6" : "15 18 9 12 15 6"} />
         </svg>
       </button>
       <div class="w-full border-t border-theme-border-em my-1" />
@@ -88,7 +96,12 @@ const SidebarRail: Component = () => {
             onClick={() => onItemClick(item.id)}
             title={item.label}
             aria-label={item.label}
-            class="relative p-2 rounded-[var(--radius-sm)] text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-elevated transition-colors cursor-pointer sidebar-rail-icon"
+            class="relative p-2 rounded-[var(--radius-sm)] hover:text-theme-text-primary hover:bg-theme-elevated transition-colors cursor-pointer sidebar-rail-icon"
+            classList={{
+              "text-theme-accent": activeIds().has(item.id),
+              "text-theme-text-tertiary": !activeIds().has(item.id),
+              "bg-theme-elevated": !sidebarCollapsed() && expandRequestId() === item.id,
+            }}
             style={{ "--i": String(i()) }}
           >
             {item.icon()}
@@ -98,6 +111,19 @@ const SidebarRail: Component = () => {
           </button>
         )}
       </For>
+      <Show when={activeIds().size > 0}>
+        <div class="mt-auto w-full border-t border-theme-border-em my-1" />
+        <button
+          onClick={resetFilters}
+          title="Reset Filters"
+          aria-label="Reset Filters"
+          class="p-2 rounded-[var(--radius-sm)] text-theme-text-tertiary hover:text-theme-text-primary hover:bg-theme-elevated transition-colors cursor-pointer"
+        >
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="1 4 1 10 7 10" /><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10" />
+          </svg>
+        </button>
+      </Show>
     </div>
   );
 };

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -54,19 +54,9 @@ const DashboardPage: Component = () => {
         <div
           class="hidden lg:flex relative border-r border-theme-border-em h-[calc(100vh-57px)] sticky top-[57px] self-start shrink-0"
           classList={{ "transition-[width] duration-[240ms] ease-[cubic-bezier(0.22,0.61,0.36,1)]": !resizing() }}
-          style={{ width: `${RAIL_WIDTH + (sidebarCollapsed() ? 0 : sidebarWidth())}px` }}
+          style={{ width: `${sidebarCollapsed() ? RAIL_WIDTH : sidebarWidth()}px` }}
         >
-          <div
-            class="w-12 shrink-0 h-full"
-            classList={{ "border-r border-theme-border-em": !sidebarCollapsed() }}
-          >
-            <SidebarRail />
-          </div>
-          {!sidebarCollapsed() && (
-            <div class="flex-1 min-w-0 h-full">
-              <Sidebar />
-            </div>
-          )}
+          {sidebarCollapsed() ? <SidebarRail /> : <Sidebar />}
           {!sidebarCollapsed() && <SidebarResizeHandle />}
         </div>
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -54,9 +54,19 @@ const DashboardPage: Component = () => {
         <div
           class="hidden lg:flex relative border-r border-theme-border-em h-[calc(100vh-57px)] sticky top-[57px] self-start shrink-0"
           classList={{ "transition-[width] duration-[240ms] ease-[cubic-bezier(0.22,0.61,0.36,1)]": !resizing() }}
-          style={{ width: `${sidebarCollapsed() ? RAIL_WIDTH : sidebarWidth()}px` }}
+          style={{ width: `${RAIL_WIDTH + (sidebarCollapsed() ? 0 : sidebarWidth())}px` }}
         >
-          {sidebarCollapsed() ? <SidebarRail /> : <Sidebar />}
+          <div
+            class="w-12 shrink-0 h-full"
+            classList={{ "border-r border-theme-border-em": !sidebarCollapsed() }}
+          >
+            <SidebarRail />
+          </div>
+          {!sidebarCollapsed() && (
+            <div class="flex-1 min-w-0 h-full">
+              <Sidebar />
+            </div>
+          )}
           {!sidebarCollapsed() && <SidebarResizeHandle />}
         </div>
 


### PR DESCRIPTION
**What's changed**:
*   Sidebar expand and collapse click targets are now wider.
*   The Filters section icon now uses a palette glyph.
*   Expanded sidebar headers now display section icons.
*   The dashboard sidebar rail is now a persistent activity bar, hiding when the main sidebar expands.